### PR TITLE
Phase 2: device-session management and complete Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Built with Compose for Desktop — real Skia-rendered UI, real OS installers, no
 | Dedicated fiction-detail screen | ✅ |
 | Player UI (play/pause, seek, ±30 s, next/previous, up-next queue) | ✅ |
 | **MP3 audio playback** | ✅ |
-| Settings / logout / version | ✅ |
+| Settings — two-pane control centre (account, devices, about) | ✅ |
+| Device sessions — list, mark current, revoke one / revoke all others | ✅ |
+| Playback preferences / offline downloads | ❌ |
 | Variable-rate playback ("speed") | ❌ |
 
 > The `SourceDataLine` backend cannot resample, so `PlaybackController.setSpeed` only records a
@@ -68,6 +70,8 @@ track the CMP version, and the ProGuard override needed for Java 25 bytecode —
 [`docs/adr/0001-2026-build-baseline.md`](docs/adr/0001-2026-build-baseline.md). Credential storage,
 centralized bearer injection and capability discovery are covered by
 [`docs/adr/0002-credential-storage-and-capability-discovery.md`](docs/adr/0002-credential-storage-and-capability-discovery.md).
+Device-session management, the two-pane Settings screen and how an older server is detected are in
+[`docs/adr/0003-device-sessions-and-settings.md`](docs/adr/0003-device-sessions-and-settings.md).
 
 ## 🚀 Bootstrap
 

--- a/docs/adr/0003-device-sessions-and-settings.md
+++ b/docs/adr/0003-device-sessions-and-settings.md
@@ -1,0 +1,127 @@
+# ADR 0003 — Device-session management and a two-pane Settings screen
+
+- **Status:** Accepted
+- **Date:** 2026-08-06
+- **Context issue:** [#8 — Add device-session management and complete Settings](https://github.com/jonarihen/TTSRoad-Desktop/issues/8) (part of #1, depends on #6)
+
+## Context
+
+Settings was one scrolling column with three read-only rows and a Sign-out button, and the client
+had no way to see or end the other sessions on the account. The server has had
+`GET /api/mobile/me`, `GET /api/mobile/devices`, `DELETE /api/mobile/devices/{token_id}` and
+`POST /api/mobile/devices/revoke-others` since 1.4.0, and Phase 1 already discovers the
+`device_management` capability — nothing consumed either.
+
+Three properties of the server make this more than a CRUD screen:
+
+1. The device API is **additive**: `api_version` did not change when it shipped, so a `404` is the
+   only signal that a backend predates it.
+2. `DELETE /api/mobile/devices/{token_id}` answers **404 for three different things** — no such
+   endpoint, no such token, and a token that is already revoked (`app/routers/mobile.py`).
+3. Timestamps come from **two different serializers**: `app/routers/mobile.py::_utc_iso` keeps
+   microseconds, `app/services/mobile_auth.py::_utc_iso` truncates to seconds, and other paths emit
+   naive values. The same client reads all of them.
+
+## Decision
+
+### 1. Two gates on the device UI, not one
+
+`SettingsStateHolder.loadDevices()` skips the request only when discovery **succeeded** and said
+`device_management: false`. A baseline capability set means discovery never got an answer (404,
+offline, a proxy) — refusing to try on that basis would hide a working feature behind an unrelated
+failure. The second gate is the endpoint's own 404, which `RetrofitTtsRoadRepository.devices()`
+turns into `null`.
+
+`null` and `emptyList()` are therefore *load-bearing and different*: "nothing else is signed in" is
+a correct, normal answer, while "this server cannot answer" has to render the concise unsupported
+card. That distinction is asserted in both `DevicesRepositoryTest` and `SettingsStateHolderTest`.
+
+**A 404 never signs anyone out.** `ifEndpointExists` catches exactly `404`; every other status,
+including `401`, keeps its Phase 1 meaning and still ends the session.
+
+### 2. The 404-on-DELETE ambiguity is resolved by context, not by guessing
+
+The repository reports the 404 as `false` and does not interpret it. The state holder does: a
+client that just rendered a successfully loaded list is demonstrably talking to a server that has
+the endpoint, so a 404 there means *that session is already gone* and the list is simply re-read.
+Only a 404 with nothing loaded is treated as an old server.
+
+### 3. Every revoke re-reads the list
+
+No local patching. After "revoke others" the client cannot know how many rows the server actually
+took, and after a single revoke a partial failure is possible; the server is the authority on what
+survived. The cost is one extra `GET` per action, which is the right trade for a screen whose whole
+purpose is showing the truth about live sessions.
+
+A failure message is re-applied **after** that reload. A successful reload legitimately clears a
+stale load error, and without re-applying it the screen would look exactly as if the revoke had
+worked.
+
+### 4. The current session is unrevokable from its row, twice over
+
+`DeviceSession.isCurrentFor(session)` is `is_current || session.deviceId == id` — the server's flag
+plus the `device_id` kept from the login response, because the flag is only set when the request
+itself carried a bearer token. The row renders with no revoke control, *and*
+`SettingsStateHolder.askRevoke` refuses for that device, so a future UI change cannot reintroduce
+the accident. Ending this session stays Sign out, which has its own confirmation.
+
+### 5. Timestamps are parsed permissively and rendered locally
+
+`parseServerInstant` tries `Instant.parse`, then `OffsetDateTime`, then `LocalDateTime` read as UTC,
+and returns `null` rather than throwing — a device row with one unreadable date is still worth
+showing. Rendering goes through `formatServerTimestamp(zone = systemDefault())`, and expiry is
+deliberately coarse (`expires in 42 days`): tokens last 90 days and renew on every authenticated
+request, so the exact hour is noise.
+
+### 6. Settings state is hoisted above navigation
+
+`App` owns the `SettingsStateHolder`. Navigation is a `when (screen)`, which disposes the screen it
+leaves, so a holder created inside `SettingsScreen` would drop the selected pane and the loaded
+device list every time the user glanced at the library. It is reset by `sessionEnded()` when the
+session goes, because device rows name other machines on *that* account.
+
+### 7. Placeholder panes describe the gap instead of faking it
+
+Playback and Offline render one honest paragraph each and no controls. A switch that looks live and
+changes nothing is worse than an empty pane, because the user cannot tell it did not work. The
+Offline pane also states the thing the issue asks the app to guarantee: nothing is stored for
+offline use, so signing out cannot delete anything the user asked to keep.
+
+The About pane says "Update check: not available" rather than "you're up to date" — there is no
+updater in this build, and claiming otherwise would be a claim nothing checked.
+
+### 8. Accessibility is in the widgets, not in a pass afterwards
+
+- Pane entries are `Modifier.selectable(role = Role.Tab)`: Tab-reachable, Enter/Space-activatable,
+  and announced with their selected state.
+- Each device row carries a single `contentDescription` sentence, so a screen reader gets
+  "Pixel 9, active, last used …, last IP …" instead of eight unlabelled fragments in layout order.
+  The revoke button sits outside that merged node with its own "Sign out <device>" description,
+  which is also what the UI tests click.
+- The confirmation dialog sets `paneTitle`, handles `Escape` explicitly via `onPreviewKeyEvent`
+  rather than relying on the platform back-press mapping, and **focuses CANCEL**, so the key a user
+  hits reflexively is the safe one.
+
+## Consequences
+
+- Four new endpoints, one new model file, one new state holder, one new screen. `Repository`'s
+  interface grew by four methods; `FakeRepository` implements them, so every existing test still
+  compiles unchanged.
+- Sign-out now requires a confirmation click. That is one more interaction on a common action; it
+  was accepted because the issue asks for confirmation on irreversible actions and because the same
+  dialog component then covers all three.
+- `GET /api/mobile/me` is called once when the Account pane opens. It is a cheap way to notice an
+  `is_admin` change made from the web console while the desktop session was open; a failure is
+  silent and the stored session still stands.
+- The device list is *not* cached across sign-ins and is not persisted. It is only ever looked at
+  deliberately, and a stale answer is worse than a short spinner.
+
+## What is not covered
+
+- **No admin device view.** `GET /api/admin/devices` exists and adds a `username` per row; this
+  phase is deliberately account-scoped.
+- **`revoke-others` over a cookie session revokes everything.** The server keeps
+  `request.state.mobile_token_id`, which is only set for bearer auth. The desktop client is always
+  bearer, so this cannot happen here, but it is worth knowing before the code is reused.
+- **Diagnostics are read-only.** "Copy diagnostics" puts a `redactSecrets`-scrubbed block on the
+  AWT clipboard; there is no log file to attach because the app still has no file logging.

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -30,7 +29,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,25 +41,21 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
-import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
-import dk.perspektiva.ttsroad.desktop.data.SessionStore
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.di.AppContainer
-import dk.perspektiva.ttsroad.desktop.ui.AarisCard
 import dk.perspektiva.ttsroad.desktop.ui.AarisColor
 import dk.perspektiva.ttsroad.desktop.ui.ContentMaxWidth
 import dk.perspektiva.ttsroad.desktop.ui.FictionDetailScreen
 import dk.perspektiva.ttsroad.desktop.ui.LibraryScreen
 import dk.perspektiva.ttsroad.desktop.ui.LoginStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.MetaText
-import dk.perspektiva.ttsroad.desktop.ui.NarrowMaxWidth
 import dk.perspektiva.ttsroad.desktop.ui.NowPlayingBar
 import dk.perspektiva.ttsroad.desktop.ui.PageGutter
-import dk.perspektiva.ttsroad.desktop.ui.PageScroll
 import dk.perspektiva.ttsroad.desktop.ui.PlayerScreen
+import dk.perspektiva.ttsroad.desktop.ui.SettingsScreen
+import dk.perspektiva.ttsroad.desktop.ui.SettingsStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.hasSession
 import dk.perspektiva.ttsroad.desktop.ui.rememberStateHolder
-import kotlinx.coroutines.launch
 
 private sealed interface Screen {
     data object Library : Screen
@@ -82,6 +76,12 @@ fun App(container: AppContainer = remember { AppContainer() }) {
     val playback = container.playback
     val session by sessionStore.session.collectAsState()
     val sessionEnd by repository.sessionEnd.collectAsState()
+    // Hoisted above navigation on purpose: `when (screen)` disposes the screen it leaves, so a
+    // holder created inside SettingsScreen would drop the selected pane and the loaded device list
+    // every time the user glanced at the library.
+    val settings = rememberStateHolder(repository, sessionStore) {
+        SettingsStateHolder(repository, sessionStore)
+    }
     var screen by remember { mutableStateOf<Screen>(Screen.Library) }
     // Where the full player collapses back to, so expanding the bar never loses browse context.
     var playerReturn by remember { mutableStateOf<Screen>(Screen.Library) }
@@ -100,6 +100,9 @@ fun App(container: AppContainer = remember { AppContainer() }) {
             playback.stop()
             screen = Screen.Library
             playerReturn = Screen.Library
+            // Device rows name other machines on the account that just ended; keeping them on
+            // screen for whoever signs in next would be both wrong and a small privacy leak.
+            settings.sessionEnded()
         } else {
             // Cheap, and it is what makes optional UI correct after a restart, where login did
             // not run but a keyring-backed session was restored.
@@ -139,7 +142,7 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                             onBack = { screen = Screen.Library },
                         )
                         Screen.Player -> PlayerScreen(playback, onBack = { screen = playerReturn })
-                        Screen.Settings -> SettingsScreen(sessionStore, repository)
+                        Screen.Settings -> SettingsScreen(sessionStore, repository, settings)
                     }
                 }
                 if (playerState.hasSession && screen != Screen.Player) {
@@ -300,82 +303,3 @@ private fun Field(label: String, value: String, password: Boolean = false, onVal
     )
 }
 
-@Composable
-private fun SettingsScreen(sessionStore: SessionStore, repository: TtsRoadRepository) {
-    val scope = rememberCoroutineScope()
-    val session by sessionStore.session.collectAsState()
-    val capabilities by repository.currentCapabilities.collectAsState()
-    var busy by remember { mutableStateOf(false) }
-    PageScroll(maxWidth = NarrowMaxWidth, verticalArrangement = Arrangement.spacedBy(16.dp)) {
-        MetaText(text = "// Session", color = AarisColor.Accent)
-        AarisCard {
-            Column(Modifier.fillMaxWidth().padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                SettingRow("Server", session.serverUrl)
-                HorizontalDivider(thickness = 1.dp, color = AarisColor.Line)
-                SettingRow("User", session.username.orEmpty())
-                HorizontalDivider(thickness = 1.dp, color = AarisColor.Line)
-                SettingRow("Role", if (session.isAdmin) "Admin" else "User")
-                HorizontalDivider(thickness = 1.dp, color = AarisColor.Line)
-                // Where the bearer token actually lives. Worth surfacing: it is the difference
-                // between a session that survives a restart and one that deliberately does not.
-                SettingRow(
-                    "Credential storage",
-                    sessionStore.credentialStoreName +
-                        if (sessionStore.persistsCredentials) "" else " (this session only)",
-                )
-                HorizontalDivider(thickness = 1.dp, color = AarisColor.Line)
-                // BuildInfo is generated from the single `ttsroad.version` Gradle property, so
-                // this always matches the installer the user actually ran.
-                SettingRow("Version", "${BuildInfo.APP_NAME} ${BuildInfo.VERSION}")
-            }
-        }
-        MetaText(text = "// Server", color = AarisColor.Accent)
-        AarisCard {
-            Column(Modifier.fillMaxWidth().padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                SettingRow(
-                    "Build",
-                    listOfNotNull(
-                        capabilities.serverName.takeIf { capabilities.isDiscovered } ?: session.serverName,
-                        capabilities.serverVersion ?: session.serverVersion,
-                    ).joinToString(" "),
-                )
-                HorizontalDivider(thickness = 1.dp, color = AarisColor.Line)
-                // An older server answers 404 to discovery and lands on the baseline, where every
-                // optional feature is off — which is exactly what this row then says.
-                SettingRow("Optional features", describeCapabilities(capabilities))
-            }
-        }
-        Button(
-            onClick = { scope.launch { busy = true; repository.logout(); busy = false } },
-            enabled = !busy,
-            shape = RectangleShape,
-            modifier = Modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
-        ) { Text(if (busy) "SIGNING OUT" else "SIGN OUT") }
-    }
-}
-
-/** One line naming everything the signed-in server advertised, or saying that it advertised none. */
-private fun describeCapabilities(capabilities: ServerCapabilities): String {
-    val enabled = buildList {
-        if (capabilities.readAlong) add("Read-along")
-        if (capabilities.search) add("Server search")
-        if (capabilities.bookmarks) add("Bookmarks")
-        if (capabilities.deltaSync) add("Delta sync")
-        if (capabilities.batchProgress) add("Batch progress")
-        if (capabilities.audioContentHash) add("Audio content hash")
-        if (capabilities.deviceManagement) add("Device management")
-    }
-    return when {
-        enabled.isNotEmpty() -> enabled.joinToString(", ")
-        capabilities.isDiscovered -> "None advertised"
-        else -> "Not advertised by this server"
-    }
-}
-
-@Composable
-private fun SettingRow(label: String, value: String) {
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        MetaText(label)
-        Text(value.ifBlank { "-" }, style = MaterialTheme.typography.titleMedium, color = AarisColor.Ink)
-    }
-}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/DeviceSessions.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/DeviceSessions.kt
@@ -1,0 +1,121 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Json
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+/** `GET /api/mobile/me` — the account as the server sees it right now. */
+data class CurrentUserResponse(val user: MobileUser)
+
+/** `GET /api/mobile/devices`. */
+data class DevicesResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    val devices: List<DeviceSession> = emptyList(),
+)
+
+/**
+ * One sign-in on this account — a row of the server's `MobileApiToken` table.
+ *
+ * Everything but [id] is optional on purpose: `last_ip` is null until the session is actually used,
+ * and a server that omits a field (or sends one this build has never heard of) must still produce a
+ * listable row rather than failing the whole response. That is also why the timestamps stay
+ * `String` here and are parsed at the edge — one unreadable date costs that one line, not the list.
+ */
+data class DeviceSession(
+    val id: Int = 0,
+    @param:Json(name = "device_name") val deviceName: String? = null,
+    @param:Json(name = "created_at") val createdAt: String? = null,
+    @param:Json(name = "last_used_at") val lastUsedAt: String? = null,
+    @param:Json(name = "expires_at") val expiresAt: String? = null,
+    @param:Json(name = "last_ip") val lastIp: String? = null,
+    /** `active` | `revoked` | `expired`, computed server-side. Null on a server that omits it. */
+    val status: String? = null,
+    @param:Json(name = "is_current") val isCurrent: Boolean = false,
+) {
+    /** Never blank, so a nameless session still has something to read and click. */
+    val resolvedName: String
+        get() = deviceName?.trim()?.takeIf { it.isNotEmpty() } ?: "Unnamed device"
+
+    /**
+     * Whether this row is the window the user is looking at.
+     *
+     * The server marks it, but only from the token that made the request — a listing fetched over a
+     * session cookie, or a backend that omits the flag, would mark nothing at all. The `device_id`
+     * kept from the login response is the local second opinion, and getting this wrong is the one
+     * mistake that matters here: an unmarked current session is a session the user can revoke by
+     * accident from its own row.
+     */
+    fun isCurrentFor(session: SessionState): Boolean =
+        isCurrent || (session.deviceId != null && session.deviceId == id)
+}
+
+/**
+ * The current session first, then the rest most-recently-used first.
+ *
+ * The server already orders by `last_used_at DESC`, but that ordering says nothing about which row
+ * is *this* device, and "the one you are holding" is the row a user looks for first.
+ */
+fun List<DeviceSession>.currentSessionFirst(session: SessionState): List<DeviceSession> =
+    sortedWith(
+        compareByDescending<DeviceSession> { it.isCurrentFor(session) }
+            .thenByDescending { parseServerInstant(it.lastUsedAt)?.toEpochMilli() ?: Long.MIN_VALUE }
+            .thenByDescending { it.id },
+    )
+
+/**
+ * Reads a timestamp the backend produced.
+ *
+ * The server is not consistent about the zone suffix — `app/routers/mobile.py` emits
+ * `...123456Z` while `app/services/mobile_auth.py` emits second-precision `...Z`, and other paths
+ * serialize naive values — so `Z`, an explicit offset, and a bare local date-time are all tried.
+ * Naive input is read as UTC, which is what the database stores. Returns null rather than throwing:
+ * a device row with one unreadable date is still worth showing.
+ */
+fun parseServerInstant(iso: String?): Instant? {
+    val text = iso?.trim().orEmpty()
+    if (text.isEmpty()) return null
+    return runCatching { Instant.parse(text) }
+        .recoverCatching { OffsetDateTime.parse(text).toInstant() }
+        .recoverCatching { LocalDateTime.parse(text).toInstant(ZoneOffset.UTC) }
+        .getOrNull()
+}
+
+private const val TimestampPattern = "d MMM yyyy, HH:mm"
+
+/**
+ * A server timestamp as a short local date and time, or null when there is nothing usable.
+ *
+ * Rendered in the desktop's own zone and locale: "last used" only means something measured against
+ * the clock the user is looking at. [zone] and [locale] are parameters so the formatting can be
+ * asserted without the test depending on the machine's settings.
+ */
+fun formatServerTimestamp(
+    iso: String?,
+    zone: ZoneId = ZoneId.systemDefault(),
+    locale: Locale = Locale.getDefault(),
+): String? {
+    val instant = parseServerInstant(iso) ?: return null
+    return DateTimeFormatter.ofPattern(TimestampPattern, locale).withZone(zone).format(instant)
+}
+
+/**
+ * How much life a session has left, in whole days.
+ *
+ * Deliberately coarse: tokens last 90 days and are renewed by every authenticated request, so the
+ * exact hour is noise. The only question worth answering is whether a session is about to lapse.
+ */
+fun formatExpiresIn(iso: String?, nowMs: Long): String? {
+    val expiry = parseServerInstant(iso) ?: return null
+    val remainingMs = expiry.toEpochMilli() - nowMs
+    if (remainingMs <= 0L) return "expired"
+    return when (val days = remainingMs / 86_400_000L) {
+        0L -> "expires today"
+        1L -> "expires in 1 day"
+        else -> "expires in $days days"
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -84,6 +84,37 @@ interface TtsRoadRepository {
 
     suspend fun library(): LibraryResponse
 
+    /**
+     * The signed-in account as the server sees it now, or null when the server has no `/me`.
+     *
+     * Worth asking even though login already returned a user: `is_admin` can be changed from the
+     * web console while a desktop session is open, and this is the cheapest way to notice.
+     */
+    suspend fun currentUser(): MobileUser?
+
+    /**
+     * Every session on this account, or **null when the server has no device-management API**.
+     *
+     * Null rather than an empty list because the two mean opposite things to the UI: "nothing else
+     * is signed in" is a normal, correct answer, while "this server cannot answer" has to become a
+     * concise unsupported state instead of an HTTP error the user cannot act on.
+     */
+    suspend fun devices(): List<DeviceSession>?
+
+    /**
+     * Revokes one session.
+     *
+     * False means the server answered 404, which is ambiguous by design: the endpoint may be
+     * missing, or that session may already be gone (`app/routers/mobile.py` returns the same 404
+     * for an unknown, an already-revoked, and another user's token). Callers disambiguate with what
+     * they already know — a caller holding a successfully loaded list is clearly talking to a
+     * server that has the endpoint.
+     */
+    suspend fun revokeDevice(tokenId: Int): Boolean
+
+    /** Revokes every session except this one. False means 404, as in [revokeDevice]. */
+    suspend fun revokeOtherDevices(): Boolean
+
     suspend fun chapters(fictionId: Int, playableOnly: Boolean = false): ChaptersResponse
 
     suspend fun markPlayed(chapterIds: List<Int>, played: Boolean): PlaybackMarkResponse
@@ -260,6 +291,16 @@ class RetrofitTtsRoadRepository(
 
     override suspend fun library(): LibraryResponse = withAuthorizedApi { it.library() }
 
+    override suspend fun currentUser(): MobileUser? = ifEndpointExists { it.me() }?.user
+
+    override suspend fun devices(): List<DeviceSession>? = ifEndpointExists { it.devices() }?.devices
+
+    override suspend fun revokeDevice(tokenId: Int): Boolean =
+        ifEndpointExists { it.revokeDevice(tokenId) } != null
+
+    override suspend fun revokeOtherDevices(): Boolean =
+        ifEndpointExists { it.revokeOtherDevices() } != null
+
     override suspend fun chapters(fictionId: Int, playableOnly: Boolean): ChaptersResponse =
         withAuthorizedApi { it.chapters(fictionId = fictionId, playableOnly = playableOnly) }
 
@@ -293,6 +334,20 @@ class RetrofitTtsRoadRepository(
     private fun forgetSessionScopedState(serverUrl: String) {
         forgetCapabilities(serverUrl)
         _currentCapabilities.value = ServerCapabilities.Baseline
+    }
+
+    /**
+     * Runs an authenticated call, answering null when the server has never heard of the endpoint.
+     *
+     * The device-management API is *additive* and `api_version` did not change with it, so there is
+     * no version to test against and a 404 is the only available signal that the backend predates
+     * it. Everything else keeps its normal meaning — in particular a 401 still ends the session,
+     * because "this server is old" and "this token is dead" must not be confused.
+     */
+    private suspend fun <T> ifEndpointExists(block: suspend (TtsRoadApi) -> T): T? = try {
+        withAuthorizedApi(block)
+    } catch (e: HttpException) {
+        if (e.code() == 404) null else throw e
     }
 
     private suspend fun <T> withAuthorizedApi(block: suspend (TtsRoadApi) -> T): T =

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -1,6 +1,7 @@
 package dk.perspektiva.ttsroad.desktop.data
 
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.POST
@@ -34,6 +35,28 @@ interface TtsRoadApi {
 
     @POST("api/mobile/logout")
     suspend fun logout()
+
+    /** The signed-in account as the server sees it — the authoritative `is_admin`. */
+    @GET("api/mobile/me")
+    suspend fun me(): CurrentUserResponse
+
+    /** Every mobile/desktop sign-in on this account. 404 on a server older than the endpoint. */
+    @GET("api/mobile/devices")
+    suspend fun devices(): DevicesResponse
+
+    // Both revoke calls answer with a small status object (`{"status": "ok", ...}`) whose shape is
+    // not worth modelling: the client re-reads the list afterwards rather than trusting an echo,
+    // because a 404 on the DELETE is ambiguous between "already gone" and "no such endpoint".
+    @DELETE("api/mobile/devices/{token_id}")
+    suspend fun revokeDevice(@Path("token_id") tokenId: Int)
+
+    /**
+     * Revokes every *other* session. One server-side call rather than a loop of deletes, precisely
+     * so the client cannot get the "which one am I" question wrong: the token making the request is
+     * the one the server keeps.
+     */
+    @POST("api/mobile/devices/revoke-others")
+    suspend fun revokeOtherDevices()
 
     @GET("api/mobile/library")
     suspend fun library(): LibraryResponse

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
@@ -1,0 +1,702 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.BuildInfo
+import dk.perspektiva.ttsroad.desktop.data.DeviceSession
+import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
+import dk.perspektiva.ttsroad.desktop.data.SessionState
+import dk.perspektiva.ttsroad.desktop.data.SessionStore
+import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
+import dk.perspektiva.ttsroad.desktop.data.formatExpiresIn
+import dk.perspektiva.ttsroad.desktop.data.formatServerTimestamp
+import dk.perspektiva.ttsroad.desktop.data.redactSecrets
+
+/** Below this the two panes stack, so the settings list stays usable in a narrow window. */
+private val TwoPaneMinWidth = 780.dp
+private val NavPaneWidth = 220.dp
+
+/**
+ * The desktop control centre: a two-pane settings screen.
+ *
+ * State lives in [SettingsStateHolder] rather than in this composable, and the production caller
+ * hoists that holder above navigation — so leaving settings and coming back keeps the selected pane
+ * and the loaded device list. Everything irreversible here goes through one confirmation dialog.
+ */
+@Composable
+fun SettingsScreen(
+    sessionStore: SessionStore,
+    repository: TtsRoadRepository,
+    holder: SettingsStateHolder = rememberStateHolder(repository, sessionStore) {
+        SettingsStateHolder(repository, sessionStore)
+    },
+    // Injected so "expires in 42 days" can be asserted without the test depending on wall time.
+    nowMs: () -> Long = System::currentTimeMillis,
+) {
+    val ui by holder.state.collectAsState()
+    val session by sessionStore.session.collectAsState()
+    val capabilities by repository.currentCapabilities.collectAsState()
+
+    LaunchedEffect(ui.section) {
+        when (ui.section) {
+            SettingsSection.Account -> holder.verifyAccount()
+            SettingsSection.Devices -> holder.ensureDevicesLoaded()
+            else -> Unit
+        }
+    }
+
+    BoxWithConstraints(Modifier.fillMaxSize()) {
+        val stacked = maxWidth < TwoPaneMinWidth
+        val pane: @Composable () -> Unit = {
+            Column(
+                Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(PageGutter),
+            ) {
+                Column(
+                    Modifier.widthIn(max = ContentMaxWidth).fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    when (ui.section) {
+                        SettingsSection.Account -> AccountPane(ui, session, capabilities, sessionStore, holder, nowMs)
+                        SettingsSection.Devices -> DevicesPane(ui, session, holder, nowMs)
+                        SettingsSection.Playback -> PlaybackPane()
+                        SettingsSection.Offline -> OfflinePane()
+                        SettingsSection.About -> AboutPane(session, capabilities, sessionStore)
+                    }
+                }
+            }
+        }
+
+        if (stacked) {
+            Column(Modifier.fillMaxSize()) {
+                SettingsNav(current = ui.section, stacked = true, onSelect = holder::openSection)
+                HorizontalDivider(thickness = 1.dp, color = AarisColor.Line)
+                Box(Modifier.weight(1f).fillMaxWidth()) { pane() }
+            }
+        } else {
+            Row(Modifier.fillMaxSize()) {
+                SettingsNav(current = ui.section, stacked = false, onSelect = holder::openSection)
+                VerticalDivider(thickness = 1.dp, color = AarisColor.Line)
+                Box(Modifier.weight(1f).fillMaxHeight()) { pane() }
+            }
+        }
+    }
+
+    ui.confirmation?.let { pending ->
+        val copy = confirmationCopy(pending)
+        ConfirmDialog(
+            title = copy.title,
+            body = copy.body,
+            confirmLabel = copy.confirmLabel,
+            onConfirm = holder::confirm,
+            onDismiss = holder::dismissConfirmation,
+        )
+    }
+}
+
+private data class ConfirmationCopy(val title: String, val body: String, val confirmLabel: String)
+
+private fun confirmationCopy(confirmation: SettingsConfirmation): ConfirmationCopy = when (confirmation) {
+    is SettingsConfirmation.RevokeDevice -> ConfirmationCopy(
+        title = "SIGN OUT DEVICE",
+        body = "${confirmation.device.resolvedName} will need to sign in again. " +
+            "Anything playing on it stops.",
+        confirmLabel = "SIGN IT OUT",
+    )
+
+    SettingsConfirmation.RevokeOtherDevices -> ConfirmationCopy(
+        title = "SIGN OUT OTHER DEVICES",
+        body = "Every other signed-in device will need to sign in again. This one stays signed in.",
+        confirmLabel = "SIGN THEM OUT",
+    )
+
+    SettingsConfirmation.SignOut -> ConfirmationCopy(
+        title = "SIGN OUT",
+        body = "This device will need to sign in again. Nothing you asked to keep on this " +
+            "computer is deleted.",
+        // Not just "SIGN OUT": the button that opened this dialog says that, and a confirmation
+        // whose answer is worded identically to the thing you just pressed is not a confirmation.
+        confirmLabel = "SIGN OUT THIS DEVICE",
+    )
+}
+
+// --- Navigation ----------------------------------------------------------------------------
+
+@Composable
+private fun SettingsNav(current: SettingsSection, stacked: Boolean, onSelect: (SettingsSection) -> Unit) {
+    if (stacked) {
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
+                .padding(horizontal = PageGutter, vertical = 10.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            SettingsSection.entries.forEach { NavEntry(it, it == current, onSelect) }
+        }
+    } else {
+        Column(
+            Modifier
+                .width(NavPaneWidth)
+                .fillMaxHeight()
+                .verticalScroll(rememberScrollState())
+                .padding(vertical = PageGutter, horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            MetaText(text = "// Settings", color = AarisColor.Accent)
+            Spacer(Modifier.height(8.dp))
+            SettingsSection.entries.forEach { NavEntry(it, it == current, onSelect) }
+        }
+    }
+}
+
+/**
+ * One entry in the settings list.
+ *
+ * `selectable` rather than `clickable`: it makes the entry reachable with Tab, activatable with
+ * Enter or Space, and — through [Role.Tab] and the selected flag — announced as "tab, selected" by
+ * a screen reader instead of as an anonymous piece of text.
+ */
+@Composable
+private fun NavEntry(section: SettingsSection, selected: Boolean, onSelect: (SettingsSection) -> Unit) {
+    Row(
+        Modifier
+            .selectable(
+                selected = selected,
+                role = Role.Tab,
+                onClick = { onSelect(section) },
+            )
+            .pointerHoverIcon(PointerIcon.Hand)
+            .background(if (selected) AarisColor.BgHover else Color.Transparent)
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            Modifier
+                .width(2.dp)
+                .height(14.dp)
+                .background(if (selected) AarisColor.Accent else Color.Transparent),
+        )
+        Spacer(Modifier.width(10.dp))
+        MetaText(section.label, color = if (selected) AarisColor.Ink else AarisColor.Muted)
+    }
+}
+
+// --- Account -------------------------------------------------------------------------------
+
+@Composable
+private fun AccountPane(
+    ui: SettingsUiState,
+    session: SessionState,
+    capabilities: ServerCapabilities,
+    sessionStore: SessionStore,
+    holder: SettingsStateHolder,
+    nowMs: () -> Long,
+) {
+    PaneTitle("Account", "Server, sign-in and this device")
+
+    SettingsCard {
+        SettingRow("Server", listOfNotNull(serverDisplayName(session, capabilities), capabilities.serverVersion ?: session.serverVersion).joinToString(" "))
+        RowDivider()
+        SettingRow("Address", session.serverUrl)
+        RowDivider()
+        // An older server answers 404 to discovery and lands on the baseline, where every optional
+        // feature is off — which is exactly what this row then says.
+        SettingRow("Optional features", describeCapabilities(capabilities))
+    }
+
+    MetaText(text = "// Signed in", color = AarisColor.Accent)
+    SettingsCard {
+        SettingRow("User", ui.verifiedUser?.username ?: session.username.orEmpty())
+        RowDivider()
+        SettingRow("Role", if (ui.verifiedUser?.isAdmin ?: session.isAdmin) "Admin" else "User")
+        RowDivider()
+        // Where the bearer token actually lives. Worth surfacing: it is the difference between a
+        // session that survives a restart and one that deliberately does not.
+        SettingRow(
+            "Credential storage",
+            sessionStore.credentialStoreName +
+                if (sessionStore.persistsCredentials) "" else " (this session only)",
+        )
+    }
+
+    MetaText(text = "// This device", color = AarisColor.Accent)
+    SettingsCard {
+        SettingRow("Session id", session.deviceId?.toString() ?: "Not reported by this server")
+        RowDivider()
+        SettingRow(
+            "Session expires",
+            listOfNotNull(
+                formatServerTimestamp(session.expiresAt),
+                formatExpiresIn(session.expiresAt, nowMs()),
+            ).joinToString(" · ").ifBlank { "Unknown" },
+        )
+    }
+
+    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        OutlinedButton(
+            onClick = { holder.openSection(SettingsSection.Devices) },
+            shape = RectangleShape,
+            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+        ) { Text("MANAGE DEVICE SESSIONS") }
+        Button(
+            onClick = holder::askSignOut,
+            enabled = !ui.signingOut,
+            shape = RectangleShape,
+            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+        ) { Text(if (ui.signingOut) "SIGNING OUT" else "SIGN OUT") }
+    }
+}
+
+// --- Device sessions -----------------------------------------------------------------------
+
+@Composable
+private fun DevicesPane(
+    ui: SettingsUiState,
+    session: SessionState,
+    holder: SettingsStateHolder,
+    nowMs: () -> Long,
+) {
+    val devices = ui.devices
+    PaneTitle("Device sessions", "Everything signed in to this account")
+
+    when {
+        // Gated: either the server said it has no device management, or the endpoint answered 404.
+        // Either way this is a missing feature, not a fault, and every other setting still works.
+        devices.unsupported -> InfoCard(
+            "This server has no device-session API. Update the backend to manage sign-ins from " +
+                "here. Everything else in Settings works as usual.",
+        )
+
+        devices.isInitialLoad -> Box(Modifier.fillMaxWidth().height(120.dp)) { CenterProgress() }
+
+        devices.loaded == null -> {
+            Text(
+                devices.error ?: "Could not load device sessions",
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            OutlinedButton(
+                onClick = holder::refreshDevices,
+                enabled = !devices.isLoading,
+                shape = RectangleShape,
+                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+            ) { Text("RETRY") }
+        }
+
+        else -> {
+            // A failed refresh reports itself above the list it failed to replace, rather than
+            // replacing it with an error screen.
+            if (devices.isLoading) ThinProgress(fraction = 1f, modifier = Modifier.fillMaxWidth(), height = 2.dp)
+            devices.error?.let {
+                Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodyMedium)
+            }
+            devices.notice?.let { MetaText(text = it, color = AarisColor.Ok) }
+
+            MetaText(text = "// This device", color = AarisColor.Accent)
+            val current = holder.currentDevice()
+            if (current == null) {
+                InfoCard("This session is not in the list yet.")
+            } else {
+                // No revoke control on this row at all: ending *this* session is what Sign out is
+                // for, and a delete button next to "This device" is an accident waiting to happen.
+                DeviceCard(current, isCurrent = true, nowMs = nowMs, onRevoke = null)
+            }
+
+            MetaText(text = "// Other sessions", color = AarisColor.Accent)
+            val others = holder.otherDevices()
+            if (others.isEmpty()) {
+                InfoCard("Nothing else is signed in.")
+            } else {
+                others.forEach { device ->
+                    DeviceCard(
+                        device = device,
+                        isCurrent = false,
+                        nowMs = nowMs,
+                        onRevoke = { holder.askRevoke(device) }.takeIf { !devices.isBusy },
+                    )
+                }
+                Button(
+                    onClick = holder::askRevokeOtherDevices,
+                    enabled = !devices.isBusy,
+                    shape = RectangleShape,
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                ) { Text(if (devices.isBusy) "WORKING" else "SIGN OUT ALL OTHER DEVICES") }
+            }
+
+            OutlinedButton(
+                onClick = holder::refreshDevices,
+                enabled = !devices.isLoading && !devices.isBusy,
+                shape = RectangleShape,
+                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+            ) { Text("REFRESH") }
+        }
+    }
+
+    if (devices.loaded != null) {
+        MetaText(
+            text = "Signing a device out cannot be undone — it has to sign in again.",
+            color = AarisColor.Dim,
+        )
+    }
+    // Shown when the list cannot be: the current session's identity comes from the login response,
+    // so it never depends on an endpoint the server may not have.
+    if (session.deviceId != null && (devices.unsupported || devices.error != null)) {
+        MetaText(text = "This session's id is ${session.deviceId}", color = AarisColor.Dim)
+    }
+}
+
+@Composable
+private fun DeviceCard(
+    device: DeviceSession,
+    isCurrent: Boolean,
+    nowMs: () -> Long,
+    onRevoke: (() -> Unit)?,
+) {
+    val lastUsed = formatServerTimestamp(device.lastUsedAt) ?: "Never"
+    val signedIn = formatServerTimestamp(device.createdAt) ?: "-"
+    val expires = listOfNotNull(
+        formatServerTimestamp(device.expiresAt),
+        formatExpiresIn(device.expiresAt, nowMs()),
+    ).joinToString(" · ").ifBlank { "-" }
+    val lastIp = device.lastIp ?: "-"
+    // One sentence for a screen reader, instead of eight unlabelled fragments read in layout order.
+    val spoken = buildString {
+        append(device.resolvedName)
+        if (isCurrent) append(", this device")
+        device.status?.takeIf { it.isNotBlank() }?.let { append(", $it") }
+        append(", last used $lastUsed, signed in $signedIn, $expires, last IP $lastIp")
+    }
+
+    AarisCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            Modifier.fillMaxWidth().padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Column(
+                Modifier
+                    .fillMaxWidth()
+                    .semantics(mergeDescendants = true) { contentDescription = spoken },
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        device.resolvedName,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = AarisColor.Ink,
+                        modifier = Modifier.weight(1f),
+                    )
+                    if (isCurrent) AarisTag(text = "This device")
+                    device.status?.takeIf { it.isNotBlank() }?.let {
+                        Spacer(Modifier.width(6.dp))
+                        AarisTag(text = it)
+                    }
+                }
+                DeviceDetail("Last used", lastUsed)
+                DeviceDetail("Signed in", signedIn)
+                DeviceDetail("Expires", expires)
+                // Null until the session is actually used, so a fresh sign-in shows a dash.
+                DeviceDetail("Last IP", lastIp)
+            }
+            onRevoke?.let {
+                OutlinedButton(
+                    onClick = it,
+                    shape = RectangleShape,
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = AarisColor.Danger),
+                    modifier = Modifier
+                        .pointerHoverIcon(PointerIcon.Hand)
+                        .semantics { contentDescription = "Sign out ${device.resolvedName}" },
+                ) { Text("SIGN OUT") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeviceDetail(label: String, value: String) {
+    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        MetaText(label)
+        Spacer(Modifier.width(12.dp))
+        MetaText(value, color = AarisColor.Ink)
+    }
+}
+
+// --- Not-yet-built phases ------------------------------------------------------------------
+
+/**
+ * Playback preferences do not exist yet.
+ *
+ * Deliberately a description and not a set of dead switches: a control that looks live and changes
+ * nothing is worse than an honest empty pane, because the user cannot tell it did not work.
+ */
+@Composable
+private fun PlaybackPane() {
+    PaneTitle("Playback", "Not available yet")
+    InfoCard(
+        "Playback preferences are not part of this build. Skip interval, playback speed, " +
+            "auto-marking a finished chapter and a sleep timer arrive with the playback-preferences " +
+            "phase; until then the player uses fixed 30-second skips at normal speed.",
+    )
+}
+
+@Composable
+private fun OfflinePane() {
+    PaneTitle("Offline", "Not available yet")
+    InfoCard(
+        "Offline downloads are not part of this build. Nothing is stored for offline use, so " +
+            "there is no download cache to size or clear here — and signing out cannot delete " +
+            "anything you asked to keep. Chapters are streamed to a temporary file that is removed " +
+            "when playback moves on.",
+    )
+}
+
+// --- Updates & About -----------------------------------------------------------------------
+
+@Composable
+private fun AboutPane(
+    session: SessionState,
+    capabilities: ServerCapabilities,
+    sessionStore: SessionStore,
+) {
+    PaneTitle("Updates & About", "Build, licences and diagnostics")
+
+    SettingsCard {
+        // BuildInfo is generated from the single `ttsroad.version` Gradle property, so this always
+        // matches the installer the user actually ran.
+        SettingRow("Application", "${BuildInfo.APP_NAME} ${BuildInfo.VERSION}")
+        RowDivider()
+        SettingRow("Release channel", "Installed build")
+        RowDivider()
+        // Honest rather than aspirational: there is no updater in this build, so claiming to be
+        // "up to date" would be a claim nothing checked.
+        SettingRow("Update check", "Not available — install a newer build to update")
+        RowDivider()
+        SettingRow("Java runtime", "${System.getProperty("java.vm.name")} ${System.getProperty("java.version")}")
+    }
+
+    MetaText(text = "// Open source", color = AarisColor.Accent)
+    SettingsCard {
+        SettingRow("Apache License 2.0", "Kotlin, Compose Multiplatform, OkHttp, Retrofit, Moshi, Coil")
+        RowDivider()
+        SettingRow("LGPL 2.1", "JLayer, MP3SPI, Tritonus (JavaZOOM) — MP3 decoding")
+    }
+
+    MetaText(text = "// Diagnostics", color = AarisColor.Accent)
+    val diagnostics = buildDiagnostics(
+        session = session,
+        capabilities = capabilities,
+        credentialStoreName = sessionStore.credentialStoreName,
+        persistsCredentials = sessionStore.persistsCredentials,
+    )
+    SettingsCard {
+        Text(
+            diagnostics,
+            style = MaterialTheme.typography.bodyMedium,
+            color = AarisColor.Muted,
+        )
+    }
+    OutlinedButton(
+        onClick = { copyToClipboard(diagnostics) },
+        shape = RectangleShape,
+        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+    ) { Text("COPY DIAGNOSTICS") }
+}
+
+/**
+ * The block a user can paste into a bug report.
+ *
+ * Everything here is either a machine fact or a server hint; the bearer token has no line of its
+ * own *and* the whole block goes through [redactSecrets], so a future field that accidentally
+ * carries a credential cannot make it into the clipboard verbatim.
+ */
+fun buildDiagnostics(
+    session: SessionState,
+    capabilities: ServerCapabilities,
+    credentialStoreName: String,
+    persistsCredentials: Boolean,
+): String = redactSecrets(
+    buildString {
+        appendLine("${BuildInfo.APP_NAME} ${BuildInfo.VERSION}")
+        appendLine("OS: ${System.getProperty("os.name")} ${System.getProperty("os.version")} (${System.getProperty("os.arch")})")
+        appendLine("Java: ${System.getProperty("java.vm.name")} ${System.getProperty("java.version")}")
+        appendLine("Credential storage: $credentialStoreName${if (persistsCredentials) "" else " (session only)"}")
+        appendLine("Server: ${session.serverUrl.ifBlank { "-" }}")
+        appendLine("Server build: ${serverDisplayName(session, capabilities)} ${capabilities.serverVersion ?: session.serverVersion ?: "unknown"}")
+        appendLine("Optional features: ${describeCapabilities(capabilities)}")
+        appendLine("Session id: ${session.deviceId?.toString() ?: "unknown"}")
+    }.trim(),
+)
+
+private fun copyToClipboard(text: String) {
+    // Headless CI has no clipboard; a failure to copy is not worth crashing settings over.
+    runCatching {
+        java.awt.Toolkit.getDefaultToolkit().systemClipboard
+            .setContents(java.awt.datatransfer.StringSelection(text), null)
+    }
+}
+
+// --- Shared bits ---------------------------------------------------------------------------
+
+private fun serverDisplayName(session: SessionState, capabilities: ServerCapabilities): String =
+    capabilities.serverName.takeIf { capabilities.isDiscovered } ?: session.serverName
+
+/** One line naming everything the signed-in server advertised, or saying that it advertised none. */
+fun describeCapabilities(capabilities: ServerCapabilities): String {
+    val enabled = buildList {
+        if (capabilities.readAlong) add("Read-along")
+        if (capabilities.search) add("Server search")
+        if (capabilities.bookmarks) add("Bookmarks")
+        if (capabilities.deltaSync) add("Delta sync")
+        if (capabilities.batchProgress) add("Batch progress")
+        if (capabilities.audioContentHash) add("Audio content hash")
+        if (capabilities.deviceManagement) add("Device management")
+    }
+    return when {
+        enabled.isNotEmpty() -> enabled.joinToString(", ")
+        capabilities.isDiscovered -> "None advertised"
+        else -> "Not advertised by this server"
+    }
+}
+
+@Composable
+private fun PaneTitle(title: String, subtitle: String) {
+    Column(Modifier.fillMaxWidth()) {
+        Text(title.uppercase(), style = MaterialTheme.typography.titleLarge, color = AarisColor.Ink)
+        Spacer(Modifier.height(4.dp))
+        MetaText(subtitle)
+        Spacer(Modifier.height(8.dp))
+        HorizontalDivider(thickness = 1.dp, color = AarisColor.Line)
+    }
+}
+
+@Composable
+private fun SettingsCard(content: @Composable () -> Unit) {
+    AarisCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            Modifier.fillMaxWidth().padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) { content() }
+    }
+}
+
+@Composable
+private fun InfoCard(text: String) {
+    AarisCard(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text,
+            modifier = Modifier.padding(16.dp),
+            style = MaterialTheme.typography.bodyMedium,
+            color = AarisColor.Muted,
+        )
+    }
+}
+
+@Composable
+private fun RowDivider() = HorizontalDivider(thickness = 1.dp, color = AarisColor.Line)
+
+@Composable
+private fun SettingRow(label: String, value: String) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        MetaText(label)
+        Text(value.ifBlank { "-" }, style = MaterialTheme.typography.titleMedium, color = AarisColor.Ink)
+    }
+}
+
+/**
+ * The one dialog every irreversible action goes through.
+ *
+ * Keyboard behaviour is the point of the extra wiring: Escape dismisses (explicitly, rather than
+ * relying on the platform mapping), and focus lands on CANCEL — so the key a user hits reflexively
+ * is the safe one, never the destructive one.
+ */
+@Composable
+private fun ConfirmDialog(
+    title: String,
+    body: String,
+    confirmLabel: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val cancelFocus = remember { FocusRequester() }
+    LaunchedEffect(title) { runCatching { cancelFocus.requestFocus() } }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = Modifier
+            .onPreviewKeyEvent { event ->
+                if (event.type == KeyEventType.KeyDown && event.key == Key.Escape) {
+                    onDismiss()
+                    true
+                } else {
+                    false
+                }
+            }
+            .semantics { paneTitle = title },
+        containerColor = AarisColor.BgRaise,
+        title = { Text(title, style = MaterialTheme.typography.titleLarge, color = AarisColor.Ink) },
+        text = { Text(body, style = MaterialTheme.typography.bodyMedium, color = AarisColor.Muted) },
+        confirmButton = {
+            Button(
+                onClick = onConfirm,
+                shape = RectangleShape,
+                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+            ) { Text(confirmLabel) }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                shape = RectangleShape,
+                modifier = Modifier.focusRequester(cancelFocus).pointerHoverIcon(PointerIcon.Hand),
+            ) { Text("CANCEL") }
+        },
+    )
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsStateHolder.kt
@@ -1,0 +1,263 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.data.DeviceSession
+import dk.perspektiva.ttsroad.desktop.data.MobileUser
+import dk.perspektiva.ttsroad.desktop.data.SessionStore
+import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
+import dk.perspektiva.ttsroad.desktop.data.currentSessionFirst
+import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/** The panes of the settings screen, in the order they appear in the left-hand list. */
+enum class SettingsSection(val label: String) {
+    Account("Account"),
+    Devices("Device sessions"),
+    Playback("Playback"),
+    Offline("Offline"),
+    About("Updates & About"),
+}
+
+/**
+ * A question the user has to answer before something irreversible happens.
+ *
+ * One slot, one dialog: only one of these can be pending at a time, and modelling it as state
+ * rather than as a `var showDialog` inside a composable is what makes both answers — confirm and
+ * cancel — testable without a display.
+ */
+sealed interface SettingsConfirmation {
+    data class RevokeDevice(val device: DeviceSession) : SettingsConfirmation
+    data object RevokeOtherDevices : SettingsConfirmation
+    data object SignOut : SettingsConfirmation
+}
+
+/**
+ * Everything the device-sessions pane needs.
+ *
+ * [loaded] and [unsupported] answer two different questions and are deliberately separate:
+ * `loaded == emptyList()` means "this account has no other sessions", while [unsupported] means
+ * "this server cannot answer at all". [error] never clears [loaded] — a failed refresh must leave
+ * the list the user was already reading on screen.
+ */
+data class DeviceSessionsUiState(
+    val isLoading: Boolean = false,
+    val isBusy: Boolean = false,
+    val loaded: List<DeviceSession>? = null,
+    val unsupported: Boolean = false,
+    val error: String? = null,
+    val notice: String? = null,
+) {
+    /** True only while there is nothing at all to show yet — the one case that owes a spinner. */
+    val isInitialLoad: Boolean get() = isLoading && loaded == null && error == null && !unsupported
+}
+
+data class SettingsUiState(
+    val section: SettingsSection = SettingsSection.Account,
+    val confirmation: SettingsConfirmation? = null,
+    val devices: DeviceSessionsUiState = DeviceSessionsUiState(),
+    /** From `GET /api/mobile/me`; null until it answers, or against a server without the endpoint. */
+    val verifiedUser: MobileUser? = null,
+    val signingOut: Boolean = false,
+)
+
+/**
+ * State for the whole settings screen, including device-session management.
+ *
+ * Held above the settings composable (see `App`) so switching to the library and back keeps the
+ * selected pane and the loaded device list — settings that reset themselves every time the user
+ * looks at something else are settings nobody trusts.
+ */
+class SettingsStateHolder(
+    private val repository: TtsRoadRepository,
+    private val sessionStore: SessionStore,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : StateHolder(dispatcher) {
+    private val _state = MutableStateFlow(SettingsUiState())
+    val state: StateFlow<SettingsUiState> = _state.asStateFlow()
+
+    private var loadJob: Job? = null
+    private var verifyJob: Job? = null
+
+    fun openSection(section: SettingsSection) {
+        _state.update { it.copy(section = section) }
+    }
+
+    /**
+     * Drops everything that belonged to the session that just ended.
+     *
+     * Called when the app loses its session: device rows name other machines on *that* account, so
+     * showing them to whoever signs in next would be both wrong and a small privacy leak.
+     */
+    fun sessionEnded() {
+        loadJob?.cancel()
+        verifyJob?.cancel()
+        _state.value = SettingsUiState()
+    }
+
+    // --- Account ---------------------------------------------------------------------------
+
+    /** Confirms the account with the server. Silent on failure: the stored session still stands. */
+    fun verifyAccount() {
+        if (verifyJob?.isActive == true || _state.value.verifiedUser != null) return
+        verifyJob = scope.launch {
+            runCatching { repository.currentUser() }
+                .onSuccess { user -> _state.update { it.copy(verifiedUser = user) } }
+        }
+    }
+
+    fun askSignOut() {
+        _state.update { it.copy(confirmation = SettingsConfirmation.SignOut) }
+    }
+
+    // --- Device sessions -------------------------------------------------------------------
+
+    /** Loads on first entry to the pane; a second visit reuses what is already there. */
+    fun ensureDevicesLoaded() {
+        val devices = _state.value.devices
+        if (devices.isLoading || devices.loaded != null || devices.unsupported) return
+        refreshDevices()
+    }
+
+    fun refreshDevices() {
+        loadJob?.cancel()
+        // The notice belongs to the last action, not to this list; re-reading on demand is exactly
+        // when "Signed out Pixel 9" stops being news.
+        updateDevices { it.copy(notice = null) }
+        loadJob = scope.launch { loadDevices() }
+    }
+
+    /**
+     * Offers to revoke [device].
+     *
+     * Refuses for the current session even if a caller asks: the row for this window has no revoke
+     * control, and the deliberate way to end *this* session is Sign out. Enforcing it here as well
+     * means a future UI change cannot reintroduce the accident.
+     */
+    fun askRevoke(device: DeviceSession) {
+        if (device.isCurrentFor(sessionStore.current())) return
+        _state.update { it.copy(confirmation = SettingsConfirmation.RevokeDevice(device)) }
+    }
+
+    fun askRevokeOtherDevices() {
+        _state.update { it.copy(confirmation = SettingsConfirmation.RevokeOtherDevices) }
+    }
+
+    fun dismissConfirmation() {
+        _state.update { it.copy(confirmation = null) }
+    }
+
+    /** Carries out whatever is pending. A no-op when nothing is, so a stray Enter cannot fire it. */
+    fun confirm() {
+        val pending = _state.value.confirmation ?: return
+        _state.update { it.copy(confirmation = null) }
+        when (pending) {
+            is SettingsConfirmation.RevokeDevice -> runRevoke(
+                success = "Signed out ${pending.device.resolvedName}",
+                failure = "Could not sign that device out",
+            ) { repository.revokeDevice(pending.device.id) }
+
+            SettingsConfirmation.RevokeOtherDevices -> runRevoke(
+                success = "Signed out every other device",
+                failure = "Could not sign the other devices out",
+            ) { repository.revokeOtherDevices() }
+
+            SettingsConfirmation.SignOut -> signOut()
+        }
+    }
+
+    /** The devices to render, current session first. Empty when nothing has loaded. */
+    fun visibleDevices(): List<DeviceSession> =
+        _state.value.devices.loaded.orEmpty().currentSessionFirst(sessionStore.current())
+
+    fun currentDevice(): DeviceSession? {
+        val session = sessionStore.current()
+        return _state.value.devices.loaded?.firstOrNull { it.isCurrentFor(session) }
+    }
+
+    fun otherDevices(): List<DeviceSession> {
+        val session = sessionStore.current()
+        return visibleDevices().filterNot { it.isCurrentFor(session) }
+    }
+
+    private suspend fun loadDevices() {
+        // Gate one: what the server said about itself. Only a *discovered* "no" skips the call —
+        // an undiscovered baseline means we never got an answer, and refusing to ask on that basis
+        // would hide a working feature. Gate two is the 404 below.
+        val capabilities = repository.currentCapabilities.value
+        if (capabilities.isDiscovered && !capabilities.deviceManagement) {
+            updateDevices { it.copy(isLoading = false, unsupported = true, loaded = null, error = null) }
+            return
+        }
+        updateDevices { it.copy(isLoading = true, error = null) }
+        runCatching { repository.devices() }
+            .onSuccess { loaded ->
+                updateDevices {
+                    it.copy(
+                        isLoading = false,
+                        unsupported = loaded == null,
+                        loaded = loaded,
+                        error = null,
+                    )
+                }
+            }
+            .onFailure { failure ->
+                // `loaded` is deliberately untouched: a refresh that fails must not blank a list
+                // the user is already reading. The message goes inline above it instead.
+                updateDevices {
+                    it.copy(
+                        isLoading = false,
+                        error = userFacingMessage(failure, "Could not load device sessions"),
+                    )
+                }
+            }
+    }
+
+    private fun runRevoke(success: String, failure: String, action: suspend () -> Boolean) {
+        loadJob?.cancel()
+        loadJob = scope.launch {
+            updateDevices { it.copy(isBusy = true, error = null, notice = null) }
+            val outcome = runCatching { action() }
+            outcome.onSuccess { endpointExists ->
+                updateDevices {
+                    when {
+                        endpointExists -> it.copy(notice = success)
+                        // A 404 from a server that just answered the listing is the server saying
+                        // that session is already gone, not that it lacks the feature.
+                        it.loaded != null -> it.copy(notice = "That session was already signed out")
+                        else -> it.copy(unsupported = true)
+                    }
+                }
+            }
+            updateDevices { it.copy(isBusy = false) }
+            // Re-read rather than patching locally: the server decides what survived, and after
+            // "revoke others" the client cannot know how many rows that was.
+            loadDevices()
+            // Re-applied *after* the reload: a successful reload legitimately clears a stale load
+            // error, and without this it would also clear the report of the action that just
+            // failed — leaving a screen that looks like the revoke worked.
+            outcome.exceptionOrNull()?.let { error ->
+                updateDevices { it.copy(error = userFacingMessage(error, failure)) }
+            }
+        }
+    }
+
+    private fun signOut() {
+        scope.launch {
+            _state.update { it.copy(signingOut = true) }
+            runCatching { repository.logout() }
+            // No state reset here — losing the session drives `sessionEnded()` from App, which is
+            // the same path a server-side revocation takes.
+            _state.update { it.copy(signingOut = false) }
+        }
+    }
+
+    private fun updateDevices(block: (DeviceSessionsUiState) -> DeviceSessionsUiState) {
+        _state.update { it.copy(devices = block(it.devices)) }
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -2,9 +2,11 @@ package dk.perspektiva.ttsroad.desktop
 
 import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
 import dk.perspektiva.ttsroad.desktop.data.ChaptersResponse
+import dk.perspektiva.ttsroad.desktop.data.DeviceSession
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
 import dk.perspektiva.ttsroad.desktop.data.LibraryResponse
 import dk.perspektiva.ttsroad.desktop.data.LoginResult
+import dk.perspektiva.ttsroad.desktop.data.MobileUser
 import dk.perspektiva.ttsroad.desktop.data.PlaybackMarkResponse
 import dk.perspektiva.ttsroad.desktop.data.PlaybackProgressResponse
 import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
@@ -28,6 +30,10 @@ open class FakeRepository(
     var chaptersResult: Result<ChaptersResponse> = Result.success(ChaptersResponse(fiction = FictionSummary())),
     var serverUrl: String = "https://ttsroad.example.com/",
     var capabilitiesResult: ServerCapabilities = ServerCapabilities.Baseline,
+    /** `success(null)` is the server saying it has no device API — not "no devices". */
+    var devicesResult: Result<List<DeviceSession>?> = Result.success(emptyList()),
+    var revokeResult: Result<Boolean> = Result.success(true),
+    var currentUserResult: Result<MobileUser?> = Result.success(null),
 ) : TtsRoadRepository {
     var loginCalls: Int = 0
         private set
@@ -39,6 +45,13 @@ open class FakeRepository(
         private set
     var chaptersCalls: Int = 0
         private set
+    var devicesCalls: Int = 0
+        private set
+    var revokeOtherDevicesCalls: Int = 0
+        private set
+
+    /** Token ids passed to [revokeDevice], in order — "the current session was never revoked". */
+    val revokedDevices: MutableList<Int> = mutableListOf()
 
     /** Base URLs discovery was asked about, in order — capability probing is observable. */
     val capabilityProbes: MutableList<String> = mutableListOf()
@@ -85,6 +98,23 @@ open class FakeRepository(
     override suspend fun library(): LibraryResponse {
         libraryCalls++
         return libraryResult.getOrThrow()
+    }
+
+    override suspend fun currentUser(): MobileUser? = currentUserResult.getOrThrow()
+
+    override suspend fun devices(): List<DeviceSession>? {
+        devicesCalls++
+        return devicesResult.getOrThrow()
+    }
+
+    override suspend fun revokeDevice(tokenId: Int): Boolean {
+        revokedDevices += tokenId
+        return revokeResult.getOrThrow()
+    }
+
+    override suspend fun revokeOtherDevices(): Boolean {
+        revokeOtherDevicesCalls++
+        return revokeResult.getOrThrow()
     }
 
     override suspend fun chapters(fictionId: Int, playableOnly: Boolean): ChaptersResponse {

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ServerFixtures.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ServerFixtures.kt
@@ -335,6 +335,103 @@ object ServerFixtures {
         }
     """.trimIndent()
 
+    /** GET /api/mobile/me — 200. */
+    val ME = """{"user": {"id": 1, "username": "admin", "is_admin": true}}"""
+
+    /**
+     * GET /api/mobile/devices — 200 (`mobile_token_payload`, app/services/mobile_auth.py).
+     *
+     * Three rows on purpose: the current desktop session, a still-active phone, and a revoked one
+     * the server keeps for 30 days after revocation. Note the timestamps are *second* precision
+     * with a `Z` here, while login's `expires_at` carries microseconds — the same client has to
+     * read both. The revoked row also carries `user_id`, which the client does not model.
+     */
+    val DEVICES = """
+        {
+          "api_version": 1,
+          "devices": [
+            {
+              "id": 42,
+              "user_id": 1,
+              "device_name": "workstation · Windows 11",
+              "created_at": "2026-08-01T09:00:00Z",
+              "last_used_at": "2026-08-06T09:10:00Z",
+              "expires_at": "2026-10-30T09:00:00Z",
+              "last_ip": "192.168.1.20",
+              "status": "active",
+              "is_current": true
+            },
+            {
+              "id": 43,
+              "user_id": 1,
+              "device_name": "Pixel 9",
+              "created_at": "2026-07-02T18:30:00Z",
+              "last_used_at": "2026-08-05T21:04:00Z",
+              "expires_at": "2026-09-30T18:30:00Z",
+              "last_ip": "10.0.0.5",
+              "status": "active",
+              "is_current": false
+            },
+            {
+              "id": 44,
+              "user_id": 1,
+              "device_name": null,
+              "created_at": "2026-06-01T10:00:00Z",
+              "last_used_at": null,
+              "expires_at": "2026-08-30T10:00:00Z",
+              "last_ip": null,
+              "status": "revoked",
+              "is_current": false
+            }
+          ]
+        }
+    """.trimIndent()
+
+    /** An account whose only session is this one. */
+    val DEVICES_ONLY_CURRENT = """
+        {
+          "api_version": 1,
+          "devices": [
+            {
+              "id": 42,
+              "device_name": "workstation · Windows 11",
+              "created_at": "2026-08-01T09:00:00Z",
+              "last_used_at": "2026-08-06T09:10:00Z",
+              "expires_at": "2026-10-30T09:00:00Z",
+              "last_ip": "192.168.1.20",
+              "status": "active",
+              "is_current": true
+            }
+          ]
+        }
+    """.trimIndent()
+
+    /**
+     * A row from a server that fills in almost nothing, plus one unparseable date.
+     *
+     * The point of the fixture is that a malformed optional field costs that field and nothing
+     * else: the row still lists, with dashes where the data is missing.
+     */
+    val DEVICES_MALFORMED_ROW = """
+        {
+          "devices": [
+            {"id": 51, "last_used_at": "yesterday", "expires_at": "", "future_field": {"x": 1}}
+          ]
+        }
+    """.trimIndent()
+
+    /** DELETE /api/mobile/devices/{id} — 200. */
+    val DEVICE_REVOKED = """{"status": "ok", "revoked": true, "token_id": 43}"""
+
+    /** POST /api/mobile/devices/revoke-others — 200. */
+    val DEVICES_REVOKED_OTHERS = """{"status": "ok", "revoked_count": 2}"""
+
+    /** What a server without the device API answers on any of the three device routes. */
+    val NOT_FOUND = """{"detail": "Not Found"}"""
+
+    /** DELETE on a token that is already gone — the same 404 an old server sends. */
+    val DEVICE_NOT_FOUND = """{"detail": "Active device session not found"}"""
+
     /** POST /api/mobile/playback/progress — 200. */
     val PROGRESS_SAVED = """{"status": "saved", "chapter_id": 101}"""
 
@@ -362,4 +459,12 @@ object ParsedFixtures {
             moshi.adapter(dk.perspektiva.ttsroad.desktop.data.ChaptersResponse::class.java)
                 .fromJson(ServerFixtures.CHAPTERS),
         )
+
+    val devices: List<dk.perspektiva.ttsroad.desktop.data.DeviceSession>
+        get() = devicesFrom(ServerFixtures.DEVICES)
+
+    fun devicesFrom(json: String): List<dk.perspektiva.ttsroad.desktop.data.DeviceSession> =
+        requireNotNull(
+            moshi.adapter(dk.perspektiva.ttsroad.desktop.data.DevicesResponse::class.java).fromJson(json),
+        ).devices
 }

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/DeviceSessionsTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/DeviceSessionsTest.kt
@@ -1,0 +1,167 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import dk.perspektiva.ttsroad.desktop.ParsedFixtures
+import dk.perspektiva.ttsroad.desktop.ServerFixtures
+import java.time.Instant
+import java.time.ZoneId
+import java.util.Locale
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The device-session model and its timestamps.
+ *
+ * Timestamps get this much attention because the backend emits at least three shapes for the same
+ * kind of field — microsecond `Z` from `app/routers/mobile.py`, second-precision `Z` from
+ * `app/services/mobile_auth.py`, and naive values from other paths — and because a device list is
+ * exactly the screen where a `DateTimeParseException` would take out the whole page.
+ */
+class DeviceSessionsTest {
+
+    // --- parseServerInstant ------------------------------------------------------------------
+
+    @Test
+    fun `a Z-suffixed UTC timestamp parses`() {
+        assertEquals(Instant.parse("2026-10-26T12:00:00Z"), parseServerInstant("2026-10-26T12:00:00Z"))
+    }
+
+    @Test
+    fun `microsecond precision parses — that is what the login response sends`() {
+        assertEquals(
+            Instant.parse("2026-11-04T09:12:33.123456Z"),
+            parseServerInstant("2026-11-04T09:12:33.123456Z"),
+        )
+    }
+
+    @Test
+    fun `a numeric offset parses and is converted to UTC`() {
+        assertEquals(
+            Instant.parse("2026-10-26T12:30:00Z"),
+            parseServerInstant("2026-10-26T14:30:00+02:00"),
+        )
+    }
+
+    @Test
+    fun `a naive timestamp is read as UTC, which is what the database stores`() {
+        assertEquals(Instant.parse("2026-10-26T12:00:00Z"), parseServerInstant("2026-10-26T12:00:00"))
+    }
+
+    @Test
+    fun `unusable input yields null instead of throwing`() {
+        listOf(null, "", "   ", "yesterday", "2026-13-45T99:99:99Z", "0").forEach {
+            assertNull(parseServerInstant(it), "expected null for ${it.orEmpty()}")
+        }
+    }
+
+    // --- formatServerTimestamp ---------------------------------------------------------------
+
+    @Test
+    fun `a timestamp renders in the requested zone, not in UTC`() {
+        // The acceptance criterion is "local timezone": the same instant must read differently in
+        // Copenhagen than in UTC, or the formatting is not doing its job.
+        val utc = formatServerTimestamp("2026-10-26T12:00:00Z", ZoneId.of("UTC"), Locale.UK)
+        val copenhagen = formatServerTimestamp("2026-10-26T12:00:00Z", ZoneId.of("Europe/Copenhagen"), Locale.UK)
+
+        assertEquals("26 Oct 2026, 12:00", utc)
+        assertEquals("26 Oct 2026, 13:00", copenhagen)
+    }
+
+    @Test
+    fun `an unreadable timestamp formats to null so the row can show a dash`() {
+        assertNull(formatServerTimestamp("not a date"))
+        assertNull(formatServerTimestamp(null))
+    }
+
+    // --- formatExpiresIn ---------------------------------------------------------------------
+
+    @Test
+    fun `expiry is described in whole days`() {
+        val now = Instant.parse("2026-08-06T09:00:00Z").toEpochMilli()
+
+        assertEquals("expires in 42 days", formatExpiresIn("2026-09-17T09:00:00Z", now))
+        assertEquals("expires in 1 day", formatExpiresIn("2026-08-07T10:00:00Z", now))
+        assertEquals("expires today", formatExpiresIn("2026-08-06T20:00:00Z", now))
+        assertEquals("expired", formatExpiresIn("2026-08-05T09:00:00Z", now))
+        assertNull(formatExpiresIn(null, now))
+    }
+
+    // --- the model ---------------------------------------------------------------------------
+
+    @Test
+    fun `the devices payload decodes, including the null-heavy revoked row`() {
+        val devices = ParsedFixtures.devices
+
+        assertEquals(3, devices.size)
+        assertEquals("workstation · Windows 11", devices[0].resolvedName)
+        assertTrue(devices[0].isCurrent)
+        assertEquals("192.168.1.20", devices[0].lastIp)
+        assertEquals("revoked", devices[2].status)
+        assertNull(devices[2].lastIp)
+        assertNull(devices[2].lastUsedAt)
+    }
+
+    @Test
+    fun `a nameless session still has something to read`() {
+        assertEquals("Unnamed device", DeviceSession(id = 1).resolvedName)
+        assertEquals("Unnamed device", DeviceSession(id = 1, deviceName = "   ").resolvedName)
+    }
+
+    @Test
+    fun `a row with almost nothing in it, and an unparseable date, still lists`() {
+        val devices = ParsedFixtures.devicesFrom(ServerFixtures.DEVICES_MALFORMED_ROW)
+
+        assertEquals(1, devices.size)
+        assertEquals(51, devices[0].id)
+        assertEquals("Unnamed device", devices[0].resolvedName)
+        // The bad values cost their own fields and nothing else.
+        assertNull(formatServerTimestamp(devices[0].lastUsedAt))
+        assertNull(formatExpiresIn(devices[0].expiresAt, System.currentTimeMillis()))
+        assertNull(devices[0].status)
+    }
+
+    @Test
+    fun `the stored device id identifies this session when the server does not mark it`() {
+        val row = DeviceSession(id = 42, isCurrent = false)
+
+        assertTrue(row.isCurrentFor(SessionState(deviceId = 42)))
+        assertFalse(row.isCurrentFor(SessionState(deviceId = 43)))
+        assertFalse(row.isCurrentFor(SessionState(deviceId = null)))
+        // ...and the server's own flag is still honoured on its own.
+        assertTrue(DeviceSession(id = 42, isCurrent = true).isCurrentFor(SessionState(deviceId = null)))
+    }
+
+    @Test
+    fun `the current session sorts first, then most recently used`() {
+        val devices = ParsedFixtures.devices
+
+        val ordered = devices.currentSessionFirst(SessionState(deviceId = 42))
+
+        // 42 leads because it is this session; 43 beats 44 because 44 has never been used.
+        assertEquals(listOf(42, 43, 44), ordered.map { it.id })
+    }
+
+    @Test
+    fun `a session the server did not mark still leads once the stored id recognises it`() {
+        val devices = listOf(
+            DeviceSession(id = 7, lastUsedAt = "2026-08-06T09:00:00Z"),
+            DeviceSession(id = 9, lastUsedAt = "2026-08-01T09:00:00Z"),
+        )
+
+        val ordered = devices.currentSessionFirst(SessionState(deviceId = 9))
+
+        assertEquals(listOf(9, 7), ordered.map { it.id })
+    }
+
+    @Test
+    fun `a session with no last-used date sorts last rather than crashing the comparator`() {
+        val ordered = listOf(
+            DeviceSession(id = 1, lastUsedAt = null),
+            DeviceSession(id = 2, lastUsedAt = "2026-08-05T21:04:00Z"),
+        ).currentSessionFirst(SessionState())
+
+        assertEquals(listOf(2, 1), ordered.map { it.id })
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/DevicesRepositoryTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/DevicesRepositoryTest.kt
@@ -1,0 +1,203 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import dk.perspektiva.ttsroad.desktop.ServerFixtures
+import dk.perspektiva.ttsroad.desktop.authedClient
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.Headers
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import retrofit2.HttpException
+
+/**
+ * `/api/mobile/me` and the three device-management endpoints, on the wire.
+ *
+ * The distinctions being pinned here are the ones a UI cannot recover from if the repository gets
+ * them wrong: 404 means "this server has no such endpoint" and must NOT sign anyone out, 401 still
+ * must, and 500 is neither.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DevicesRepositoryTest {
+    private lateinit var server: MockWebServer
+    private lateinit var sessionStore: InMemorySessionStore
+    private lateinit var repository: RetrofitTtsRoadRepository
+
+    private val jsonHeaders = Headers.headersOf("Content-Type", "application/json")
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        sessionStore = InMemorySessionStore(
+            SessionState(
+                serverUrl = server.url("/").toString(),
+                token = "ttsr_token",
+                username = "admin",
+                isAdmin = true,
+                deviceId = 42,
+            ),
+        )
+        repository = RetrofitTtsRoadRepository(
+            sessionStore = sessionStore,
+            client = authedClient(sessionStore),
+            ioDispatcher = UnconfinedTestDispatcher(),
+            deviceNameProvider = { "test-host" },
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.close()
+    }
+
+    private fun enqueue(code: Int, body: String) {
+        server.enqueue(MockResponse(code = code, headers = jsonHeaders, body = body))
+    }
+
+    // --- me ----------------------------------------------------------------------------------
+
+    @Test
+    fun `me returns the account the server currently sees`() = runTest {
+        enqueue(200, ServerFixtures.ME)
+
+        val user = repository.currentUser()
+
+        assertEquals("admin", user?.username)
+        assertEquals(true, user?.isAdmin)
+        val request = server.takeRequest()
+        assertEquals("GET", request.method)
+        assertEquals("/api/mobile/me", request.url.encodedPath)
+        assertEquals("Bearer ttsr_token", request.headers["Authorization"])
+    }
+
+    // --- listing -----------------------------------------------------------------------------
+
+    @Test
+    fun `devices decodes every row and sends the bearer header`() = runTest {
+        enqueue(200, ServerFixtures.DEVICES)
+
+        val devices = repository.devices()
+
+        assertEquals(listOf(42, 43, 44), devices?.map { it.id })
+        val request = server.takeRequest()
+        assertEquals("GET", request.method)
+        assertEquals("/api/mobile/devices", request.url.encodedPath)
+        assertEquals("Bearer ttsr_token", request.headers["Authorization"])
+    }
+
+    @Test
+    fun `an empty list means no sessions, not an unsupported server`() = runTest {
+        enqueue(200, """{"api_version": 1, "devices": []}""")
+
+        val devices = repository.devices()
+
+        assertEquals(emptyList(), devices)
+        assertFalse(devices == null, "an empty list must stay distinguishable from null")
+    }
+
+    @Test
+    fun `a 404 means the server has no device API and does not sign the user out`() = runTest {
+        enqueue(404, ServerFixtures.NOT_FOUND)
+
+        val devices = repository.devices()
+
+        assertNull(devices)
+        assertEquals(0, sessionStore.clearTokenCalls)
+        assertTrue(sessionStore.current().isLoggedIn)
+        assertNull(repository.sessionEnd.value)
+    }
+
+    @Test
+    fun `a 401 on the devices call still ends the session`() = runTest {
+        enqueue(401, ServerFixtures.UNAUTHORIZED_TOKEN_REVOKED)
+
+        assertThrows<HttpException> { repository.devices() }
+
+        assertEquals(1, sessionStore.clearTokenCalls)
+        assertEquals(SessionEndReason.Revoked, repository.sessionEnd.value?.reason)
+    }
+
+    @Test
+    fun `a 500 propagates rather than being mistaken for an old server`() = runTest {
+        enqueue(500, """{"detail": "boom"}""")
+
+        assertThrows<HttpException> { repository.devices() }
+
+        assertEquals(0, sessionStore.clearTokenCalls)
+        assertNull(repository.sessionEnd.value)
+    }
+
+    // --- revoking ----------------------------------------------------------------------------
+
+    @Test
+    fun `revokeDevice deletes the token id in the path`() = runTest {
+        enqueue(200, ServerFixtures.DEVICE_REVOKED)
+
+        assertTrue(repository.revokeDevice(43))
+
+        val request = server.takeRequest()
+        assertEquals("DELETE", request.method)
+        assertEquals("/api/mobile/devices/43", request.url.encodedPath)
+        assertEquals("Bearer ttsr_token", request.headers["Authorization"])
+    }
+
+    @Test
+    fun `a 404 on a revoke is reported as false, not thrown, and keeps the session`() = runTest {
+        // The server sends this both for "no such endpoint" and for "that session is already
+        // gone"; the repository deliberately does not guess which, it just reports the 404.
+        enqueue(404, ServerFixtures.DEVICE_NOT_FOUND)
+
+        assertFalse(repository.revokeDevice(999))
+
+        assertEquals(0, sessionStore.clearTokenCalls)
+        assertTrue(sessionStore.current().isLoggedIn)
+    }
+
+    @Test
+    fun `revokeOtherDevices posts to the revoke-others route`() = runTest {
+        enqueue(200, ServerFixtures.DEVICES_REVOKED_OTHERS)
+
+        assertTrue(repository.revokeOtherDevices())
+
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/api/mobile/devices/revoke-others", request.url.encodedPath)
+    }
+
+    @Test
+    fun `a 404 on revoke-others is an unsupported server, not a failure`() = runTest {
+        enqueue(404, ServerFixtures.NOT_FOUND)
+
+        assertFalse(repository.revokeOtherDevices())
+
+        assertEquals(0, sessionStore.clearTokenCalls)
+    }
+
+    @Test
+    fun `a 401 while revoking ends the session — the token, not the endpoint, is the problem`() = runTest {
+        enqueue(401, ServerFixtures.UNAUTHORIZED_TOKEN_EXPIRED)
+
+        assertThrows<HttpException> { repository.revokeDevice(43) }
+
+        assertEquals(SessionEndReason.Expired, repository.sessionEnd.value?.reason)
+        assertFalse(sessionStore.current().isLoggedIn)
+    }
+
+    @Test
+    fun `a device call while signed out never reaches the network`() = runTest {
+        sessionStore.clearToken()
+
+        assertThrows<IllegalArgumentException> { repository.devices() }
+
+        assertEquals(0, server.requestCount)
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/DiagnosticsTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/DiagnosticsTest.kt
@@ -1,0 +1,70 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.BuildInfo
+import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
+import dk.perspektiva.ttsroad.desktop.data.SessionState
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The About pane's copyable diagnostics block.
+ *
+ * The assertion that matters is the negative one: this text exists to be pasted into a public bug
+ * report, so a bearer token reaching it would be a credential leak with a one-click delivery
+ * mechanism.
+ */
+class DiagnosticsTest {
+
+    private val session = SessionState(
+        serverUrl = "https://ttsroad.example.com/",
+        token = "ttsr_Zm9vYmFyYmF6cXV1eA",
+        username = "admin",
+        isAdmin = true,
+        serverName = "Perspektiva TTSRoad",
+        serverVersion = "1.4.0",
+        deviceId = 42,
+    )
+
+    @Test
+    fun `diagnostics never carry the bearer token`() {
+        val text = buildDiagnostics(
+            session = session,
+            capabilities = ServerCapabilities(serverVersion = "1.4.0", deviceManagement = true),
+            credentialStoreName = "Windows Credential Manager",
+            persistsCredentials = true,
+        )
+
+        assertFalse(text.contains("ttsr_Zm9vYmFyYmF6cXV1eA"), text)
+        assertFalse(text.contains("Bearer", ignoreCase = true), text)
+    }
+
+    @Test
+    fun `diagnostics name the things a bug report needs`() {
+        val text = buildDiagnostics(
+            session = session,
+            capabilities = ServerCapabilities(serverVersion = "1.4.0", deviceManagement = true),
+            credentialStoreName = "Windows Credential Manager",
+            persistsCredentials = true,
+        )
+
+        assertTrue(text.contains(BuildInfo.VERSION), text)
+        assertTrue(text.contains("https://ttsroad.example.com/"), text)
+        assertTrue(text.contains("Windows Credential Manager"), text)
+        assertTrue(text.contains("Device management"), text)
+        assertTrue(text.contains("Session id: 42"), text)
+    }
+
+    @Test
+    fun `a session-only credential store says so`() {
+        val text = buildDiagnostics(
+            session = session,
+            capabilities = ServerCapabilities.Baseline,
+            credentialStoreName = "In memory",
+            persistsCredentials = false,
+        )
+
+        assertTrue(text.contains("In memory (session only)"), text)
+        assertTrue(text.contains("Not advertised by this server"), text)
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ScreensUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ScreensUiTest.kt
@@ -1,6 +1,8 @@
 package dk.perspektiva.ttsroad.desktop.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isSelectable
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst
@@ -163,6 +165,71 @@ class ScreensUiTest {
 
         compose.onNodeWithText("https://ttsroad.example.com/").assertIsDisplayed()
         compose.onNodeWithText("operator").assertIsDisplayed()
+    }
+
+    // --- App: settings ----------------------------------------------------------------------
+
+    @Test
+    fun `settings keeps its open pane and loaded devices across a trip to the library`() {
+        val repository = FakeRepository(
+            libraryResult = Result.success(ParsedFixtures.library),
+            devicesResult = Result.success(ParsedFixtures.devices),
+        )
+        val app = container(
+            SessionState(serverUrl = "https://x/", token = "t", username = "admin", deviceId = 42),
+            repository,
+        )
+        compose.setContent { TtsRoadTheme { App(app) } }
+        compose.waitForIdle()
+
+        compose.onNodeWithText("SETTINGS").performClick()
+        compose.waitForIdle()
+        compose.onNode(hasText("DEVICE SESSIONS") and isSelectable()).performClick()
+        compose.waitForIdle()
+        compose.onNodeWithText("Pixel 9").assertIsDisplayed()
+
+        // Away and back: the holder lives above navigation, so nothing is refetched or reset.
+        compose.onNodeWithText("LIBRARY").performClick()
+        compose.waitForIdle()
+        compose.onNodeWithText("SETTINGS").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("Pixel 9").assertIsDisplayed()
+        assertEquals(1, repository.devicesCalls, "returning to settings must not refetch")
+    }
+
+    @Test
+    fun `signing out from settings drops the device rows of the account that ended`() {
+        val repository = FakeRepository(
+            libraryResult = Result.success(ParsedFixtures.library),
+            devicesResult = Result.success(ParsedFixtures.devices),
+        )
+        val store = InMemorySessionStore(
+            SessionState(serverUrl = "https://x/", token = "t", username = "admin", deviceId = 42),
+        )
+        val app = AppContainer(
+            sessionStore = store,
+            repositoryFactory = { _, _, _ -> repository },
+            playbackFactory = { _, _, _, _ -> FakePlaybackController() },
+        )
+        compose.setContent { TtsRoadTheme { App(app) } }
+        compose.waitForIdle()
+        compose.onNodeWithText("SETTINGS").performClick()
+        compose.waitForIdle()
+        compose.onNode(hasText("DEVICE SESSIONS") and isSelectable()).performClick()
+        compose.waitForIdle()
+        compose.onNodeWithText("Pixel 9").assertIsDisplayed()
+
+        // What logout — or a 401 — does: the token goes.
+        store.clearToken()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("SIGN IN").assertIsDisplayed()
+        assertEquals(
+            0,
+            compose.onAllNodesWithText("Pixel 9").fetchSemanticsNodes().size,
+            "another account's sessions must not survive a sign-out",
+        )
     }
 
     // --- LibraryScreen --------------------------------------------------------------------

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreenUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreenUiTest.kt
@@ -1,0 +1,461 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isSelectable
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.requestFocus
+import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.ParsedFixtures
+import dk.perspektiva.ttsroad.desktop.ServerFixtures
+import dk.perspektiva.ttsroad.desktop.data.InMemorySessionStore
+import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
+import dk.perspektiva.ttsroad.desktop.data.SessionState
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * The settings screen as a user meets it.
+ *
+ * The state machine itself is covered in [SettingsStateHolderTest]; what is asserted here is what
+ * the panes render, that both destructive actions are behind a dialog, and the keyboard and
+ * screen-reader affordances the issue makes an acceptance criterion.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SettingsScreenUiTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val signedIn = SessionState(
+        serverUrl = "https://ttsroad.example.com/",
+        token = "ttsr_token",
+        username = "admin",
+        isAdmin = true,
+        serverName = "Perspektiva TTSRoad",
+        serverVersion = "1.4.0",
+        deviceId = 42,
+        expiresAt = "2026-11-04T09:12:33.123456Z",
+    )
+
+    private val capable = ServerCapabilities(
+        serverName = "Perspektiva TTSRoad",
+        serverVersion = "1.4.0",
+        readAlong = true,
+        deviceManagement = true,
+    )
+
+    /** Fixed "now" so the expiry wording asserted below cannot drift with the calendar. */
+    private val now = java.time.Instant.parse("2026-08-06T09:00:00Z").toEpochMilli()
+
+    private fun setContent(
+        repository: FakeRepository,
+        session: SessionState = signedIn,
+        capabilities: ServerCapabilities = capable,
+    ) {
+        val store = InMemorySessionStore(session)
+        repository.capabilitiesResult = capabilities
+        runBlocking { repository.refreshCurrentCapabilities(forceRefresh = true) }
+        compose.setContent { TtsRoadTheme { SettingsScreen(store, repository, nowMs = { now }) } }
+        compose.waitForIdle()
+    }
+
+    /** A pane entry, told apart from the identically worded pane heading by being selectable. */
+    private fun navEntry(label: String) = compose.onNode(hasText(label) and isSelectable())
+
+    private fun openDevices() {
+        navEntry("DEVICE SESSIONS").performClick()
+        compose.waitForIdle()
+    }
+
+    // --- Account pane ----------------------------------------------------------------------
+
+    @Test
+    fun `settings opens on the account pane and names the server`() {
+        setContent(FakeRepository())
+
+        compose.onNodeWithText("Perspektiva TTSRoad 1.4.0").assertIsDisplayed()
+        compose.onNodeWithText("https://ttsroad.example.com/").assertIsDisplayed()
+        compose.onNodeWithText("admin").assertIsDisplayed()
+        compose.onNodeWithText("Admin").assertIsDisplayed()
+        compose.onNodeWithText("Read-along, Device management").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the account pane shows this session's identity and expiry`() {
+        setContent(FakeRepository())
+
+        compose.onNodeWithText("42").assertIsDisplayed()
+        // The date itself is rendered in the machine's own zone, so only the coarse part — the bit
+        // that actually tells a user whether this session is about to lapse — is asserted verbatim.
+        compose.onNodeWithText("expires in 90 days", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun `signing out is behind a confirmation, and cancelling keeps the session`() {
+        val repository = FakeRepository()
+        setContent(repository)
+
+        compose.onNodeWithText("SIGN OUT").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("SIGN OUT THIS DEVICE").assertIsDisplayed()
+        assertEquals(0, repository.logoutCalls, "opening the dialog must not sign anyone out")
+
+        compose.onNodeWithText("CANCEL").performClick()
+        compose.waitForIdle()
+
+        assertEquals(0, repository.logoutCalls)
+    }
+
+    @Test
+    fun `confirming sign out calls the repository`() {
+        val repository = FakeRepository()
+        setContent(repository)
+
+        compose.onNodeWithText("SIGN OUT").performClick()
+        compose.waitForIdle()
+        compose.onNodeWithText("SIGN OUT THIS DEVICE").performClick()
+        compose.waitForIdle()
+
+        assertEquals(1, repository.logoutCalls)
+    }
+
+    // --- Navigation ------------------------------------------------------------------------
+
+    @Test
+    fun `the pane list is announced as tabs and marks the open one`() {
+        setContent(FakeRepository())
+
+        navEntry("ACCOUNT").assertIsSelected()
+
+        navEntry("PLAYBACK").performClick()
+        compose.waitForIdle()
+
+        navEntry("PLAYBACK").assertIsSelected()
+    }
+
+    @Test
+    fun `a pane entry activates from the keyboard`() {
+        setContent(FakeRepository())
+
+        // Enter on a focused entry is the same as clicking it — the acceptance criterion for
+        // keyboard users, and the reason the entries are `selectable` rather than plain rows.
+        navEntry("OFFLINE").requestFocus()
+        navEntry("OFFLINE").performKeyInput { pressKey(Key.Enter) }
+        compose.waitForIdle()
+
+        compose.onNodeWithText("Offline downloads are not part of this build.", substring = true)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `a narrow window stacks the panes and the list still navigates`() {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        val store = InMemorySessionStore(signedIn)
+        repository.capabilitiesResult = capable
+        runBlocking { repository.refreshCurrentCapabilities(forceRefresh = true) }
+        // Below the two-pane threshold the nav becomes a scrolling strip above the content; the
+        // point of the test is that navigation keeps working, not what the strip looks like.
+        compose.setContent {
+            TtsRoadTheme {
+                androidx.compose.foundation.layout.Box(androidx.compose.ui.Modifier.width(420.dp)) {
+                    SettingsScreen(store, repository, nowMs = { now })
+                }
+            }
+        }
+        compose.waitForIdle()
+
+        navEntry("DEVICE SESSIONS").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("Pixel 9").assertIsDisplayed()
+    }
+
+    // --- Panes for phases that do not exist yet ----------------------------------------------
+
+    @Test
+    fun `the playback pane says it is unavailable instead of showing dead controls`() {
+        setContent(FakeRepository())
+
+        navEntry("PLAYBACK").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("NOT AVAILABLE YET").assertIsDisplayed()
+        compose.onNodeWithText("Playback preferences are not part of this build.", substring = true)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `the offline pane promises nothing and says signing out deletes nothing`() {
+        setContent(FakeRepository())
+
+        navEntry("OFFLINE").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("signing out cannot delete anything you asked to keep", substring = true)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `the about pane shows the build, licences and diagnostics`() {
+        setContent(FakeRepository())
+
+        navEntry("UPDATES & ABOUT").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("Installed build").assertIsDisplayed()
+        compose.onNodeWithText("Not available — install a newer build to update").assertIsDisplayed()
+        compose.onNodeWithText("Kotlin, Compose Multiplatform, OkHttp, Retrofit, Moshi, Coil").assertIsDisplayed()
+        compose.onNodeWithText("COPY DIAGNOSTICS").assertHasClickAction()
+    }
+
+    // --- Devices: supported ------------------------------------------------------------------
+
+    @Test
+    fun `a capable server lists sessions, marks the current one, and offers no revoke on its row`() {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        setContent(repository)
+
+        openDevices()
+
+        compose.onNodeWithText("workstation · Windows 11").assertIsDisplayed()
+        compose.onNodeWithText("Pixel 9").assertIsDisplayed()
+        compose.onNodeWithText("Unnamed device").assertIsDisplayed()
+        compose.onNodeWithText("THIS DEVICE").assertIsDisplayed()
+        // One revoke control per *other* session, and none at all for the current one.
+        assertEquals(2, compose.onAllNodesWithText("SIGN OUT").fetchSemanticsNodes().size)
+        compose.onNodeWithContentDescription("Sign out Pixel 9").assertIsDisplayed()
+        assertEquals(
+            0,
+            compose.onAllNodesWithContentDescription("Sign out workstation · Windows 11")
+                .fetchSemanticsNodes().size,
+            "the current session must have no revoke control at all",
+        )
+    }
+
+    @Test
+    fun `a device row reads as one sentence for a screen reader`() {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        setContent(repository)
+
+        openDevices()
+
+        compose.onNodeWithContentDescription("Pixel 9, active, last used", substring = true)
+            .assertIsDisplayed()
+        compose.onNodeWithContentDescription("this device", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun `an account whose only session is this one says so`() {
+        val repository = FakeRepository(
+            devicesResult = Result.success(ParsedFixtures.devicesFrom(ServerFixtures.DEVICES_ONLY_CURRENT)),
+        )
+        setContent(repository)
+
+        openDevices()
+
+        compose.onNodeWithText("Nothing else is signed in.").assertIsDisplayed()
+        assertEquals(0, compose.onAllNodesWithText("SIGN OUT").fetchSemanticsNodes().size)
+    }
+
+    @Test
+    fun `a row with missing fields lists with dashes rather than breaking the page`() {
+        val repository = FakeRepository(
+            devicesResult = Result.success(ParsedFixtures.devicesFrom(ServerFixtures.DEVICES_MALFORMED_ROW)),
+        )
+        setContent(repository)
+
+        openDevices()
+
+        compose.onNodeWithText("Unnamed device").assertIsDisplayed()
+        compose.onNodeWithContentDescription("last used NEVER", substring = true, ignoreCase = true)
+            .assertIsDisplayed()
+    }
+
+    // --- Devices: unsupported and error --------------------------------------------------------
+
+    @Test
+    fun `an older server shows a concise unsupported state and keeps every other setting`() {
+        val repository = FakeRepository(devicesResult = Result.success(null))
+        setContent(repository, capabilities = capable.copy(deviceManagement = false))
+
+        openDevices()
+
+        compose.onNodeWithText("This server has no device-session API.", substring = true).assertIsDisplayed()
+        assertEquals(0, repository.devicesCalls, "a server that said no must not be asked")
+
+        navEntry("ACCOUNT").performClick()
+        compose.waitForIdle()
+        compose.onNodeWithText("https://ttsroad.example.com/").assertIsDisplayed()
+    }
+
+    @Test
+    fun `an endpoint that answers 404 lands on the same unsupported state`() {
+        // Capability says yes, the endpoint disagrees — a proxy, or a backend mid-rollback.
+        val repository = FakeRepository(devicesResult = Result.success(null))
+        setContent(repository)
+
+        openDevices()
+
+        compose.onNodeWithText("This server has no device-session API.", substring = true).assertIsDisplayed()
+        assertEquals(1, repository.devicesCalls)
+    }
+
+    @Test
+    fun `a failed load offers a retry instead of an endless spinner`() {
+        val repository = FakeRepository(devicesResult = Result.failure(IllegalStateException("no route to host")))
+        setContent(repository)
+
+        openDevices()
+
+        compose.onNodeWithText("no route to host").assertIsDisplayed()
+        compose.onNodeWithText("RETRY").assertHasClickAction()
+
+        repository.devicesResult = Result.success(ParsedFixtures.devices)
+        compose.onNodeWithText("RETRY").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("Pixel 9").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a failed refresh reports itself above the list instead of replacing it`() {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        setContent(repository)
+        openDevices()
+
+        repository.devicesResult = Result.failure(IllegalStateException("server exploded"))
+        // REFRESH sits below the fold of a three-session list in the test window.
+        compose.onNodeWithText("REFRESH").performScrollTo().performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("server exploded").assertIsDisplayed()
+        compose.onNodeWithText("Pixel 9").assertIsDisplayed()
+    }
+
+    // --- Devices: both confirmation paths ------------------------------------------------------
+
+    @Test
+    fun `revoking one session asks first, and cancelling revokes nothing`() {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        setContent(repository)
+        openDevices()
+
+        compose.onNodeWithContentDescription("Sign out Pixel 9").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("SIGN OUT DEVICE").assertIsDisplayed()
+        compose.onNodeWithText("Pixel 9 will need to sign in again. Anything playing on it stops.")
+            .assertIsDisplayed()
+
+        compose.onNodeWithText("CANCEL").performClick()
+        compose.waitForIdle()
+
+        assertTrue(repository.revokedDevices.isEmpty(), "cancel must revoke nothing")
+        assertEquals(0, compose.onAllNodesWithText("SIGN IT OUT").fetchSemanticsNodes().size)
+    }
+
+    @Test
+    fun `revoking one session goes through on confirm and re-reads the list`() {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        setContent(repository)
+        openDevices()
+
+        compose.onNodeWithContentDescription("Sign out Pixel 9").performClick()
+        compose.waitForIdle()
+        compose.onNodeWithText("SIGN IT OUT").performClick()
+        compose.waitForIdle()
+
+        assertEquals(listOf(43), repository.revokedDevices)
+        assertEquals(2, repository.devicesCalls, "the server decides what survived, so re-read")
+        compose.onNodeWithText("SIGNED OUT PIXEL 9").assertIsDisplayed()
+    }
+
+    @Test
+    fun `revoking every other session asks first, and cancelling revokes nothing`() {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        setContent(repository)
+        openDevices()
+
+        compose.onNodeWithText("SIGN OUT ALL OTHER DEVICES").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("SIGN OUT OTHER DEVICES").assertIsDisplayed()
+        compose.onNodeWithText("CANCEL").performClick()
+        compose.waitForIdle()
+
+        assertEquals(0, repository.revokeOtherDevicesCalls)
+    }
+
+    @Test
+    fun `revoking every other session goes through on confirm`() {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        setContent(repository)
+        openDevices()
+
+        compose.onNodeWithText("SIGN OUT ALL OTHER DEVICES").performClick()
+        compose.waitForIdle()
+        compose.onNodeWithText("SIGN THEM OUT").performClick()
+        compose.waitForIdle()
+
+        assertEquals(1, repository.revokeOtherDevicesCalls)
+        assertTrue(repository.revokedDevices.isEmpty(), "one server call, not a loop of deletes")
+        compose.onNodeWithText("SIGNED OUT EVERY OTHER DEVICE").assertIsDisplayed()
+    }
+
+    // --- Dialog keyboard behaviour ------------------------------------------------------------
+
+    @Test
+    fun `a destructive dialog opens with the safe answer under the keyboard`() {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        setContent(repository)
+        openDevices()
+
+        compose.onNodeWithContentDescription("Sign out Pixel 9").performClick()
+        compose.waitForIdle()
+
+        // Focus on CANCEL, not on the destructive button: the reflexive Enter must be the safe one.
+        compose.onNodeWithText("CANCEL").assertIsFocused()
+        compose.onNodeWithText("CANCEL").performKeyInput { pressKey(Key.Enter) }
+        compose.waitForIdle()
+
+        assertTrue(repository.revokedDevices.isEmpty())
+        assertEquals(0, compose.onAllNodesWithText("SIGN IT OUT").fetchSemanticsNodes().size)
+    }
+
+    @Test
+    fun `escape dismisses a confirmation without doing anything`() {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        setContent(repository)
+        openDevices()
+
+        compose.onNodeWithContentDescription("Sign out Pixel 9").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("CANCEL").performKeyInput { pressKey(Key.Escape) }
+        compose.waitForIdle()
+
+        assertEquals(0, compose.onAllNodesWithText("SIGN IT OUT").fetchSemanticsNodes().size)
+        assertTrue(repository.revokedDevices.isEmpty())
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsStateHolderTest.kt
@@ -1,0 +1,543 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.ParsedFixtures
+import dk.perspektiva.ttsroad.desktop.ServerFixtures
+import dk.perspektiva.ttsroad.desktop.data.DeviceSession
+import dk.perspektiva.ttsroad.desktop.data.InMemorySessionStore
+import dk.perspektiva.ttsroad.desktop.data.MobileUser
+import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
+import dk.perspektiva.ttsroad.desktop.data.SessionState
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * The settings/device-session state machine.
+ *
+ * Every state the issue asks the UI to have — supported, unsupported, loading, error, empty — and
+ * both answers to both confirmation dialogs are decided here rather than in the composable, which
+ * is why they can be asserted without a display.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsStateHolderTest {
+
+    private val signedIn = SessionState(
+        serverUrl = "https://ttsroad.example.com/",
+        token = "ttsr_token",
+        username = "admin",
+        deviceId = 42,
+    )
+
+    private val capable = ServerCapabilities(
+        serverName = "Perspektiva TTSRoad",
+        serverVersion = "1.4.0",
+        deviceManagement = true,
+    )
+
+    private fun TestScope.holder(
+        repository: FakeRepository,
+        store: InMemorySessionStore = InMemorySessionStore(signedIn),
+    ): SettingsStateHolder {
+        // Publishing capabilities is what a real sign-in does; the gate reads them from here.
+        val holder = SettingsStateHolder(repository, store, UnconfinedTestDispatcher(testScheduler))
+        return holder
+    }
+
+    private suspend fun FakeRepository.publish(capabilities: ServerCapabilities) {
+        capabilitiesResult = capabilities
+        refreshCurrentCapabilities(forceRefresh = true)
+    }
+
+    // --- Sections ----------------------------------------------------------------------------
+
+    @Test
+    fun `the account pane is where settings opens`() = runTest {
+        val holder = holder(FakeRepository())
+
+        assertEquals(SettingsSection.Account, holder.state.value.section)
+        holder.clear()
+    }
+
+    @Test
+    fun `selecting a pane keeps whatever is already loaded`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        repository.publish(capable)
+        val holder = holder(repository)
+
+        holder.openSection(SettingsSection.Devices)
+        holder.ensureDevicesLoaded()
+        runCurrent()
+        holder.openSection(SettingsSection.About)
+        holder.openSection(SettingsSection.Devices)
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        assertEquals(3, holder.state.value.devices.loaded?.size)
+        assertEquals(1, repository.devicesCalls, "re-entering a pane must not refetch")
+        holder.clear()
+    }
+
+    // --- Loading / supported -----------------------------------------------------------------
+
+    @Test
+    fun `a capable server lists sessions and marks the current one`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        repository.publish(capable)
+        val holder = holder(repository)
+
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        val devices = holder.state.value.devices
+        assertFalse(devices.isLoading)
+        assertFalse(devices.unsupported)
+        assertNull(devices.error)
+        assertEquals(3, devices.loaded?.size)
+        assertEquals(42, holder.currentDevice()?.id)
+        assertEquals(listOf(43, 44), holder.otherDevices().map { it.id })
+        holder.clear()
+    }
+
+    @Test
+    fun `the current session leads the list`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        repository.publish(capable)
+        val holder = holder(repository)
+
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        assertEquals(42, holder.visibleDevices().first().id)
+        holder.clear()
+    }
+
+    @Test
+    fun `an account with only this session reports no others rather than an error`() = runTest {
+        val repository = FakeRepository(
+            devicesResult = Result.success(ParsedFixtures.devicesFrom(ServerFixtures.DEVICES_ONLY_CURRENT)),
+        )
+        repository.publish(capable)
+        val holder = holder(repository)
+
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        assertEquals(emptyList(), holder.otherDevices())
+        assertNotNull(holder.currentDevice())
+        assertFalse(holder.state.value.devices.unsupported)
+        holder.clear()
+    }
+
+    @Test
+    fun `an empty list is an empty state, not an unsupported one`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.success(emptyList()))
+        repository.publish(capable)
+        val holder = holder(repository)
+
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        assertFalse(holder.state.value.devices.unsupported)
+        assertEquals(emptyList(), holder.state.value.devices.loaded)
+        assertNull(holder.currentDevice())
+        holder.clear()
+    }
+
+    // --- Unsupported -------------------------------------------------------------------------
+
+    @Test
+    fun `a server that says it has no device management is never asked`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        repository.publish(capable.copy(deviceManagement = false))
+        val holder = holder(repository)
+
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        assertTrue(holder.state.value.devices.unsupported)
+        assertEquals(0, repository.devicesCalls, "the capability gate must save the round trip")
+        holder.clear()
+    }
+
+    @Test
+    fun `an undiscovered server is still asked — silence is not a no`() = runTest {
+        // Baseline means discovery never answered (404, offline, a proxy). Refusing to try on that
+        // basis would hide a working feature behind a failed unrelated request.
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        val holder = holder(repository)
+
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        assertEquals(1, repository.devicesCalls)
+        assertFalse(holder.state.value.devices.unsupported)
+        holder.clear()
+    }
+
+    @Test
+    fun `a 404 from the endpoint is an unsupported state, not an error screen`() = runTest {
+        // The repository reports a missing endpoint as null.
+        val repository = FakeRepository(devicesResult = Result.success(null))
+        repository.publish(capable)
+        val holder = holder(repository)
+
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        val devices = holder.state.value.devices
+        assertTrue(devices.unsupported)
+        assertNull(devices.error)
+        assertNull(devices.loaded)
+        holder.clear()
+    }
+
+    @Test
+    fun `an unsupported server is not re-asked on every visit`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.success(null))
+        val holder = holder(repository)
+
+        holder.ensureDevicesLoaded()
+        runCurrent()
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        assertEquals(1, repository.devicesCalls)
+        holder.clear()
+    }
+
+    // --- Errors ------------------------------------------------------------------------------
+
+    @Test
+    fun `a first-load failure becomes an error with a retry, not an endless spinner`() = runTest {
+        val repository = FakeRepository(
+            devicesResult = Result.failure(java.net.UnknownHostException("ttsroad.example.com")),
+        )
+        val holder = holder(repository)
+
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        val devices = holder.state.value.devices
+        assertFalse(devices.isLoading)
+        assertFalse(devices.isInitialLoad)
+        assertNull(devices.loaded)
+        assertEquals("Cannot reach that server — its address did not resolve", devices.error)
+        holder.clear()
+    }
+
+    @Test
+    fun `a failed refresh keeps the list that is already on screen`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        val holder = holder(repository)
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        repository.devicesResult = Result.failure(IllegalStateException("server exploded"))
+        holder.refreshDevices()
+        runCurrent()
+
+        val devices = holder.state.value.devices
+        assertEquals("server exploded", devices.error)
+        assertEquals(3, devices.loaded?.size, "a failed refresh must not blank the list")
+        holder.clear()
+    }
+
+    @Test
+    fun `a failure with no message still says something a user can read`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.failure(RuntimeException()))
+        val holder = holder(repository)
+
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        assertEquals("Could not load device sessions", holder.state.value.devices.error)
+        holder.clear()
+    }
+
+    @Test
+    fun `retry after a failure loads the list`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.failure(IllegalStateException("nope")))
+        val holder = holder(repository)
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        repository.devicesResult = Result.success(ParsedFixtures.devices)
+        holder.refreshDevices()
+        runCurrent()
+
+        assertNull(holder.state.value.devices.error)
+        assertEquals(3, holder.state.value.devices.loaded?.size)
+        holder.clear()
+    }
+
+    // --- Confirmation: revoke one ------------------------------------------------------------
+
+    @Test
+    fun `revoking one device asks first and does nothing until confirmed`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        val holder = holder(repository)
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        holder.askRevoke(holder.otherDevices().first())
+        runCurrent()
+
+        val pending = assertIs<SettingsConfirmation.RevokeDevice>(holder.state.value.confirmation)
+        assertEquals(43, pending.device.id)
+        assertEquals(emptyList(), repository.revokedDevices, "asking must not revoke")
+        holder.clear()
+    }
+
+    @Test
+    fun `cancelling the revoke dialog revokes nothing`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        val holder = holder(repository)
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        holder.askRevoke(holder.otherDevices().first())
+        holder.dismissConfirmation()
+        runCurrent()
+
+        assertNull(holder.state.value.confirmation)
+        assertEquals(emptyList(), repository.revokedDevices)
+        assertEquals(1, repository.devicesCalls, "cancelling must not even refetch")
+        holder.clear()
+    }
+
+    @Test
+    fun `confirming the revoke calls the server and re-reads the list`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        val holder = holder(repository)
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        holder.askRevoke(holder.otherDevices().first())
+        holder.confirm()
+        runCurrent()
+
+        assertEquals(listOf(43), repository.revokedDevices)
+        assertEquals(2, repository.devicesCalls, "the server decides what survived, so re-read")
+        assertEquals("Signed out Pixel 9", holder.state.value.devices.notice)
+        assertFalse(holder.state.value.devices.isBusy)
+        holder.clear()
+    }
+
+    @Test
+    fun `the current session cannot be revoked from its row, even if something asks`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        val holder = holder(repository)
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        holder.askRevoke(requireNotNull(holder.currentDevice()))
+        runCurrent()
+
+        assertNull(holder.state.value.confirmation, "there is no dialog for signing this device out")
+        assertEquals(emptyList(), repository.revokedDevices)
+        holder.clear()
+    }
+
+    @Test
+    fun `a revoke failure is reported inline and the list survives`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        val holder = holder(repository)
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        repository.revokeResult = Result.failure(IllegalStateException("gateway timeout"))
+        holder.askRevoke(holder.otherDevices().first())
+        holder.confirm()
+        runCurrent()
+
+        val devices = holder.state.value.devices
+        assertEquals("gateway timeout", devices.error, "the failure must survive the reload after it")
+        assertEquals(3, devices.loaded?.size)
+        assertNull(devices.notice)
+        assertFalse(devices.isBusy)
+        holder.clear()
+    }
+
+    @Test
+    fun `a 404 while revoking a listed session means it was already gone, not an old server`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        val holder = holder(repository)
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        repository.revokeResult = Result.success(false)
+        holder.askRevoke(holder.otherDevices().first())
+        holder.confirm()
+        runCurrent()
+
+        val devices = holder.state.value.devices
+        assertFalse(devices.unsupported, "a server that just listed sessions clearly has the API")
+        assertEquals("That session was already signed out", devices.notice)
+        holder.clear()
+    }
+
+    // --- Confirmation: revoke all others -----------------------------------------------------
+
+    @Test
+    fun `revoking all other devices asks first`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        val holder = holder(repository)
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        holder.askRevokeOtherDevices()
+        runCurrent()
+
+        assertEquals(SettingsConfirmation.RevokeOtherDevices, holder.state.value.confirmation)
+        assertEquals(0, repository.revokeOtherDevicesCalls)
+        holder.clear()
+    }
+
+    @Test
+    fun `cancelling revoke-all leaves every session alone`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        val holder = holder(repository)
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        holder.askRevokeOtherDevices()
+        holder.dismissConfirmation()
+        runCurrent()
+
+        assertEquals(0, repository.revokeOtherDevicesCalls)
+        assertNull(holder.state.value.confirmation)
+        holder.clear()
+    }
+
+    @Test
+    fun `confirming revoke-all makes one server call and reloads`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        val holder = holder(repository)
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        holder.askRevokeOtherDevices()
+        holder.confirm()
+        runCurrent()
+
+        assertEquals(1, repository.revokeOtherDevicesCalls)
+        assertEquals(emptyList(), repository.revokedDevices, "one call, not a loop of deletes")
+        assertEquals(2, repository.devicesCalls)
+        assertEquals("Signed out every other device", holder.state.value.devices.notice)
+        holder.clear()
+    }
+
+    @Test
+    fun `confirm does nothing when nothing is pending`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        val holder = holder(repository)
+
+        holder.confirm()
+        runCurrent()
+
+        assertEquals(0, repository.revokeOtherDevicesCalls)
+        assertEquals(emptyList(), repository.revokedDevices)
+        holder.clear()
+    }
+
+    // --- Sign out ----------------------------------------------------------------------------
+
+    @Test
+    fun `signing out asks first and only then calls the server`() = runTest {
+        val repository = FakeRepository()
+        val holder = holder(repository)
+
+        holder.askSignOut()
+        runCurrent()
+        assertEquals(SettingsConfirmation.SignOut, holder.state.value.confirmation)
+        assertEquals(0, repository.logoutCalls)
+
+        holder.confirm()
+        runCurrent()
+        assertEquals(1, repository.logoutCalls)
+        assertFalse(holder.state.value.signingOut)
+        holder.clear()
+    }
+
+    @Test
+    fun `cancelling sign-out keeps the session`() = runTest {
+        val repository = FakeRepository()
+        val holder = holder(repository)
+
+        holder.askSignOut()
+        holder.dismissConfirmation()
+        runCurrent()
+
+        assertEquals(0, repository.logoutCalls)
+        holder.clear()
+    }
+
+    @Test
+    fun `losing the session drops the device rows of the account that ended`() = runTest {
+        val repository = FakeRepository(devicesResult = Result.success(ParsedFixtures.devices))
+        val holder = holder(repository)
+        holder.openSection(SettingsSection.Devices)
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        holder.sessionEnded()
+        runCurrent()
+
+        assertEquals(SettingsUiState(), holder.state.value)
+        holder.clear()
+    }
+
+    // --- Account -----------------------------------------------------------------------------
+
+    @Test
+    fun `the account is confirmed against the server once`() = runTest {
+        val repository = FakeRepository(
+            currentUserResult = Result.success(MobileUser(id = 1, username = "operator", isAdmin = true)),
+        )
+        val holder = holder(repository)
+
+        holder.verifyAccount()
+        runCurrent()
+        holder.verifyAccount()
+        runCurrent()
+
+        assertEquals("operator", holder.state.value.verifiedUser?.username)
+        holder.clear()
+    }
+
+    @Test
+    fun `a server without a me endpoint leaves the stored account standing`() = runTest {
+        val repository = FakeRepository(currentUserResult = Result.failure(IllegalStateException("boom")))
+        val holder = holder(repository)
+
+        holder.verifyAccount()
+        runCurrent()
+
+        assertNull(holder.state.value.verifiedUser, "a failed check must not invent a user")
+        holder.clear()
+    }
+
+    @Test
+    fun `a device row the server did not mark is still recognised by the stored id`() = runTest {
+        val repository = FakeRepository(
+            devicesResult = Result.success(listOf(DeviceSession(id = 42, deviceName = "workstation"))),
+        )
+        val holder = holder(repository, InMemorySessionStore(signedIn))
+        holder.ensureDevicesLoaded()
+        runCurrent()
+
+        assertEquals(42, holder.currentDevice()?.id)
+        assertEquals(emptyList(), holder.otherDevices())
+        holder.clear()
+    }
+}


### PR DESCRIPTION
Closes #8. Stacked on #14 (Phase 1) — targets `phase-1-secure-sessions`.

## What landed

- API models and calls for `GET /api/mobile/me`, `GET /api/mobile/devices`, `DELETE /api/mobile/devices/{token_id}`, `POST /api/mobile/devices/revoke-others`.
- **Two independent unsupported-server gates**: `device_management` capability false → the devices call is never made (`devicesCalls == 0`); endpoint 404 → `devices()` returns null. Both render the same concise unsupported card rather than a fatal screen.
- Device sessions list: name, created/last-used in **local timezone**, last IP, expiry/status, current-device marker sorted first.
- **The current session cannot be revoked from its row** — enforced twice, via `onRevoke = null` on the current card and an early return in `SettingsStateHolder.askRevoke`. Sign out stays the deliberate path.
- Confirmation dialogs for revoke-one and revoke-others, both tested through confirm *and* cancel. Failures show inline without discarding loaded data.
- Settings reorganized into a two-pane desktop layout: Account/session, Playback, Offline, Updates/About. State survives navigation.
- Timestamp parsing tolerant of `Z`, numeric offsets, and naive UTC, matching mobile `DeviceSessions.kt`.

## Verification

54 tests across the two new suites, covering supported / unsupported / loading / error / empty states and both confirmation paths. `DeviceSessionsTest` pins the timezone behavior (same instant as 12:00 UTC vs 13:00 Europe/Copenhagen) and confirms a row with `"last_used_at": "yesterday"` still lists rather than breaking the page.

## Known gaps

- **Playback and Offline panes are text-only placeholders.** The issue asked them to link to preferences and cache actions "introduced in the playback-preferences phase" and "the offline phase" — neither phase exists yet, so there is nothing to link to. No dead controls ship, which is the right call, but these panes are not functional.
- **Licenses** is a hand-written component→licence mapping, not generated or bundled full texts. Thin against the issue's "licenses" bullet.
- **Release channel** is text only ("Update check: not available"). There is no updater — that is Phase 10.
- Accessibility is verified at the **Compose semantics layer only** (`Role.Tab`, `assertIsSelected`, `contentDescription`, `paneTitle`, `assertIsFocused`, Enter/Escape key injection). No real screen reader was run.
- **No live TTSRoad server was contacted.** All four endpoints are asserted against MockWebServer fixtures hand-derived from `app/routers/mobile.py` and `app/services/mobile_auth.py`. The fixtures were checked against the server source, but that is code review, not an integration test.
- `revoke-others` returns `revoked_count`; the client re-reads the list instead of trusting the echo, so the notice is generic. Small loss of information, documented in the ADR.
- The device list is not cached — every Settings visit costs one GET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
