### PR TITLE
Fix the GStreamer fallback probe, which could throw instead of declining

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,29 @@ jobs:
       - name: Set up Gradle (with dependency + build caching)
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Install Xvfb
-        run: sudo apt-get update && sudo apt-get install -y xvfb
+      # Xvfb: Skiko needs a display even for off-screen rendering.
+      #
+      # GStreamer: the production playback backend (docs/adr/0002-playback-engine.md). The runner
+      # image already carries GStreamer's *core* library but none of its plugins, which is the
+      # worst of both worlds — `Gst.init` succeeds, then every element lookup fails. Installing the
+      # plugins the pipeline actually names means GstPlaybackEngineIntegrationTest runs here
+      # instead of skipping, so the real engine has CI coverage rather than none. These are also
+      # exactly the packages the .deb will declare in phase 9 (#3).
+      - name: Install Xvfb and GStreamer
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            xvfb \
+            gstreamer1.0-plugins-base \
+            gstreamer1.0-plugins-good
+
+      # Fails the build if the pipeline's elements are missing, rather than letting the integration
+      # test quietly skip and report green.
+      - name: Verify the GStreamer elements the engine needs
+        run: |
+          for element in appsrc decodebin audioconvert scaletempo audioresample fakesink; do
+            gst-inspect-1.0 "$element" > /dev/null || { echo "missing GStreamer element: $element"; exit 1; }
+          done
 
       # Compiles main + test, runs the JUnit 5 unit tests AND the Compose desktop UI tests.
       # Skiko needs a display even for off-screen rendering, hence Xvfb.

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/GstPlaybackEngine.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/GstPlaybackEngine.kt
@@ -318,16 +318,31 @@ class GstPlaybackEngine private constructor(
          * exception, so this catches [Throwable]. Letting that propagate would turn "no GStreamer
          * installed" into "the app does not start".
          */
-        fun createOrNull(sinkElement: String = "autoaudiosink"): GstPlaybackEngine? {
-            if (!ensureInitialised()) return null
-            val missing = (REQUIRED_ELEMENTS + sinkElement).filter { ElementFactory.find(it) == null }
-            if (missing.isNotEmpty()) return null
-            return runCatching { GstPlaybackEngine(sinkElement) }.getOrNull()
-        }
+        fun createOrNull(sinkElement: String = "autoaudiosink"): GstPlaybackEngine? = runCatching {
+            if (!ensureInitialised()) return@runCatching null
+            if (!hasEveryElement(REQUIRED_ELEMENTS + sinkElement)) return@runCatching null
+            GstPlaybackEngine(sinkElement)
+        }.getOrNull()
 
         /** Whether this machine can run the GStreamer backend at all. */
-        fun isAvailable(): Boolean =
-            ensureInitialised() && REQUIRED_ELEMENTS.all { ElementFactory.find(it) != null }
+        fun isAvailable(): Boolean = runCatching {
+            ensureInitialised() && hasEveryElement(REQUIRED_ELEMENTS)
+        }.getOrDefault(false)
+
+        /**
+         * Whether every named element can be created here.
+         *
+         * `ElementFactory.find` **throws** `IllegalArgumentException` for an element that does not
+         * exist rather than returning null, so a bare null check is not a check at all. That is not
+         * hypothetical: a GitHub Ubuntu runner carries GStreamer's core library — enough for
+         * `Gst.init` to succeed — but none of its plugins, and the resulting
+         * "No such Gstreamer factory: appsrc" turned every UI test red. The whole point of this
+         * class being fallible is that a machine without GStreamer falls back to
+         * [JavaSoundPlaybackEngine]; a probe that throws defeats it.
+         */
+        private fun hasEveryElement(names: List<String>): Boolean = names.all { name ->
+            runCatching { ElementFactory.find(name) != null }.getOrDefault(false)
+        }
 
         @Synchronized
         private fun ensureInitialised(): Boolean {

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/GstAvailabilityTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/GstAvailabilityTest.kt
@@ -1,0 +1,53 @@
+package dk.perspektiva.ttsroad.desktop.player
+
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * The fallback path must survive a machine that has *part* of GStreamer.
+ *
+ * This is the case CI found and no local run could: a GitHub Ubuntu runner carries GStreamer's core
+ * library, so `Gst.init` succeeds, but none of its plugins — and `ElementFactory.find` throws
+ * `IllegalArgumentException` for a missing factory instead of returning null. The probe that was
+ * meant to select the fallback threw instead, and "No such Gstreamer factory: appsrc" failed every
+ * Compose UI test in the suite, because building the app builds a playback engine.
+ *
+ * Unlike [GstPlaybackEngineIntegrationTest] these are **not** gated on GStreamer being present:
+ * "the engine declines cleanly" has to hold on every machine, with GStreamer, without it, and with
+ * half of it. That is the entire contract of a fallible constructor.
+ */
+class GstAvailabilityTest {
+
+    @Test
+    fun `an element that cannot exist is declined rather than thrown`() {
+        // Stands in for the partially-installed runner: a name no plugin will ever provide, so the
+        // lookup fails the same way `appsrc` does where plugins are missing.
+        assertNull(
+            GstPlaybackEngine.createOrNull(sinkElement = "ttsroad-no-such-element"),
+            "a missing element must select the fallback engine, not raise",
+        )
+    }
+
+    @Test
+    fun `availability answers a plain boolean on any machine`() {
+        // Whatever this host has, asking must not throw — the answer decides which engine the app
+        // builds, and an exception here means the app does not start at all.
+        val available = GstPlaybackEngine.isAvailable()
+        // Both answers are legitimate; only a throw is not.
+        assertFalse(available && !available, "unreachable: asserts the call returned at all")
+    }
+
+    @Test
+    fun `the app always gets a working engine, whatever this machine has`() {
+        // The production selection in AppContainer, verbatim. On a developer machine this is the
+        // GStreamer engine; in CI it is the Java Sound one. Neither may be null.
+        val engine: PlaybackEngine = GstPlaybackEngine.createOrNull() ?: JavaSoundPlaybackEngine()
+        try {
+            // A capability read is what the UI does first, and it must be answerable either way.
+            engine.capabilities.coerceSpeed(1.5f)
+        } finally {
+            engine.close()
+        }
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackControllerTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackControllerTest.kt
@@ -57,6 +57,23 @@ class QueuePlaybackControllerTest {
         fail("timed out waiting for: $description; last state was ${state.value}")
     }
 
+    /**
+     * Waits on something that is *not* published through [PlaybackController.state].
+     *
+     * `state.first { }` cannot do this job: a StateFlow conflates equal values, so once the player
+     * has settled it stops emitting and a predicate over the repository is never re-evaluated. The
+     * saves below are also launched asynchronously, so asserting on them straight after the call
+     * that triggers them is a race either way.
+     */
+    private suspend fun awaitCondition(description: String, timeoutMs: Long = 15_000, predicate: () -> Boolean) {
+        val deadline = System.nanoTime() + timeoutMs * 1_000_000
+        while (System.nanoTime() < deadline) {
+            if (predicate()) return
+            kotlinx.coroutines.delay(10)
+        }
+        fail("timed out waiting for: $description")
+    }
+
     private fun finished(state: PlayerUiState) = state.hasMedia && !state.isPlaying && state.error == null
 
     @Test
@@ -280,10 +297,9 @@ class QueuePlaybackControllerTest {
         controller.togglePlayPause()
         controller.await("the pause to land") { !it.isPlaying }
 
-        assertTrue(
-            repository.savedProgress.any { it.first == 101 && it.second == 42.0 && !it.third },
-            "expected a save on pause; got ${repository.savedProgress}",
-        )
+        awaitCondition("a save on pause at the reported position") {
+            repository.savedProgress.any { it.first == 101 && it.second == 42.0 && !it.third }
+        }
         controller.release()
     }
 
@@ -303,10 +319,9 @@ class QueuePlaybackControllerTest {
         controller.togglePlayPause()
         controller.await("the pause to land") { !it.isPlaying }
 
-        assertTrue(
-            repository.savedProgress.any { it.first == 101 && it.third },
-            "expected an is_played save; got ${repository.savedProgress}",
-        )
+        awaitCondition("an is_played save without a byte-perfect end of stream") {
+            repository.savedProgress.any { it.first == 101 && it.third }
+        }
         controller.release()
     }
 
@@ -323,7 +338,7 @@ class QueuePlaybackControllerTest {
         controller.seekTo(120_000)
 
         assertEquals(listOf(120_000L), engine.seeks.toList())
-        controller.await("the seek to be saved") {
+        awaitCondition("the seek to be saved") {
             repository.savedProgress.any { saved -> saved.first == 101 && saved.second == 120.0 }
         }
         controller.release()


### PR DESCRIPTION
Fixes the red `master` from #22.

## What broke

CI failed every Compose UI test with:

```
java.lang.IllegalArgumentException: No such Gstreamer factory: appsrc
```

GitHub's Ubuntu runner carries GStreamer's **core library but none of its plugins** — the one
configuration neither a developer machine nor a bare container reproduces. `Gst.init` succeeds, so
the engine believes GStreamer is usable, and then every element lookup fails.

## Why the fallback did not save us

The probe was the bug. `ElementFactory.find` **throws** `IllegalArgumentException` for a missing
factory rather than returning null, and that call sat outside the `runCatching` in `createOrNull` —
so the null check was not a check at all.

`GstPlaybackEngine` is deliberately fallible so a machine without GStreamer falls back to
`JavaSoundPlaybackEngine`. A probe that raises defeats the entire mechanism, and turned "no plugins
installed" into "the app cannot build a playback engine" — which is why *UI* tests failed, not
playback ones: building the app builds an engine.

`createOrNull` and `isAvailable` now treat any failure to look an element up as "not available".

## Regression test

`GstAvailabilityTest`, and unlike `GstPlaybackEngineIntegrationTest` it is **not** gated on
GStreamer being present — declining cleanly has to hold with GStreamer, without it, and with half
of it. Verified to actually reproduce: reverting the fix fails it with the same
`IllegalArgumentException`.

## CI now covers the real engine

CI installs `gstreamer1.0-plugins-base` and `gstreamer1.0-plugins-good` and asserts the elements
exist before building. Without that the integration test **skips and reports green**, which is how
an engine with no CI coverage at all reached master in the first place. These are the same packages
the `.deb` will declare in phase 9 (#3).

## Also

A racy wait in `QueuePlaybackControllerTest` that failed once locally. It used `state.first { }` to
wait on a repository condition, but a `StateFlow` conflates equal values — once the player settles
it stops emitting and the predicate is never re-evaluated. The saves are launched asynchronously
too. Those three assertions now poll with a deadline.

`clean check --warning-mode fail -Pttsroad.warningsAsErrors=true` → **457 tests, green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)