### PR TITLE
Phase 6: listening preferences, sleep timer, history, MPRIS and shortcuts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       # test quietly skip and report green.
       - name: Verify the GStreamer elements the engine needs
         run: |
-          for element in appsrc decodebin audioconvert scaletempo audioresample fakesink; do
+          for element in appsrc decodebin audioconvert scaletempo audioresample volume fakesink; do
             gst-inspect-1.0 "$element" > /dev/null || { echo "missing GStreamer element: $element"; exit 1; }
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,16 @@ jobs:
       # plugins the pipeline actually names means GstPlaybackEngineIntegrationTest runs here
       # instead of skipping, so the real engine has CI coverage rather than none. These are also
       # exactly the packages the .deb will declare in phase 9 (#3).
+      #
+      # gstreamer1.0-tools is what provides `gst-inspect-1.0` itself. Without it the verification
+      # step below fails with "command not found" on the first element, which reads exactly like a
+      # missing plugin and takes the whole job down before any test runs.
       - name: Install Xvfb and GStreamer
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             xvfb \
+            gstreamer1.0-tools \
             gstreamer1.0-plugins-base \
             gstreamer1.0-plugins-good
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,11 @@ explicitly *not* — an outage is not a revocation. `data/SessionEnd.kt` holds t
 
 Two invariants worth preserving:
 
-- **Capabilities gate the UI.** Each engine reports `EngineCapabilities`; the speed control is drawn
-  only when the backend can honour it. The predecessor API accepted a speed number that no backend
-  acted on — don't reintroduce a control the engine ignores.
+- **Capabilities gate the UI.** Each engine reports `EngineCapabilities`; the speed and skip-silence
+  controls are drawn only when the backend can honour them (`variableSpeed`, `skipSilence`). The
+  predecessor API accepted a speed number that no backend acted on — don't reintroduce a control the
+  engine ignores. Gain is the deliberate exception: *every* backend must honour attenuation, because
+  the sleep timer's fade is an attenuation.
 - **Failures are typed.** `PlaybackFailure` is `SessionExpired` / `Transient` / `Fatal`, and the
   three are handled differently: end the session, retry on a timer, don't retry. Engine events go
   through a synchronous listener rather than a hot flow, so a failure raised inside `prepare` cannot
@@ -88,6 +90,46 @@ Two invariants worth preserving:
 Chapter MP3s are bearer-protected and pushed *into* GStreamer (`appsrc`) rather than fetched by it,
 via `HttpMediaSource` on the shared client — that is how the auth interceptor and its origin rule
 apply to audio.
+
+### Listening preferences, the sleep timer and history
+
+- `data/PlaybackPreferences.kt` — speed, skip interval, skip silence, volume boost, in
+  `playback.json`. **Machine-local, not session data**: signing out must not reset them and a second
+  account must not inherit them, so the store has no reference to a session at all. The on-disk type
+  is separate and fully nullable, so a file from another build loads degraded rather than throwing;
+  out-of-range values are *snapped*, not defaulted. The offered speed list always includes the
+  stored value even when it isn't a preset.
+- **The controller applies preferences, not the player screen.** `QueuePlaybackController` collects
+  the store and pushes rate/gain/skip-silence to the engine, so an auto-advanced chapter and a
+  media-key start use the same values as one the user pressed play on. `setSpeed` writes the
+  *preference*; the collector is the only thing that touches the engine.
+- `player/SleepTimer.kt` — a state machine over an injected clock, ticked by the controller's
+  existing 250 ms loop. No coroutine, no `delay`: determinism under a fake clock is an acceptance
+  criterion. Fade gain is published as a multiplier and combined with the volume boost in one place,
+  so cancelling a fade restores the boost rather than unity. End-of-chapter is checked *before* the
+  auto-advance and disarms itself.
+- `data/PlaybackHistory.kt` — bounded to 60 entries, one per chapter. The snapshot type has **no URL
+  field of any kind**; covers are re-resolved from the library cache by fiction id. Dismissal is
+  per snapshot and is *inherited* when the same chapter is re-recorded, or the next progress save
+  would undo it. History is written at transitions only, never on the progress tick.
+
+### MPRIS
+
+`player/MprisState.kt` is pure Kotlin with no D-Bus type in it — that's where the audiobook mapping
+lives (chapter as title, serial as album *and* artist) and it's what the tests target.
+`player/MprisService.kt` is the plumbing. `createOrNull` catches `Throwable` (a missing transport
+provider is a `ServiceConfigurationError`) and returning null is a normal outcome: no session bus
+means no MPRIS and a fully working player. `Position` is never announced via `PropertiesChanged` —
+the spec excludes it; discontinuities go out as `Seeked`. `AppContainer.startMpris` is called from
+`Main` rather than the constructor because Raise/Quit need the window.
+
+### Keyboard shortcuts
+
+`nav/Shortcuts.kt` is a pure matcher plus an `AppShortcut.firesWhileTyping` classification. `App`
+installs it on **two** handlers, and that split is what makes typing safety structural: shortcuts no
+text field claims go on `onPreviewKeyEvent` (so F5 works inside the search box), and the editing keys
+— Space, arrows, Ctrl+arrow — go on `onKeyEvent`, which a focused text field has already consumed
+them from. Don't replace this with focus tracking. No global hotkeys are registered.
 
 ### Navigation and state
 
@@ -137,9 +179,13 @@ last known answer rather than downgrading; `api_version` is never a proxy for a 
 - **`src/prototype/`** is a separate source set that `main` never sees, so an unaccepted evaluation
   can't reach the shipped app or its jlink image. `check` compiles it; running it needs a real
   GStreamer install: `./gradlew runPlaybackPrototype`.
-- **jlink module list** in `build.gradle.kts` (`java.desktop`, `java.naming`, `jdk.crypto.ec`, …) is
-  load-bearing — module inference misses these, and dropping one breaks the packaged app at runtime
-  rather than at build time. The `--smoke-test` launch is what catches it.
+- **jlink module list** in `build.gradle.kts` (`java.desktop`, `java.naming`, `jdk.crypto.ec`,
+  `jdk.security.auth`, …) is load-bearing — module inference misses these, and dropping one breaks
+  the packaged app at runtime rather than at build time. The `--smoke-test` launch is what catches
+  it, and it only catches what it *asserts*: each such module needs a check there, because the
+  failures are silent by nature. `jdk.security.auth` is the MPRIS one — without it dbus-java cannot
+  read the uid, and the packaged app reports "no MPRIS integration" exactly as a machine with no
+  session bus would.
 - **`--enable-native-access=ALL-UNNAMED`** is applied to run, test and the packaged app; Skiko,
   the Windows credential store and JNA all use restricted methods on JDK 25.
 
@@ -160,9 +206,9 @@ can't quietly skip its way to green.
 
 `docs/adr/` records the reasoning and rejected alternatives behind the build baseline (0001),
 credential storage and capability discovery (0002), the playback engine (0002-playback-engine),
-device sessions and Settings (0003), navigation (0004), and chapter browsing (0005). Read the
-relevant one before changing any of the invariants above — they exist because the alternative was
-tried or measured.
+device sessions and Settings (0003), navigation (0004), chapter browsing (0005), and listening
+preferences / sleep timer / MPRIS / shortcuts (0006). Read the relevant one before changing any of
+the invariants above — they exist because the alternative was tried or measured.
 
 ## CI
 

--- a/README.md
+++ b/README.md
@@ -42,16 +42,22 @@ Built with Compose for Desktop — real Skia-rendered UI, real OS installers, no
 | Bulk marks — all played / all unplayed / all previous, in one request | ✅ |
 | Optimistic marking with rollback and an inline error | ✅ |
 | Searchable up-next panel for long queues | ✅ |
-| Player UI (play/pause, seek, ±30 s, next/previous, up-next queue) | ✅ |
+| Player UI (play/pause, seek, configurable skip, next/previous, up-next queue) | ✅ |
 | **MP3 audio playback** | ✅ |
-| Settings — two-pane control centre (account, devices, about) | ✅ |
+| Settings — two-pane control centre (account, devices, playback, about) | ✅ |
 | Device sessions — list, mark current, revoke one / revoke all others | ✅ |
-| Playback preferences / offline downloads | ❌ |
+| Playback preferences — speed, skip interval, skip silence, volume boost | ✅ |
+| Sleep timer — 5/15/30/45/60 min or end of chapter, with a fade and "+5 min" | ✅ |
+| Local listening history — "Jump back in", dismissible per snapshot | ✅ |
+| MPRIS over D-Bus — Cinnamon applet, lock screen, hardware media keys | ✅ Linux |
+| App shortcuts — Space, arrows, Ctrl+arrows, Ctrl+L, Ctrl+, plus an F1 list | ✅ |
+| Offline downloads | ❌ |
 | Streaming playback — audio starts before the chapter has downloaded | ✅ Linux |
 | Seeking without decoding from the start of the chapter | ✅ Linux |
 | Variable-rate playback ("speed"), pitch-preserving 0.5×–3.0× | ✅ Linux |
+| Skip silence | ✅ with `gst-plugins-bad` |
 
-> **The last three are Linux-only, and the app says so rather than pretending otherwise.** The
+> **The playback rows above are Linux-only, and the app says so rather than pretending otherwise.** The
 > production backend is GStreamer, with `scaletempo` for pitch-preserving rate. Where GStreamer is
 > absent — Windows and macOS by default — the app falls back to the original `javax.sound.sampled`
 > engine, which cannot resample and has no random-access index. Each engine reports its own
@@ -92,6 +98,8 @@ The back stack, the repository-backed cache, lazy lists and the adaptive breakpo
 [`docs/adr/0004-stateful-adaptive-navigation.md`](docs/adr/0004-stateful-adaptive-navigation.md).
 Chapter filtering and ordering, bulk marking, optimistic rollback and current-chapter resolution are in
 [`docs/adr/0005-chapter-browsing-and-bulk-controls.md`](docs/adr/0005-chapter-browsing-and-bulk-controls.md).
+Listening preferences, the sleep timer, local history, MPRIS and the shortcut table are in
+[`docs/adr/0006-listening-preferences-and-desktop-integration.md`](docs/adr/0006-listening-preferences-and-desktop-integration.md).
 
 ## 🚀 Bootstrap
 
@@ -164,6 +172,8 @@ src/main/kotlin/dk/perspektiva/ttsroad/desktop/
 │   └── Shortcuts.kt              the keyboard table and Escape's precedence, as pure functions
 ├── data/
 │   ├── Models.kt                 mobile API models (Moshi)
+│   ├── PlaybackPreferences.kt    speed/skip/silence/boost, machine-local, migrating on read
+│   ├── PlaybackHistory.kt        bounded local snapshots, last-heard and jump-back selection
 │   ├── Cached.kt                 value + error + isRefreshing + last success, independently
 │   ├── LibraryCache.kt           library/chapter state held above the screens
 │   ├── ChapterLists.kt           filter/sort, bulk id selection, status, played patch + rollback
@@ -186,6 +196,9 @@ src/main/kotlin/dk/perspektiva/ttsroad/desktop/
 │   ├── QueuePlaybackController.kt queue, auto-advance, progress, retry ladder, session expiry
 │   ├── PlaybackEngine.kt         backend seam: transport, capabilities, typed failures
 │   ├── GstPlaybackEngine.kt      production backend — GStreamer via gst1-java-core
+│   ├── SleepTimer.kt             the timer as a state machine over an injected clock
+│   ├── MprisState.kt             PlayerUiState → MPRIS, pure and D-Bus-free
+│   ├── MprisService.kt           the session-bus plumbing; optional at runtime
 │   ├── JavaSoundPlaybackEngine.kt fallback where GStreamer is absent (no speed control)
 │   ├── MediaSource.kt            bearer-authenticated range-request byte source
 │   └── AudioEngine.kt            javax.sound.sampled seam used by the fallback engine
@@ -199,6 +212,7 @@ src/main/kotlin/dk/perspektiva/ttsroad/desktop/
     ├── LibraryScreen.kt          LazyVerticalGrid: hero, shelves, search, fictions
     ├── FictionDetailScreen.kt    LazyColumn: one header item, then chapter rows + bulk controls
     ├── SettingsScreen.kt         two-pane control centre
+    ├── ShortcutsDialog.kt        the in-app keyboard reference (F1)
     └── PlayerScreen.kt           full player + NowPlayingBar (stacked when narrow)
 
 src/test/kotlin/dk/perspektiva/ttsroad/desktop/
@@ -207,7 +221,7 @@ src/test/kotlin/dk/perspektiva/ttsroad/desktop/
 ├── data/                         URLs, model parsing, login/429, capability discovery, structured
 │                                 401s, redaction, auth-interceptor origin rules, session migration
 ├── security/                     credential stores (incl. a real Windows Credential Manager round-trip)
-├── player/                       playback state machine + audio 401 handling
+├── player/                       playback state machine, audio 401s, sleep timer, MPRIS mapping
 ├── nav/                          back-stack rules, destination keys, shortcut table
 └── ui/                           state holders, adaptive breakpoints, Compose screen and
                                   navigation tests (retained state, refresh errors, lazy bounds)
@@ -239,6 +253,71 @@ instead of re-decoding from byte zero. Measured on a 32.5 s fixture: first audio
 
 The fallback engine keeps the old behaviour — materialise the chapter, decode with **mp3spi/JLayer**,
 write PCM to a `SourceDataLine`, re-decode from the start to seek, and no speed control.
+
+## 🎚️ Listening preferences, the sleep timer and the desktop
+
+Speed, skip interval, skip silence and volume boost live in `playback.json` next to the session and
+window files — **not** in the session. Signing out does not reset them, and a second account on a
+shared machine does not inherit the first one's. The file has no notion of a user at all.
+
+- **They are applied by the controller, not the player screen.** An auto-advanced chapter and a
+  media-key start use the same values as a chapter you pressed play on, because only the controller
+  sees all three.
+- **A file this build did not write still loads.** Missing keys fall back, unknown enum values fall
+  back to the safe end, and out-of-range numbers are *snapped* rather than defaulted — a stored
+  20-second skip becomes 15, which is closer to what that listener chose than 30 is.
+- **A custom speed survives.** The menu always offers the stored value even when it is not one of
+  this build's presets, so a rate set elsewhere is not silently rounded away on first open.
+- **Boost stops at 2×.** Higher clips quiet narration instead of raising it. Both engines honour
+  gain — including the Java Sound fallback, which scales PCM in its own decode loop with saturation
+  rather than wrapping, because the sleep timer's fade has to work everywhere.
+- **Skip silence needs `gst-plugins-bad`.** Where `removesilence` is absent the control is not
+  drawn, exactly as the speed control is not drawn without GStreamer.
+
+The **sleep timer** offers 5/15/30/45/60 minutes or the end of the current chapter.
+
+- A manual pause **freezes** a countdown; resuming continues it. An hour paused costs it nothing.
+- The last 30 seconds **fade**, and the fade multiplies with the volume boost rather than replacing
+  it — so cancelling restores your boost, not unity.
+- **"+5 min"** appears during the fade, adds to what is left, and brings the volume back as you
+  press it rather than on the next tick.
+- **End of chapter** stops at the boundary and prevents the auto-advance, rather than stopping the
+  next chapter a moment after it has already started.
+- Expiry **pauses**; it does not clear the queue. Resuming in the morning is one keypress.
+
+None of that is timed by a scheduler: the timer is a state machine ticked by the playback loop over
+an injected clock, so a test steps an hour in one line.
+
+**Local history** (`history.json`, 60 entries, one per chapter) backs the "Jump back in" strip. It
+holds ids and titles and *no URL of any kind* — covers are re-resolved from the live library cache.
+Dismissing an entry hides that snapshot, not the day: a later chapter of the same serial comes back
+on its own, and a progress save for a dismissed chapter does not resurrect it.
+
+On Linux the player appears on the session bus over **MPRIS**, so Cinnamon's media applet, the lock
+screen and hardware media keys show the right metadata and control playback. It is pure Java —
+dbus-java over the JDK's own AF_UNIX socket — so it adds no native library to the bundled runtime.
+No session bus (Windows, macOS, a bare SSH session) means no MPRIS and a fully working player, with
+a note in the log rather than a failure.
+
+## ⌨️ Keyboard
+
+| Keys | Action |
+| --- | --- |
+| `Space` | Play or pause |
+| `Left` / `Right` | Skip back or forward by your skip interval |
+| `Ctrl+Left` / `Ctrl+Right` | Previous or next chapter |
+| `Alt+Left` | Back |
+| `Ctrl+L` | Library |
+| `Ctrl+,` | Settings |
+| `F5` / `Ctrl+R` | Refresh the current screen |
+| `Escape` | Close a dialog, or go back |
+| `F1` / `Ctrl+/` | The in-app shortcut list |
+
+**Shortcuts that would type do not fire while you are typing.** That is structural rather than a
+check: the combinations no text field claims are installed on the window's *preview* handler, so F5
+still refreshes from inside the search box, while Space, the arrows and Ctrl+arrow are installed on
+the ordinary handler, which a focused text field has already consumed them from. No global hotkeys
+are registered — media keys reach the app through the desktop's own MPRIS routing instead.
 
 ## 🧭 Navigation, state and window behaviour
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,14 @@ dependencies {
     implementation(libs.gst1.java.core)
     implementation(libs.jna)
 
+    // MPRIS over D-Bus (docs/adr/0006-listening-preferences-and-desktop-integration.md). Pure
+    // Java: the wire protocol is implemented in dbus-java and the session bus is reached through
+    // the JDK's own AF_UNIX SocketChannel, so this adds no native library to the jlink image.
+    // Everything behind it is optional at runtime — no D-Bus means no MPRIS, not no playback.
+    implementation(libs.dbus.java.core)
+    implementation(libs.dbus.java.transport.native.unixsocket)
+    runtimeOnly(libs.slf4j.nop)
+
     // Pure-JVM MP3 decoding, registered as a javax.sound.sampled SPI. Retained as the fallback
     // engine on machines without GStreamer — Windows and macOS by default — where it keeps the
     // behaviour it has always had, speed control included (i.e. none).
@@ -245,7 +253,18 @@ compose.desktop {
             //   java.naming   — OkHttp's DNS/JNDI usage
             //   jdk.crypto.ec — TLS elliptic-curve suites (https:// servers fail without it)
             //   java.management / jdk.unsupported — Kotlin + Skiko runtime bits
-            modules("java.desktop", "java.naming", "java.management", "jdk.crypto.ec", "jdk.unsupported")
+            //   jdk.security.auth — com.sun.security.auth.module.UnixSystem, which dbus-java's
+            //     unix-socket transport uses to read the uid when connecting to the session bus.
+            //     Reached only by reflection, so inference misses it and MPRIS degrades to "no
+            //     session bus" in the packaged image while working fine from source.
+            modules(
+                "java.desktop",
+                "java.naming",
+                "java.management",
+                "jdk.crypto.ec",
+                "jdk.security.auth",
+                "jdk.unsupported",
+            )
 
             windows {
                 // Without these the MSI installs with no Start menu / desktop entry at all.

--- a/docs/adr/0006-listening-preferences-and-desktop-integration.md
+++ b/docs/adr/0006-listening-preferences-and-desktop-integration.md
@@ -1,0 +1,253 @@
+# ADR 0006 — Listening preferences, the sleep timer, and desktop integration
+
+- **Status:** Accepted
+- **Date:** 2026-08-07
+- **Context issue:** [#9 — Phase 6: Add playback preferences, sleep timer, history, MPRIS, and media keys](https://github.com/jonarihen/TTSRoad-Desktop/issues/9) (part of #1)
+
+## Context
+
+Phase 5 made playback real: a GStreamer backend that can actually resample, seek without
+re-decoding, and stream a chapter before it has finished downloading. What it did not do is let
+anyone *keep* a choice. Speed reset to 1.0 on every launch, the skip buttons were hard-coded to 30
+seconds, and there was no sleep timer, no local history, and nothing on the session bus — so
+Cinnamon's media applet and the keyboard's transport row saw no player at all.
+
+Four questions had to be answered before any of that could be built.
+
+1. **Where do listening settings live?** They are not account data — the server has no endpoint for
+   them — and they are not session data either.
+2. **How is a sleep timer made testable?** The acceptance criteria require deterministic behaviour
+   across pause, resume, seek, chapter boundary, manual stop and app close, including a fade.
+3. **What speaks D-Bus?** MPRIS is the only way media keys and the Cinnamon applet reach a Linux
+   media player, and the JVM has no D-Bus support of its own.
+4. **How do keyboard shortcuts coexist with text fields?** Space, the arrows and Ctrl+arrow are all
+   editing keys, and the app already installs a window-level preview handler so F5 works inside the
+   search box.
+
+## Decision
+
+### Preferences are machine-local, in their own file
+
+`playback.json` in the existing config directory, beside `session.json` and `window.json`, written
+owner-only through `SecureFiles`. It holds speed, skip interval, skip-silence and volume boost.
+
+It is deliberately **not** part of the session:
+
+- signing out must not reset someone's speed and skip interval;
+- signing in as a second account on a shared machine must not inherit the first account's;
+- the file therefore has no notion of a user at all, which is a stronger guarantee than remembering
+  not to key it by one.
+
+The on-disk shape is a separate type (`StoredPlaybackPreferences`) in which every field is nullable
+and the enum is a plain string. A file written by an older build is missing keys; a file written by
+a newer one can carry a `volumeBoost` this build has never heard of. Both load — degraded, never as
+an exception during startup. Out-of-range numbers are **snapped, not defaulted**: a stored skip of
+20 seconds means somebody chose 20, and 15 is a closer answer than falling back to 30.
+
+Speed gets one extra rule. The offered list always contains the *stored* value even when it is not
+one of this build's presets, so a rate set by another build stays selectable instead of being
+silently rounded away the first time the menu is opened.
+
+### Volume boost stops at 2×
+
+Off / Low / Medium / High map to 1.0, 1.3, 1.6 and 2.0. Above roughly 2× on already-mastered speech
+the peaks clip rather than get louder, and the listener who reaches for "louder" because the
+narration is quiet is exactly the listener who will not recognise the distortion as something *this
+app* did. The ladder stops where the artefacts start.
+
+Both engines honour gain, and that is not symmetric with speed on purpose. Speed needs a resampler
+the Java Sound fallback does not have; gain is a multiply over PCM its decode loop is already
+copying. The sleep timer's fade **is** a gain, so it has to work on every backend — a timer that cut
+the audio off abruptly on one engine and faded it on the other would be worse than no boost at all.
+The fallback's implementation saturates rather than wrapping, because an overflowing 16-bit sample
+wraps from full positive to full negative, which is a click on every peak.
+
+### Skip-silence is capability-gated, like speed
+
+It needs GStreamer's `removesilence`, which ships in `gst-plugins-bad` and is absent from most
+installs — this repository's own CI included. `EngineCapabilities` grew a `skipSilence` flag,
+probed once at construction, and the UI draws the control only where the backend can honour it.
+This is the same rule Phase 5 established for the speed control, and for the same reason: the
+predecessor API accepted a number that no backend acted on.
+
+The element sits **before** `scaletempo` in the chain. Dropping buffers changes the timeline, and
+doing it after the tempo scaler would apply the rate to a stream whose length had already changed
+underneath it.
+
+```
+appsrc → decodebin → audioconvert → [removesilence] → scaletempo → audioconvert → audioresample → volume → autoaudiosink
+```
+
+Toggling it takes effect at the next chapter rather than mid-stream. Inserting or removing an
+element under a playing pipeline means a state change and a re-link, and the audible glitch is worse
+than the toggle being one chapter late.
+
+### The sleep timer is a state machine over an injected clock
+
+`SleepTimer` has no coroutine and no `delay`. It exposes `arm`, `cancel`, `extendBy`,
+`onPlaybackPaused`, `onPlaybackResumed`, `shouldStopAtChapterEnd` and `tick`, and the playback
+controller drives `tick` from the 250 ms loop it already runs.
+
+That is the whole reason the fade and the expiry are testable. "Deterministic under a fake clock" is
+an acceptance criterion, and a real timer makes every one of the required cases — pause, resume,
+seek, chapter boundary, manual stop, app close — a race against a scheduler. Here a test steps an
+hour in one line.
+
+Details that fall out of the design:
+
+- **Pause freezes, resume continues.** A manual pause stores the remainder and drops the deadline;
+  resuming rebuilds the deadline from the remainder. An hour paused costs the timer nothing.
+- **The fade is the last 30 seconds**, published as a `fadeGain` multiplier rather than written to
+  the engine directly. The controller multiplies it by the volume-boost gain, so the two compose:
+  cancelling a fade restores the *boost*, not unity.
+- **"+5 min" adds to what is left**, and clears the fade immediately rather than on the next tick —
+  a listener who is still awake should hear the audio come back as they press it. It keeps the
+  original mode, so the chosen duration stays selected in the UI.
+- **End-of-chapter is not a duration in disguise.** A chapter's remaining time changes under a seek
+  and a rate change; expressing it as "stop at the boundary" keeps it correct when either happens.
+  It is checked *before* the advance, and disarms itself so a still-loaded queue is not stopped at
+  every subsequent boundary.
+- **Expiry pauses, it does not stop.** The queue and position stay put, so the morning's resume is
+  one keypress rather than a search for the chapter.
+
+### MPRIS: dbus-java, and a mapping that is tested without a bus
+
+`com.github.hypfvieh:dbus-java-core` plus its `native-unixsocket` transport. It implements the D-Bus
+wire protocol in pure Java and reaches the session bus through the JDK's own AF_UNIX
+`SocketChannel`, so it adds **no native library** to the jlink image.
+`slf4j-nop` is pinned alongside it: without a provider, SLF4J 2 prints "No SLF4J providers were
+found" to stderr on first use, and a desktop app should not narrate its dependency wiring.
+
+It does, however, add a **jlink module**: the transport reads the caller's uid through
+`com.sun.security.auth.module.UnixSystem`, which lives in `jdk.security.auth` and is reached only by
+reflection, so module inference misses it. Leaving it out produced the worst available failure mode
+— the packaged app started, played audio, and logged "no MPRIS integration on this desktop", which
+is exactly what a machine with no session bus logs, while the same code worked from `./gradlew run`
+because a full JDK was on the module path. The `--smoke-test` launch now asserts the class resolves
+(`verifyMprisRuntimeModulesArePresent`), because the smoke test deliberately does *not* claim a bus
+name and so could never have caught this by connecting. "No session bus" stays a passing
+configuration; "no module" does not.
+
+The integration is split in two:
+
+- `MprisState.kt` is pure Kotlin with no D-Bus type in it. The audiobook mapping lives here —
+  chapter as `xesam:title`, serial as `xesam:album` **and** `xesam:artist` — and is unit-tested on
+  any machine, CI included. There is no author in the mobile API payload, and an empty artist
+  renders as a dangling separator in several shells, so repeating the serial reads better than a
+  blank. That is a display choice, not a claim about authorship.
+- `MprisService.kt` is the plumbing: one exported object answering the root interface, the player
+  interface and `Properties` at `/org/mpris/MediaPlayer2`.
+
+Rules that are easy to get wrong and are therefore written down:
+
+- **`Position` is never in a `PropertiesChanged`.** The spec excludes it, because a player emitting
+  it every tick is a signal storm. A discontinuity — a seek, a skip, a chapter change — is reported
+  as `Seeked` instead, and clients interpolate between the two.
+- **A stale `SetPosition` track id is ignored.** Clients send an absolute position for the track
+  they last saw; honouring a stale one seeks the *new* chapter to the old one's offset.
+- **`OpenUri` does nothing.** Every URI this player can open is bearer-protected and belongs to the
+  signed-in server. Accepting an arbitrary one off the session bus would be an open redirect into an
+  authenticated client.
+- **`Volume` snaps.** The shell's slider is continuous and the boost is a four-step ladder; Set
+  picks the nearest step and the property reports the snapped value back, so the slider does not
+  drift away from what is playing.
+- **Bus name collisions fall back to the spec's `.instanceN`.** Two windows publishing under one
+  name would fight over the applet's display.
+- **Absence is normal.** `createOrNull` catches `Throwable`, not `Exception` — a missing transport
+  provider arrives as a `ServiceConfigurationError`. No session bus means no MPRIS and a fully
+  working player, with a diagnostic in `AppLog`.
+- **`Properties.Get` returns the `Variant`, not `variant.value`.** `Get` is declared to return `v`,
+  and dbus-java re-wraps a bare value in an *unqualified* Variant, which cannot marshal `Metadata`
+  — its `a{sv}` signature exists only because `playerProperties` attached it. Unwrapping made every
+  scalar property work and `Metadata` alone fail, which is why `GetAll` (typed `a{sv}`, Variants
+  intact) looked fine while a client that reads properties one at a time got an error instead of a
+  title. Verified against a real session bus with `busctl`; CI has no bus and cannot catch it.
+
+`mpris:artUrl` does name the private server's host to other processes in the user's login session.
+That is the cost of the desktop being able to draw artwork at all; the cover endpoint is
+unauthenticated and nothing authenticating travels with it.
+
+### Shortcuts: two handlers, not a focus tracker
+
+The obvious way to keep Space from pausing audio while someone types is to track whether a text
+field has focus. We do not do that. Instead the shortcut table is split by a
+`AppShortcut.firesWhileTyping` classification and installed on two handlers:
+
+- `onPreviewKeyEvent` runs **before** the focused component and carries only the combinations no
+  text field claims — F5, Ctrl+R, Escape, Alt+Left, Ctrl+L, Ctrl+comma, F1. This is what keeps F5
+  working inside the library's search box, which Phase 3 established.
+- `onKeyEvent` runs **only if nothing else consumed the key**. A focused text field has already
+  taken Space, the arrows and Ctrl+arrow for editing by the time it runs, so the transport shortcuts
+  never see them.
+
+The guard is therefore structural rather than a check somebody has to remember, and the
+classification is a pure value so a test can assert it with no toolkit, no display and no focus.
+
+Media keys are bound in-app too (`Key.MediaPlayPause` and friends), for when the window has focus.
+With no focus they go to the desktop, which routes them over MPRIS — the same actions through the
+other door. **No global hotkeys are installed**, per the issue: grabbing keys system-wide without an
+explicit opt-in is hostile.
+
+### History is bounded by construction
+
+`history.json`, at most 60 entries, one per chapter, newest first. It is written on every pause and
+chapter change for the life of the install, so an unbounded list would be a slow leak that only
+shows up on the machines of the people who use the app most.
+
+Two decisions worth recording:
+
+- **The snapshot type has no URL field of any kind** — not the server, not the audio object, not the
+  cover. It holds identifiers and titles; covers are re-resolved from the live library cache by
+  fiction id at display time. The guarantee is that there is nowhere in the type to put a leak.
+- **Dismissal belongs to the snapshot, not to a day.** Hiding "continue chapter 12" must not also
+  hide chapter 13 tomorrow, and must not un-hide chapter 12 tomorrow either. Recording a new
+  position for a chapter that is already dismissed *inherits* the dismissal — otherwise the next
+  progress save would undo a dismissal within a tick of the user making it. A different chapter is a
+  different snapshot and appears normally.
+
+History is recorded at transitions — pause, chapter change, sleep, stop, shutdown — and deliberately
+not on the ten-second progress tick, which would be write amplification for no extra information.
+
+## Consequences
+
+- Speed, skip interval, skip-silence and volume boost survive a restart and a sign-out, and are
+  applied by the controller, so an auto-advanced chapter and a media-key start use the same values
+  as one the user pressed play on.
+- The sleep timer's whole surface is testable without audio, a display or wall-clock waiting.
+- Cinnamon's applet, the lock screen where present, and hardware media keys control playback and
+  show correct metadata; seek and rate stay synchronised.
+- The app gains three runtime dependencies (`dbus-java-core`, its unix-socket transport, and
+  `slf4j-nop`) and no new native ones.
+- Skip-silence is unavailable on most installs, CI included, and says so rather than pretending.
+- The `.deb` in phase 9 (#3) should recommend `gstreamer1.0-plugins-bad` so skip-silence is
+  available where a user wants it, and must install `TTSRoad.desktop` under the name
+  `Mpris.DesktopEntry` reports, or the applet will show the player without an icon.
+
+## Alternatives considered and rejected
+
+**Preferences on the server.** There is no endpoint, and inventing one would break the roadmap's
+scope rule (keep changes in the desktop client unless a missing server contract is demonstrated).
+Speed and skip interval are also genuinely per-machine — a phone on a commute and a desktop in a
+quiet room do not want the same numbers.
+
+**Preferences inside `session.json`.** Simpler, and wrong: signing out would reset them, and a
+second account on a shared machine would inherit the first's.
+
+**A coroutine-based sleep timer with `delay`.** The natural implementation, and untestable against
+the acceptance criteria without either sleeping through real minutes or mocking `delay` at the
+dispatcher level. The state machine is more code and answers every required case exactly.
+
+**Mapping the sleep fade with a second engine volume control.** Two independent volume paths writing
+one element is how a fade ends up being undone by a preference change mid-fade. One multiplied gain,
+computed in one place.
+
+**`MASTER_GAIN` on the `SourceDataLine` for the fallback engine's gain.** Its range is
+device-dependent and it is frequently absent altogether, so a fade built on it would silently do
+nothing on some machines — the one outcome a sleep timer cannot have.
+
+**Global hotkeys.** Explicitly out of scope per the issue, and rightly: a media player that grabs
+keys system-wide without being asked is the kind of thing users uninstall.
+
+**Tracking text-field focus to gate shortcuts.** Needs every text field in the app to register with
+a shared tracker, and silently breaks the moment somebody adds one that does not. The two-handler
+split gets the same result from Compose's own focus behaviour.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,11 +35,20 @@ mp3spi = "1.9.5.4"
 jlayer = "1.0.1.4"
 tritonus = "0.3.7.4"
 
-# --- Phase 5 playback-engine prototype (not in the shipped app yet) -------------------------
-# GStreamer bindings evaluated in docs/adr/0002-playback-engine.md. gst1-java-core's POM asks
-# for JNA as the open range [5.2.0,6.0); we pin it so the build stays reproducible.
+# --- Playback engine ------------------------------------------------------------------------
+# GStreamer bindings, chosen in docs/adr/0002-playback-engine.md. gst1-java-core's POM asks for
+# JNA as the open range [5.2.0,6.0); we pin it so the build stays reproducible.
 gst1JavaCore = "1.4.0"
 jna = "5.19.1"
+
+# --- MPRIS / D-Bus (Linux desktop integration) ----------------------------------------------
+# dbus-java 5.x talks the D-Bus wire protocol in pure Java and reaches the session bus through
+# the JDK's own AF_UNIX socket support, so there is no JNI and no libdbus to package. See
+# docs/adr/0006-listening-preferences-and-desktop-integration.md.
+dbusJava = "5.2.0"
+# dbus-java logs through SLF4J. Version-locked to what dbus-java resolves, because an api/provider
+# mismatch is exactly the case SLF4J reports by printing to stderr — which is what we are avoiding.
+slf4j = "2.0.17"
 
 # --- Test ----------------------------------------------------------------------------------
 junit = "6.1.2"
@@ -72,10 +81,20 @@ soundlibs-mp3spi = { module = "com.googlecode.soundlibs:mp3spi", version.ref = "
 soundlibs-jlayer = { module = "com.googlecode.soundlibs:jlayer", version.ref = "jlayer" }
 soundlibs-tritonusShare = { module = "com.googlecode.soundlibs:tritonus-share", version.ref = "tritonus" }
 
-# GStreamer bindings — used ONLY by the `prototype` source set, never by `main`.
+# GStreamer bindings.
 # jna-platform is deliberately absent: gst1-java-core's only compile dependency is `jna`.
 gst1-java-core = { module = "org.freedesktop.gstreamer:gst1-java-core", version.ref = "gst1JavaCore" }
 jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
+
+# D-Bus, for the MPRIS media-player interface Cinnamon's applet and the media keys speak.
+# The unix-socket transport is the JDK-native one (SocketChannel over AF_UNIX, JDK 16+), which is
+# why this costs no native library of its own.
+dbus-java-core = { module = "com.github.hypfvieh:dbus-java-core", version.ref = "dbusJava" }
+dbus-java-transport-native-unixsocket = { module = "com.github.hypfvieh:dbus-java-transport-native-unixsocket", version.ref = "dbusJava" }
+# The no-op SLF4J provider. Without *a* provider, SLF4J 2 prints "No SLF4J providers were found"
+# to stderr on first use; a desktop app should not narrate its own dependency wiring to the user,
+# and D-Bus problems are reported through AppLog where they can actually say something useful.
+slf4j-nop = { module = "org.slf4j:slf4j-nop", version.ref = "slf4j" }
 
 # Cover images.
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
@@ -79,6 +80,7 @@ import dk.perspektiva.ttsroad.desktop.ui.PlayerScreen
 import dk.perspektiva.ttsroad.desktop.ui.SettingsScreen
 import dk.perspektiva.ttsroad.desktop.ui.SettingsSection
 import dk.perspektiva.ttsroad.desktop.ui.SettingsStateHolder
+import dk.perspektiva.ttsroad.desktop.ui.ShortcutsDialog
 import dk.perspektiva.ttsroad.desktop.ui.WindowSizeClass
 import dk.perspektiva.ttsroad.desktop.ui.hasSession
 import dk.perspektiva.ttsroad.desktop.ui.rememberStateHolder
@@ -129,12 +131,65 @@ fun App(container: AppContainer = remember { AppContainer() }) {
     // silently dismiss an invisible dialog instead of going back.
     //
     // Returns whether the key did anything, so an Escape that means nothing is not swallowed here.
+    var showShortcuts by remember { mutableStateOf(false) }
+
     fun dismissOrGoBack(): Boolean {
+        // The shortcuts dialog is owned here rather than by a screen, so it is the first thing
+        // Escape closes — ahead of a settings confirmation that may also be open behind it.
+        if (showShortcuts) {
+            showShortcuts = false
+            return true
+        }
         val ownsOverlay = nav.current == Destination.Settings || nav.current == Destination.Devices
         return when (escapeAction(settings.hasOpenOverlay && ownsOverlay, nav.canGoBack)) {
             EscapeAction.CloseOverlay -> settings.dismissTopOverlay()
             EscapeAction.GoBack -> nav.back()
             EscapeAction.None -> false
+        }
+    }
+
+    // Each branch reports whether it actually did something: a Back, an Escape or a transport key
+    // with nothing to act on must fall through rather than be swallowed at the root.
+    fun handleShortcut(shortcut: AppShortcut?): Boolean {
+        // Transport shortcuts need something loaded. Without this guard, Space on the login screen
+        // would report itself handled and never reach the button under the cursor.
+        fun whenPlaying(action: () -> Unit): Boolean {
+            if (!playerState.hasMedia) return false
+            action()
+            return true
+        }
+        return when (shortcut) {
+            AppShortcut.Back -> nav.back()
+
+            AppShortcut.Refresh -> {
+                refreshCurrentScreen()
+                true
+            }
+
+            AppShortcut.Dismiss -> dismissOrGoBack()
+
+            AppShortcut.PlayPause -> whenPlaying(playback::togglePlayPause)
+            AppShortcut.SeekBackward -> whenPlaying(playback::skipBackward)
+            AppShortcut.SeekForward -> whenPlaying(playback::skipForward)
+            AppShortcut.PreviousChapter -> whenPlaying(playback::skipToPreviousChapter)
+            AppShortcut.NextChapter -> whenPlaying(playback::skipToNextChapter)
+
+            AppShortcut.OpenLibrary -> {
+                nav.open(Destination.Library)
+                true
+            }
+
+            AppShortcut.OpenSettings -> {
+                nav.open(Destination.Settings)
+                true
+            }
+
+            AppShortcut.ShowShortcuts -> {
+                showShortcuts = true
+                true
+            }
+
+            null -> false
         }
     }
 
@@ -163,23 +218,21 @@ fun App(container: AppContainer = remember { AppContainer() }) {
             .background(AarisColor.Bg)
             .focusRequester(rootFocus)
             .focusable()
-            // A *preview* handler, so the window shortcuts work even while a text field has focus:
-            // F5 in the library's search box still refreshes.
-            .onPreviewKeyEvent { event ->
-                // Each branch reports whether it actually did something: a Back or an Escape that
-                // has nothing to act on must fall through rather than be swallowed at the root.
-                when (shortcutFor(event)) {
-                    AppShortcut.Back -> nav.back()
-
-                    AppShortcut.Refresh -> {
-                        refreshCurrentScreen()
-                        true
-                    }
-
-                    AppShortcut.Dismiss -> dismissOrGoBack()
-
-                    null -> false
-                }
+            // Two handlers, and the split is what makes "shortcuts do not fire while typing"
+            // structural rather than a check somebody has to remember.
+            //
+            // The *preview* pass runs before the focused component, so it is limited to the
+            // combinations no text field claims — F5 in the library's search box still refreshes.
+            // Passing `textInputFocused = true` is how that limit is expressed: it asks the table
+            // for exactly the shortcuts that are safe mid-word.
+            .onPreviewKeyEvent { event -> handleShortcut(shortcutFor(event, textInputFocused = true)) }
+            // The ordinary pass runs only if nothing else consumed the key. A focused text field
+            // has already taken Space, the arrows and Ctrl+arrow for editing by the time this
+            // runs, so the transport shortcuts simply never see them — no focus tracking needed.
+            .onKeyEvent { event ->
+                val shortcut = shortcutFor(event, textInputFocused = false)
+                // Anything the preview pass already had a chance at must not run twice.
+                if (shortcut == null || shortcut.firesWhileTyping) false else handleShortcut(shortcut)
             },
     ) {
         // Keyboard shortcuts are delivered to the focus owner and previewed on the way down, so
@@ -223,6 +276,7 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                     cache = cache,
                                     repository = repository,
                                     playback = playback,
+                                    history = container.playbackHistory,
                                     onOpenFiction = { nav.open(Destination.Fiction(it)) },
                                     onOpenPlayer = { nav.open(Destination.Player) },
                                 )
@@ -246,6 +300,7 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                 Destination.Player -> PlayerScreen(
                                     playback = playback,
                                     sizeClass = sizeClass,
+                                    preferences = container.playbackPreferences,
                                     onBack = { nav.back() },
                                 )
 
@@ -253,6 +308,12 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                     sessionStore = sessionStore,
                                     repository = repository,
                                     holder = settings,
+                                    preferences = container.playbackPreferences,
+                                    // Read off the player state rather than the engine, so the
+                                    // Settings pane and the player agree about what the backend
+                                    // can do by construction.
+                                    canChangeSpeed = playerState.canChangeSpeed,
+                                    canSkipSilence = playerState.canSkipSilence,
                                     // Keeps the destination and the open pane in step, so the
                                     // Devices deep link and the in-screen pane list are the same
                                     // thing rather than two competing notions of "where am I".
@@ -280,6 +341,10 @@ fun App(container: AppContainer = remember { AppContainer() }) {
             }
         }
     }
+
+    // Outside the login branch on purpose: F1 is a reasonable thing to press on the sign-in
+    // screen, and the list is useful there too.
+    if (showShortcuts) ShortcutsDialog(onDismiss = { showShortcuts = false })
 
     // The Devices destination is a deep link into the settings screen: entering it selects the
     // pane, so a future "manage sessions" link from anywhere lands on the right place.

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/Main.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/Main.kt
@@ -16,6 +16,7 @@ import dk.perspektiva.ttsroad.desktop.ui.TtsRoadTheme
 import java.awt.Dimension
 import java.awt.Frame
 import java.awt.GraphicsEnvironment
+import java.awt.event.WindowEvent
 import java.util.ServiceLoader
 import java.util.concurrent.atomic.AtomicReference
 import javax.sound.sampled.spi.AudioFileReader
@@ -43,6 +44,28 @@ private fun verifyMp3SpiIsRegistered() {
         System.err.println("FATAL: the MP3 AudioFileReader SPI is not registered in this runtime image")
         exitProcess(1)
     }
+}
+
+/**
+ * The classes MPRIS needs that live outside the modules jlink infers.
+ *
+ * `com.sun.security.auth.module.UnixSystem` is in `jdk.security.auth` and is reached only by
+ * reflection from dbus-java's unix-socket transport, so leaving that module out of the jlink list
+ * produces the worst possible failure mode: the app starts, plays audio, and reports "no MPRIS
+ * integration on this desktop" — indistinguishable from a machine that genuinely has no session
+ * bus. Checked here rather than by connecting, because CI has no session bus and "no bus" must stay
+ * a passing configuration while "no module" must not.
+ *
+ * Linux only: this is where MPRIS applies, and the class does not exist on Windows runtimes.
+ */
+private fun verifyMprisRuntimeModulesArePresent() {
+    if (!System.getProperty("os.name").orEmpty().contains("linux", ignoreCase = true)) return
+    val required = "com.sun.security.auth.module.UnixSystem"
+    runCatching { Class.forName(required) }.onFailure {
+        System.err.println("FATAL: $required is missing from this runtime image (jdk.security.auth)")
+        exitProcess(1)
+    }
+    println("MPRIS runtime modules present: $required")
 }
 
 /**
@@ -100,6 +123,19 @@ fun main(args: Array<String>) {
             // would grow or shrink the window by the display's scale factor on every restart.
             LaunchedEffect(Unit) {
                 frame.set(window)
+                // The window exists now, so Raise and Quit have something to act on. Skipped
+                // under --smoke-test: claiming a bus name in CI would leave a player advertised
+                // for the two seconds before the process exits, for no coverage in return.
+                if (!smokeTest) {
+                    container.startMpris(
+                        onRaise = {
+                            window.toFront()
+                            window.requestFocus()
+                            if (window.extendedState == Frame.ICONIFIED) window.extendedState = Frame.NORMAL
+                        },
+                        onQuit = { window.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING)) },
+                    )
+                }
                 window.minimumSize = Dimension(WindowPlacements.MinWidth, WindowPlacements.MinHeight)
                 window.setSize(restored.width, restored.height)
                 val x = restored.x
@@ -115,6 +151,7 @@ fun main(args: Array<String>) {
                 LaunchedEffect(Unit) {
                     delay(2_000)
                     verifyMp3SpiIsRegistered()
+                    verifyMprisRuntimeModulesArePresent()
                     println("${BuildInfo.APP_NAME} ${BuildInfo.VERSION} smoke test OK")
                     container.close()
                     exitApplication()

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/AppDirectories.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/AppDirectories.kt
@@ -1,0 +1,101 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import java.io.File
+
+/**
+ * Where this app is allowed to write, split by what the operating system is entitled to do with it.
+ *
+ * The split is the whole point and it is not cosmetic:
+ *
+ * - **Config** is small, hand-made state — the server, the window placement, the listening
+ *   preferences. Losing it is annoying.
+ * - **Data** is what the *user asked for*: downloaded chapters. A cleaner is entitled to empty a
+ *   cache directory without asking, so a download parked in one would evaporate on a machine with
+ *   an aggressive janitor — and the user would find an "Offline" badge with no bytes behind it.
+ * - **Cache** is everything the app can rebuild by asking the server again: streamed audio it chose
+ *   to retain, HTTP metadata. Deleting it costs bandwidth and nothing else.
+ *
+ * [osName], [userHome] and [env] are parameters throughout so the path rules — in particular the
+ * XDG Base Directory spec, where honouring `$XDG_DATA_HOME` is the difference between respecting a
+ * user's layout and ignoring it — can be tested from any platform.
+ */
+object AppDirectories {
+
+    /** The directory name this app owns inside each platform base. */
+    const val AppFolder: String = "TTSRoad"
+
+    /**
+     * Small, hand-made state: `session.json`, `playback.json`, `history.json`, window placement.
+     *
+     * `%APPDATA%/TTSRoad`, `~/Library/Application Support/TTSRoad`, or `$XDG_CONFIG_HOME/TTSRoad`.
+     */
+    fun configDir(
+        osName: String = System.getProperty("os.name").orEmpty(),
+        userHome: String = System.getProperty("user.home").orEmpty(),
+        env: (String) -> String? = System::getenv,
+    ): File = when (platformOf(osName)) {
+        Platform.Windows -> File(envDir(env, "APPDATA") ?: File(userHome, "AppData/Roaming"), AppFolder)
+        Platform.MacOs -> File(File(userHome, "Library/Application Support"), AppFolder)
+        Platform.Linux -> File(xdgDir(env, "XDG_CONFIG_HOME", userHome, ".config"), AppFolder)
+    }
+
+    /**
+     * User-requested downloads. **Never** evicted by this app or by the platform's cache cleaner.
+     *
+     * On Windows this is `%LOCALAPPDATA%`, not `%APPDATA%`: a roaming profile copies its contents
+     * to a domain server at every sign-in, and an audiobook library is precisely the thing that
+     * must not be dragged across a network by a login script.
+     */
+    fun dataDir(
+        osName: String = System.getProperty("os.name").orEmpty(),
+        userHome: String = System.getProperty("user.home").orEmpty(),
+        env: (String) -> String? = System::getenv,
+    ): File = when (platformOf(osName)) {
+        Platform.Windows -> File(envDir(env, "LOCALAPPDATA") ?: File(userHome, "AppData/Local"), AppFolder)
+        Platform.MacOs -> File(File(userHome, "Library/Application Support"), AppFolder)
+        Platform.Linux -> File(xdgDir(env, "XDG_DATA_HOME", userHome, ".local/share"), AppFolder)
+    }
+
+    /**
+     * Rebuildable bytes. Anything here may be deleted at any time by the app, the user, or the OS.
+     *
+     * Nothing may live here that the app would later report as "Offline" — see [dataDir].
+     */
+    fun cacheDir(
+        osName: String = System.getProperty("os.name").orEmpty(),
+        userHome: String = System.getProperty("user.home").orEmpty(),
+        env: (String) -> String? = System::getenv,
+    ): File = when (platformOf(osName)) {
+        // Windows has no cache base of its own; the convention is a Cache folder under LocalAppData.
+        Platform.Windows ->
+            File(File(envDir(env, "LOCALAPPDATA") ?: File(userHome, "AppData/Local"), AppFolder), "Cache")
+
+        Platform.MacOs -> File(File(userHome, "Library/Caches"), AppFolder)
+        Platform.Linux -> File(xdgDir(env, "XDG_CACHE_HOME", userHome, ".cache"), AppFolder)
+    }
+
+    private enum class Platform { Windows, MacOs, Linux }
+
+    private fun platformOf(osName: String): Platform {
+        val os = osName.lowercase()
+        return when {
+            os.contains("win") -> Platform.Windows
+            os.contains("mac") || os.contains("darwin") -> Platform.MacOs
+            else -> Platform.Linux
+        }
+    }
+
+    private fun envDir(env: (String) -> String?, name: String): File? =
+        env(name)?.takeIf { it.isNotBlank() }?.let { File(it) }
+
+    /**
+     * An XDG base directory, honouring the spec's "ignore a relative value" rule.
+     *
+     * The spec is explicit that a non-absolute `$XDG_*_HOME` must be treated as unset rather than
+     * resolved against the working directory — otherwise a stray `XDG_DATA_HOME=tmp` would scatter
+     * a user's downloads into whatever directory the app happened to be launched from.
+     */
+    private fun xdgDir(env: (String) -> String?, name: String, userHome: String, fallback: String): File =
+        env(name)?.takeIf { it.isNotBlank() && it.startsWith("/") }?.let { File(it) }
+            ?: File(userHome, fallback)
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackHistory.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackHistory.kt
@@ -1,0 +1,212 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.squareup.moshi.Types
+import dk.perspektiva.ttsroad.desktop.security.SecureFiles
+import java.io.File
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * One "you were here" record.
+ *
+ * There is deliberately no URL field of any kind — not the server, not the audio object, not the
+ * cover. This file sits unencrypted in the user's config directory and outlives the session that
+ * wrote it, so the rule is that it holds *identifiers and titles the user typed or the server
+ * named*, and nothing that could reconstruct where the content lives or who was signed in. Covers
+ * are re-resolved from the live library cache by [fictionId] at display time.
+ *
+ * [dismissed] is a property of this snapshot, not of a day. Hiding "continue chapter 12" must not
+ * also hide chapter 13 tomorrow, and must not un-hide chapter 12 tomorrow either.
+ */
+data class PlaybackSnapshot(
+    val fictionId: Int,
+    val chapterId: Int,
+    val fictionTitle: String,
+    val chapterTitle: String,
+    val positionSeconds: Double,
+    val durationSeconds: Double,
+    val recordedAtMs: Long,
+    val dismissed: Boolean = false,
+) {
+    /**
+     * Identity for thinning and for dismissal.
+     *
+     * A chapter, not a playback session: listening to chapter 12 twice is one thing to offer to
+     * resume, and a dismissal of it should survive the position moving.
+     */
+    val key: String get() = "$fictionId:$chapterId"
+
+    /** How far in, 0..1. Zero when the duration is unknown, so a bar cannot render nonsense. */
+    val progress: Float
+        get() = if (durationSeconds <= 0.0) 0f
+        else (positionSeconds / durationSeconds).coerceIn(0.0, 1.0).toFloat()
+}
+
+/**
+ * Local listening history: what to offer as "last heard", and what the jump-back list shows.
+ *
+ * Bounded by construction — [PlaybackHistory.MaxEntries] entries, one per chapter, newest first —
+ * because this is written on every pause and every chapter change for the life of the install. An
+ * unbounded list would be a slow leak that only shows up on the machines of the people who use the
+ * app most.
+ */
+object PlaybackHistory {
+    /**
+     * How many chapters are remembered.
+     *
+     * Enough to cover several serials in flight; small enough that the file stays a few kilobytes
+     * and the whole thing can be read synchronously at startup.
+     */
+    const val MaxEntries: Int = 60
+
+    /** How many distinct fictions the jump-back surface offers at once. */
+    const val JumpBackChoices: Int = 4
+
+    /**
+     * A chapter this far in is not worth offering to resume.
+     *
+     * At 96% the playback controller has already marked it played, so "continue" would mean
+     * "replay the last few seconds and then auto-advance", which is not what the listener wants
+     * from a card that says *continue*.
+     */
+    const val ResumableCeiling: Float = 0.96f
+
+    /**
+     * Adds or updates [snapshot], then thins.
+     *
+     * Rules, in order:
+     * 1. An existing entry for the same chapter is replaced, not appended — listening for an hour
+     *    leaves one record of that chapter, at the furthest point reached.
+     * 2. The replacement **inherits the old entry's dismissal**. Otherwise the next progress save
+     *    would silently undo a dismissal the user had just made.
+     * 3. Newest first, capped at [MaxEntries].
+     */
+    fun record(existing: List<PlaybackSnapshot>, snapshot: PlaybackSnapshot): List<PlaybackSnapshot> {
+        val previous = existing.firstOrNull { it.key == snapshot.key }
+        val merged = snapshot.copy(dismissed = previous?.dismissed ?: snapshot.dismissed)
+        return (listOf(merged) + existing.filterNot { it.key == merged.key })
+            .sortedByDescending { it.recordedAtMs }
+            .take(MaxEntries)
+    }
+
+    /** Marks one chapter's snapshot dismissed. A later snapshot of a *different* chapter is unaffected. */
+    fun dismiss(existing: List<PlaybackSnapshot>, key: String): List<PlaybackSnapshot> =
+        existing.map { if (it.key == key) it.copy(dismissed = true) else it }
+
+    /**
+     * The single thing to offer as "last heard", or null.
+     *
+     * Skips dismissed entries and ones that are effectively finished, so the card is always an
+     * offer the listener can act on rather than one they have to dismiss again.
+     */
+    fun lastHeard(existing: List<PlaybackSnapshot>): PlaybackSnapshot? =
+        existing.filter { it.isResumable }.maxByOrNull { it.recordedAtMs }
+
+    /**
+     * Up to [limit] things to jump back to, newest first, at most one per fiction.
+     *
+     * One per fiction because the alternative — the raw list — fills with consecutive chapters of
+     * whatever serial was last playing, which is the one thing the listener does not need help
+     * finding.
+     */
+    fun jumpBackChoices(
+        existing: List<PlaybackSnapshot>,
+        limit: Int = JumpBackChoices,
+    ): List<PlaybackSnapshot> =
+        existing.filter { it.isResumable }
+            .sortedByDescending { it.recordedAtMs }
+            .distinctBy { it.fictionId }
+            .take(limit)
+
+    private val PlaybackSnapshot.isResumable: Boolean
+        get() = !dismissed && progress < ResumableCeiling
+}
+
+/** Seam so tests never touch the real user config directory. */
+interface PlaybackHistoryStore {
+    val history: StateFlow<List<PlaybackSnapshot>>
+
+    fun record(snapshot: PlaybackSnapshot)
+
+    fun dismiss(key: String)
+
+    fun clear()
+}
+
+/** In-memory store for tests and for a session with nowhere safe to write. */
+class InMemoryPlaybackHistoryStore(
+    initial: List<PlaybackSnapshot> = emptyList(),
+) : PlaybackHistoryStore {
+    private val _history = MutableStateFlow(initial)
+    override val history: StateFlow<List<PlaybackSnapshot>> = _history.asStateFlow()
+
+    override fun record(snapshot: PlaybackSnapshot) {
+        _history.value = PlaybackHistory.record(_history.value, snapshot)
+    }
+
+    override fun dismiss(key: String) {
+        _history.value = PlaybackHistory.dismiss(_history.value, key)
+    }
+
+    override fun clear() {
+        _history.value = emptyList()
+    }
+}
+
+/**
+ * `history.json` beside the other settings, written owner-only through [SecureFiles].
+ *
+ * Owner-only despite holding no secret: fiction and chapter titles are a reading history, which is
+ * the sort of thing that should not be world-readable on a shared machine just because it is not a
+ * password.
+ */
+class FilePlaybackHistoryStore(
+    private val file: File = defaultFile(),
+) : PlaybackHistoryStore {
+    private val adapter = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+        .adapter<List<PlaybackSnapshot>>(
+            Types.newParameterizedType(List::class.java, PlaybackSnapshot::class.java),
+        )
+
+    private val _history = MutableStateFlow(read())
+    override val history: StateFlow<List<PlaybackSnapshot>> = _history.asStateFlow()
+
+    override fun record(snapshot: PlaybackSnapshot) {
+        write(PlaybackHistory.record(_history.value, snapshot))
+    }
+
+    override fun dismiss(key: String) {
+        write(PlaybackHistory.dismiss(_history.value, key))
+    }
+
+    override fun clear() {
+        write(emptyList())
+    }
+
+    private fun write(next: List<PlaybackSnapshot>) {
+        if (next == _history.value) return
+        _history.value = next
+        runCatching { SecureFiles.writeAtomically(file, adapter.toJson(next)) }
+            .onFailure { AppLog.warn("could not write the playback history file", it) }
+    }
+
+    private fun read(): List<PlaybackSnapshot> =
+        runCatching { if (file.isFile) adapter.fromJson(file.readText()) else null }
+            .onFailure { AppLog.warn("could not read the playback history file", it) }
+            .getOrNull()
+            // Trim on the way in as well: a file from a build with a larger cap must not make this
+            // build's list unbounded just because it was written before the cap came down.
+            ?.sortedByDescending { it.recordedAtMs }
+            ?.distinctBy { it.key }
+            ?.take(PlaybackHistory.MaxEntries)
+            ?: emptyList()
+
+    companion object {
+        fun defaultFile(): File = FileSessionStore.configDir().resolve("history.json")
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackPreferences.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackPreferences.kt
@@ -1,0 +1,203 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dk.perspektiva.ttsroad.desktop.security.SecureFiles
+import java.io.File
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * How much the output is amplified above unity.
+ *
+ * Capped at [VolumeBoost.High] on purpose. Digital gain above roughly 2× on already-mastered
+ * speech clips the peaks rather than making them louder, and a listener who reaches for "louder"
+ * because the narration is quiet is exactly the listener who will not recognise distortion as
+ * something *this app* did. The ladder stops where the artefacts start.
+ */
+enum class VolumeBoost(val label: String, val gain: Double) {
+    Off("Off", 1.0),
+    Low("Low", 1.3),
+    Medium("Medium", 1.6),
+    High("High", 2.0),
+}
+
+/**
+ * Listening settings that belong to the machine, not to the account.
+ *
+ * Deliberately persisted outside the session: signing out must not reset someone's speed and skip
+ * interval, and signing in as a second account on a shared machine must not inherit the first
+ * account's — the file has no notion of a user because these are properties of *this desktop*.
+ * Nothing here is secret, and there is nowhere in the type to put something that is.
+ */
+data class PlaybackPreferences(
+    val speed: Float = DefaultSpeed,
+    val skipIntervalSeconds: Int = DefaultSkipSeconds,
+    /**
+     * Default **off**, matching mobile 0.9.0 and the web player.
+     *
+     * Skipping silence changes where a chapter's timings fall, so a listener who has never asked
+     * for it must not find their read-along drifting after an update.
+     */
+    val skipSilence: Boolean = false,
+    val volumeBoost: VolumeBoost = VolumeBoost.Off,
+) {
+    companion object {
+        const val DefaultSpeed: Float = 1f
+        const val MinSpeed: Float = 0.5f
+        const val MaxSpeed: Float = 3.0f
+
+        const val DefaultSkipSeconds: Int = 30
+
+        /** The skip intervals the UI offers. Anything else in a stored file is snapped to these. */
+        val SkipIntervals: List<Int> = listOf(10, 15, 30, 45, 60)
+
+        /**
+         * The speeds the UI offers as one-tap choices.
+         *
+         * 1.25× is here because it is the single most-used non-unity rate on mobile and stepping
+         * 1.0 → 1.5 skips straight past it.
+         */
+        val SpeedPresets: List<Float> = listOf(0.5f, 0.75f, 1f, 1.25f, 1.5f, 1.75f, 2f, 2.5f, 3f)
+
+        /**
+         * The presets, plus [current] when it is not one of them.
+         *
+         * A value that arrived from an older build — or from a future one with a longer ladder —
+         * stays selectable instead of being silently rounded to the nearest preset the moment the
+         * user opens the menu. Losing someone's 1.35× because this build does not offer it is a
+         * worse outcome than one odd-looking entry.
+         */
+        fun speedOptions(current: Float): List<Float> {
+            val normalised = normaliseSpeed(current)
+            if (SpeedPresets.any { it.isSameSpeedAs(normalised) }) return SpeedPresets
+            return (SpeedPresets + normalised).sorted()
+        }
+
+        fun normaliseSpeed(speed: Float): Float =
+            if (speed.isNaN()) DefaultSpeed else speed.coerceIn(MinSpeed, MaxSpeed)
+
+        /**
+         * Nearest offered interval.
+         *
+         * Snapping rather than clamping: a stored 20 means a build that offered 20, and 15 is a
+         * closer answer to what that listener chose than either end of this build's ladder.
+         */
+        fun normaliseSkipSeconds(seconds: Int): Int =
+            SkipIntervals.minByOrNull { kotlin.math.abs(it - seconds) } ?: DefaultSkipSeconds
+    }
+}
+
+/** Float equality with a tolerance, so 1.2499999 and 1.25 are the same choice. */
+private fun Float.isSameSpeedAs(other: Float): Boolean = kotlin.math.abs(this - other) < 0.001f
+
+/** [PlaybackPreferences.skipIntervalSeconds] as the milliseconds the transport actually skips. */
+val PlaybackPreferences.skipIntervalMs: Long get() = skipIntervalSeconds * 1000L
+
+/**
+ * The on-disk shape, kept separate from [PlaybackPreferences] so the in-memory type stays total.
+ *
+ * Every field is nullable and the enum is a plain string: a file written by an older build is
+ * missing keys, and one written by a newer build can carry a `volumeBoost` this build has never
+ * heard of. Both must load — degraded, not empty, and never as an exception during startup.
+ */
+internal data class StoredPlaybackPreferences(
+    val version: Int? = null,
+    val speed: Float? = null,
+    val skipIntervalSeconds: Int? = null,
+    val skipSilence: Boolean? = null,
+    val volumeBoost: String? = null,
+) {
+    fun toPreferences(): PlaybackPreferences = PlaybackPreferences(
+        speed = PlaybackPreferences.normaliseSpeed(speed ?: PlaybackPreferences.DefaultSpeed),
+        skipIntervalSeconds = PlaybackPreferences.normaliseSkipSeconds(
+            skipIntervalSeconds ?: PlaybackPreferences.DefaultSkipSeconds,
+        ),
+        skipSilence = skipSilence ?: false,
+        // An unrecognised name falls back to Off rather than to the loudest thing in the enum.
+        volumeBoost = VolumeBoost.entries.firstOrNull { it.name.equals(volumeBoost, ignoreCase = true) }
+            ?: VolumeBoost.Off,
+    )
+
+    companion object {
+        /** Bumped only when a field changes meaning; new *optional* fields do not need it. */
+        const val CurrentVersion: Int = 1
+
+        fun from(preferences: PlaybackPreferences) = StoredPlaybackPreferences(
+            version = CurrentVersion,
+            speed = preferences.speed,
+            skipIntervalSeconds = preferences.skipIntervalSeconds,
+            skipSilence = preferences.skipSilence,
+            volumeBoost = preferences.volumeBoost.name,
+        )
+    }
+}
+
+/** Seam so tests never touch the real user config directory. */
+interface PlaybackPreferencesStore {
+    val preferences: StateFlow<PlaybackPreferences>
+
+    fun update(transform: (PlaybackPreferences) -> PlaybackPreferences)
+}
+
+/** In-memory store for tests and for the smoke test, which must not write to a real home. */
+class InMemoryPlaybackPreferencesStore(
+    initial: PlaybackPreferences = PlaybackPreferences(),
+) : PlaybackPreferencesStore {
+    private val _preferences = MutableStateFlow(initial)
+    override val preferences: StateFlow<PlaybackPreferences> = _preferences.asStateFlow()
+
+    override fun update(transform: (PlaybackPreferences) -> PlaybackPreferences) {
+        _preferences.value = transform(_preferences.value).sanitised()
+    }
+}
+
+/**
+ * `playback.json` beside the session and window settings, written owner-only through [SecureFiles].
+ *
+ * Loaded once, eagerly, because the engine needs a speed before the first chapter prepares — a lazy
+ * read would apply the saved rate one chapter late. Writes are fire-and-forget and failure is
+ * logged rather than surfaced: losing a remembered skip interval is not worth an error dialog.
+ */
+class FilePlaybackPreferencesStore(
+    private val file: File = defaultFile(),
+) : PlaybackPreferencesStore {
+    private val adapter = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+        .adapter(StoredPlaybackPreferences::class.java)
+
+    private val _preferences = MutableStateFlow(read())
+    override val preferences: StateFlow<PlaybackPreferences> = _preferences.asStateFlow()
+
+    override fun update(transform: (PlaybackPreferences) -> PlaybackPreferences) {
+        val next = transform(_preferences.value).sanitised()
+        if (next == _preferences.value) return
+        _preferences.value = next
+        runCatching { SecureFiles.writeAtomically(file, adapter.toJson(StoredPlaybackPreferences.from(next))) }
+            .onFailure { AppLog.warn("could not write the playback settings file", it) }
+    }
+
+    private fun read(): PlaybackPreferences =
+        runCatching { if (file.isFile) adapter.fromJson(file.readText()) else null }
+            .onFailure { AppLog.warn("could not read the playback settings file", it) }
+            .getOrNull()
+            ?.toPreferences()
+            ?: PlaybackPreferences()
+
+    companion object {
+        fun defaultFile(): File = FileSessionStore.configDir().resolve("playback.json")
+    }
+}
+
+/**
+ * Brings a caller-supplied value back into range.
+ *
+ * Applied on the way *in* rather than only on the way out, so a bad value can never sit in memory
+ * being handed to the engine even if it never reaches disk.
+ */
+internal fun PlaybackPreferences.sanitised(): PlaybackPreferences = copy(
+    speed = PlaybackPreferences.normaliseSpeed(speed),
+    skipIntervalSeconds = PlaybackPreferences.normaliseSkipSeconds(skipIntervalSeconds),
+)

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/di/AppContainer.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/di/AppContainer.kt
@@ -1,8 +1,12 @@
 package dk.perspektiva.ttsroad.desktop.di
 
+import dk.perspektiva.ttsroad.desktop.data.FilePlaybackHistoryStore
+import dk.perspektiva.ttsroad.desktop.data.FilePlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.FileSessionStore
 import dk.perspektiva.ttsroad.desktop.data.FileWindowPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.LibraryCache
+import dk.perspektiva.ttsroad.desktop.data.PlaybackHistoryStore
+import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.RetrofitTtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.data.SessionStore
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadAuthInterceptor
@@ -12,6 +16,7 @@ import dk.perspektiva.ttsroad.desktop.player.GstPlaybackEngine
 import dk.perspektiva.ttsroad.desktop.player.HttpMediaSource
 import dk.perspektiva.ttsroad.desktop.player.JavaSoundPlaybackEngine
 import dk.perspektiva.ttsroad.desktop.player.MediaSourceFactory
+import dk.perspektiva.ttsroad.desktop.player.MprisService
 import dk.perspektiva.ttsroad.desktop.player.PlaybackController
 import dk.perspektiva.ttsroad.desktop.player.PlaybackEngine
 import dk.perspektiva.ttsroad.desktop.player.QueuePlaybackController
@@ -19,7 +24,10 @@ import dk.perspektiva.ttsroad.desktop.security.CredentialStore
 import dk.perspektiva.ttsroad.desktop.security.CredentialStores
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import okhttp3.OkHttpClient
 
 /**
@@ -66,8 +74,24 @@ class AppContainer(
     // A machine with no GStreamer must still get a working app, just without speed control.
     audioEngineFactory: () -> PlaybackEngine =
         { GstPlaybackEngine.createOrNull() ?: JavaSoundPlaybackEngine() },
-    playbackFactory: (TtsRoadRepository, MediaSourceFactory, PlaybackEngine, AppDispatchers) -> PlaybackController =
-        { repo, mediaSources, engine, d -> QueuePlaybackController(repo, mediaSources, engine, d.io) },
+    /**
+     * Listening settings, persisted per machine rather than per account — see
+     * [dk.perspektiva.ttsroad.desktop.data.PlaybackPreferences]. A store rather than a path, so a
+     * test never writes into the user's config directory.
+     */
+    val playbackPreferences: PlaybackPreferencesStore = FilePlaybackPreferencesStore(),
+    val playbackHistory: PlaybackHistoryStore = FilePlaybackHistoryStore(),
+    playbackFactory: (
+        TtsRoadRepository,
+        MediaSourceFactory,
+        PlaybackEngine,
+        AppDispatchers,
+        PlaybackPreferencesStore,
+        PlaybackHistoryStore,
+    ) -> PlaybackController =
+        { repo, mediaSources, engine, d, prefs, history ->
+            QueuePlaybackController(repo, mediaSources, engine, d.io, prefs, history)
+        },
     libraryCacheFactory: (TtsRoadRepository, AppDispatchers, () -> Long) -> LibraryCache =
         { repo, d, now -> LibraryCache(repo, d.main, now) },
     // A store rather than a file path, so a test never writes into the user's config directory.
@@ -77,7 +101,36 @@ class AppContainer(
     val repository: TtsRoadRepository = repositoryFactory(sessionStore, httpClient, dispatchers)
     val mediaSources: MediaSourceFactory = mediaSourceFactory(httpClient, repository)
     val audioEngine: PlaybackEngine = audioEngineFactory()
-    val playback: PlaybackController = playbackFactory(repository, mediaSources, audioEngine, dispatchers)
+    val playback: PlaybackController =
+        playbackFactory(repository, mediaSources, audioEngine, dispatchers, playbackPreferences, playbackHistory)
+
+    /**
+     * The scope MPRIS publishes from. Its own, not the controller's: the bus mirror has to keep
+     * running while a chapter is between jobs, and it is torn down here rather than by whatever
+     * happens to cancel a playback job.
+     */
+    private val mprisScope = CoroutineScope(SupervisorJob() + dispatchers.io)
+
+    @Volatile private var mpris: MprisService? = null
+
+    /**
+     * Puts the player on the session bus, if there is one.
+     *
+     * Called from `main` rather than from the constructor because Raise and Quit need the window,
+     * which does not exist yet when the container is built. A machine with no D-Bus — every
+     * Windows and macOS machine, and a good many Linux ones — silently gets no MPRIS and a fully
+     * working player; see [MprisService.createOrNull].
+     */
+    fun startMpris(onRaise: () -> Unit, onQuit: () -> Unit) {
+        if (mpris != null) return
+        mpris = MprisService.createOrNull(
+            controller = playback,
+            preferences = playbackPreferences,
+            scope = mprisScope,
+            onRaise = onRaise,
+            onQuit = onQuit,
+        )
+    }
 
     /**
      * Library and chapter data, held here rather than inside a screen.
@@ -93,6 +146,11 @@ class AppContainer(
 
     /** Called when the main window closes; without it the playback job and temp file outlive it. */
     override fun close() {
+        // Off the bus before the transport it mirrors goes away, so a panel applet never holds a
+        // name that answers with a half-released player.
+        runCatching { mpris?.close() }
+        mpris = null
+        mprisScope.cancel()
         playback.release()
         libraryCache.close()
         httpClient.dispatcher.executorService.shutdown()

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/nav/Shortcuts.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/nav/Shortcuts.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isAltPressed
 import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 
@@ -19,6 +20,49 @@ enum class AppShortcut {
 
     /** Escape — closes the top dialog or sheet first, and only navigates if there was none. */
     Dismiss,
+
+    /** Space. */
+    PlayPause,
+
+    /** Left — back by the configured skip interval. */
+    SeekBackward,
+
+    /** Right — forward by the configured skip interval. */
+    SeekForward,
+
+    /** Ctrl+Left. */
+    PreviousChapter,
+
+    /** Ctrl+Right. */
+    NextChapter,
+
+    /** Ctrl+L. */
+    OpenLibrary,
+
+    /** Ctrl+comma — the platform convention for preferences. */
+    OpenSettings,
+
+    /** F1 or Ctrl+slash. */
+    ShowShortcuts,
+    ;
+
+    /**
+     * Whether this shortcut may fire while a text field has focus.
+     *
+     * The distinction is the whole requirement: Space, the arrows and Ctrl+arrow are all *text
+     * editing* keys, and a search box that pauses the audiobook instead of typing a space is
+     * broken in a way that is hard to even describe as a bug report. The rest are combinations no
+     * text field claims, and they stay live so F5 still refreshes from inside the search box.
+     *
+     * `App` enforces this structurally as well — the two groups are installed on the preview and
+     * the ordinary key handler respectively — but the classification is here so it can be asserted
+     * without a focused text field and a real toolkit event.
+     */
+    val firesWhileTyping: Boolean
+        get() = when (this) {
+            Back, Refresh, Dismiss, OpenLibrary, OpenSettings, ShowShortcuts -> true
+            PlayPause, SeekBackward, SeekForward, PreviousChapter, NextChapter -> false
+        }
 }
 
 /**
@@ -30,6 +74,8 @@ enum class AppShortcut {
  * UI test on a machine with a display.
  *
  * Key *up* is ignored on purpose: a shortcut that fires on both edges of one press navigates twice.
+ *
+ * [textInputFocused] suppresses the editing-key shortcuts; see [AppShortcut.firesWhileTyping].
  */
 fun shortcutFor(
     key: Key,
@@ -37,15 +83,48 @@ fun shortcutFor(
     alt: Boolean = false,
     ctrl: Boolean = false,
     meta: Boolean = false,
+    shift: Boolean = false,
+    textInputFocused: Boolean = false,
 ): AppShortcut? {
     if (type != KeyEventType.KeyDown) return null
+    val match = match(key, alt, ctrl, meta, shift) ?: return null
+    if (textInputFocused && !match.firesWhileTyping) return null
+    return match
+}
+
+private fun match(key: Key, alt: Boolean, ctrl: Boolean, meta: Boolean, shift: Boolean): AppShortcut? {
+    // The accelerator modifier: Ctrl everywhere, Cmd on macOS. Both are accepted on both, because
+    // guessing the platform from a key event is worse than accepting one extra combination.
+    val accel = ctrl || meta
     return when {
         key == Key.Escape -> AppShortcut.Dismiss
         key == Key.F5 -> AppShortcut.Refresh
-        key == Key.R && (ctrl || meta) -> AppShortcut.Refresh
+        key == Key.F1 -> AppShortcut.ShowShortcuts
+        key == Key.R && accel -> AppShortcut.Refresh
+        key == Key.L && accel -> AppShortcut.OpenLibrary
+        key == Key.Comma && accel -> AppShortcut.OpenSettings
+        key == Key.Slash && accel -> AppShortcut.ShowShortcuts
+
+        // Chapter stepping is checked before plain seeking: Ctrl+Left is a chapter, not a skip.
+        key == Key.DirectionLeft && accel -> AppShortcut.PreviousChapter
+        key == Key.DirectionRight && accel -> AppShortcut.NextChapter
+
+        // Alt+Left stays Back, and is therefore checked before the bare arrow.
         key == Key.DirectionLeft && alt -> AppShortcut.Back
         // The dedicated "browser back" key some keyboards and mice send.
         key == Key.Back -> AppShortcut.Back
+
+        key == Key.DirectionLeft && !shift -> AppShortcut.SeekBackward
+        key == Key.DirectionRight && !shift -> AppShortcut.SeekForward
+        key == Key.Spacebar && !accel && !alt -> AppShortcut.PlayPause
+
+        // The keys a keyboard's transport row sends when the app itself has focus. With no focus
+        // they go to the desktop, which routes them over MPRIS instead — same actions, other door.
+        key == Key.MediaPlayPause || key == Key.MediaPlay || key == Key.MediaPause ->
+            AppShortcut.PlayPause
+        key == Key.MediaNext -> AppShortcut.NextChapter
+        key == Key.MediaPrevious -> AppShortcut.PreviousChapter
+
         else -> null
     }
 }
@@ -66,10 +145,36 @@ fun escapeAction(hasOpenOverlay: Boolean, canGoBack: Boolean): EscapeAction = wh
     else -> EscapeAction.None
 }
 
-fun shortcutFor(event: KeyEvent): AppShortcut? = shortcutFor(
+fun shortcutFor(event: KeyEvent, textInputFocused: Boolean = false): AppShortcut? = shortcutFor(
     key = event.key,
     type = event.type,
     alt = event.isAltPressed,
     ctrl = event.isCtrlPressed,
     meta = event.isMetaPressed,
+    shift = event.isShiftPressed,
+    textInputFocused = textInputFocused,
+)
+
+/** One row of the in-app shortcuts dialog. */
+data class ShortcutHelp(val keys: String, val action: String)
+
+/**
+ * The shortcut table as the help dialog shows it.
+ *
+ * Written out rather than derived from [shortcutFor], because the dialog has to name the
+ * *alternatives* too, and a listing generated from the matcher would either miss them or read like
+ * a decompiled `when`. Kept next to the matcher so the two are edited together.
+ */
+val ShortcutHelpTable: List<ShortcutHelp> = listOf(
+    ShortcutHelp("Space", "Play or pause"),
+    ShortcutHelp("Left / Right", "Skip back or forward by your skip interval"),
+    ShortcutHelp("Ctrl+Left / Ctrl+Right", "Previous or next chapter"),
+    ShortcutHelp("Alt+Left", "Back"),
+    ShortcutHelp("Ctrl+L", "Library"),
+    ShortcutHelp("Ctrl+,", "Settings"),
+    ShortcutHelp("F5 / Ctrl+R", "Refresh the current screen"),
+    ShortcutHelp("Escape", "Close a dialog, or go back"),
+    ShortcutHelp("F1 / Ctrl+/", "This list"),
+    ShortcutHelp("Media keys", "Play/pause, previous and next, also from the desktop"),
+    ShortcutHelp("Tab", "Move between controls"),
 )

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/GstPlaybackEngine.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/GstPlaybackEngine.kt
@@ -47,9 +47,20 @@ class GstPlaybackEngine private constructor(
      * stand in for.
      */
     private val sinkElement: String,
+    /**
+     * Whether `removesilence` could be created here. It lives in `gst-plugins-bad`, which a great
+     * many installs — including this repository's CI — do not carry, so it is probed once at
+     * construction and reported as a capability rather than assumed.
+     */
+    canSkipSilence: Boolean = false,
 ) : PlaybackEngine {
 
-    override val capabilities = EngineCapabilities(variableSpeed = true, speedRange = 0.5f..3.0f)
+    override val capabilities = EngineCapabilities(
+        variableSpeed = true,
+        speedRange = 0.5f..3.0f,
+        volumeBoost = true,
+        skipSilence = canSkipSilence,
+    )
 
     @Volatile private var listener: PlaybackEngineListener? = null
 
@@ -65,8 +76,16 @@ class GstPlaybackEngine private constructor(
     private var pipeline: Pipeline? = null
     private var stream: MediaStream? = null
 
+    /** The `volume` element of the live pipeline, so a gain change does not need a rebuild. */
+    private var volumeElement: Element? = null
+
     /** Survives across chapters: a listener who chose 1.5× means it for the next chapter too. */
     @Volatile private var rate: Float = 1f
+
+    /** Ditto for gain and skip-silence — both are preferences, not properties of a chapter. */
+    @Volatile private var gain: Double = 1.0
+
+    @Volatile private var skipSilence: Boolean = false
 
     /**
      * Once a read or the bus has reported a failure, the end-of-stream that follows is a
@@ -148,6 +167,23 @@ class GstPlaybackEngine private constructor(
         return applied
     }
 
+    override fun setGain(gain: Double) {
+        val clamped = gain.coerceIn(EngineCapabilities.GainRange)
+        this.gain = clamped
+        // Applied live. The `volume` element takes a linear multiplier, which is what the fade
+        // ramp and the boost ladder both already are, so there is no dB conversion to get wrong.
+        synchronized(lock) { volumeElement }?.let { element ->
+            runCatching { element.set("volume", clamped) }
+        }
+    }
+
+    override fun setSkipSilence(enabled: Boolean) {
+        // Deliberately not applied to the live pipeline: inserting or removing an element under a
+        // playing stream means a state change and a re-link, and the audible glitch is worse than
+        // the toggle taking effect at the next chapter. Documented on the interface.
+        skipSilence = enabled && capabilities.skipSilence
+    }
+
     override fun positionMs(): Long {
         val current = synchronized(lock) { pipeline } ?: return 0
         return current.queryPosition(Format.TIME).takeIf { it > 0 }?.div(NANOS_PER_MILLI) ?: 0
@@ -194,13 +230,33 @@ class GstPlaybackEngine private constructor(
         val tempo = ElementFactory.make("scaletempo", "tempo")
         val convertOut = ElementFactory.make("audioconvert", "convert-out")
         val resample = ElementFactory.make("audioresample", "resample")
+        val volume = ElementFactory.make("volume", "volume").apply {
+            runCatching { set("volume", gain) }
+        }
         // autoaudiosink resolves to pulsesink on Mint, which is also what PipeWire presents, so
         // PipeWire and PulseAudio are one code path. It also re-resolves the default device.
         val sink = ElementFactory.make(sinkElement, "sink")
 
-        pipeline.addMany(src, decode, convertIn, tempo, convertOut, resample, sink)
+        // Silence removal sits *before* scaletempo: dropping buffers changes the timeline, and
+        // doing it after the tempo scaler would make the rate apply to a stream whose length has
+        // already changed underneath it. Absent unless the install has the element and the
+        // listener asked for it.
+        val silence = if (skipSilence && capabilities.skipSilence) makeSilenceRemover() else null
+
+        val chain = buildList {
+            add(convertIn)
+            silence?.let(::add)
+            add(tempo)
+            add(convertOut)
+            add(resample)
+            add(volume)
+            add(sink)
+        }.toTypedArray()
+
+        pipeline.addMany(src, decode, *chain)
         src.link(decode)
-        Element.linkMany(convertIn, tempo, convertOut, resample, sink)
+        Element.linkMany(*chain)
+        synchronized(lock) { volumeElement = volume }
         // decodebin cannot expose its audio pad until it has sniffed the container.
         decode.connect(
             Element.PAD_ADDED { _, pad ->
@@ -240,6 +296,27 @@ class GstPlaybackEngine private constructor(
         )
         return pipeline
     }
+
+    /**
+     * `removesilence`, tuned so it drops dead air rather than the pauses that carry meaning.
+     *
+     * Every property is set defensively. The element's properties have changed across
+     * `plugins-bad` releases, and an engine that refuses to build because one tuning knob was
+     * renamed would take the whole chapter down with it — the default for any property that does
+     * not exist here is the element's own, which is serviceable.
+     */
+    private fun makeSilenceRemover(): Element? = runCatching {
+        ElementFactory.make(SKIP_SILENCE_ELEMENT, "silence").apply {
+            // The only property that matters: without it the element measures silence and
+            // announces it on the bus, but passes every buffer through unchanged.
+            set("remove", true)
+            // A tenth of a second below -50 dB is dead air. A shorter window would clip the stops
+            // between sentences, which is what makes badly-tuned silence removal sound rushed.
+            runCatching { set("threshold", SILENCE_THRESHOLD_DB) }
+            runCatching { set("minimum-silence-time", SILENCE_MIN_NANOS) }
+            runCatching { set("squash", true) }
+        }
+    }.getOrNull()
 
     private fun feed(src: AppSrc, stream: MediaStream, buffer: ByteArray, requested: Int) {
         try {
@@ -282,6 +359,9 @@ class GstPlaybackEngine private constructor(
             val s = stream
             pipeline = null
             stream = null
+            // Belongs to the pipeline being disposed; holding it would hand `setGain` a pointer
+            // into freed native memory.
+            volumeElement = null
             p to s
         }
         oldPipeline?.let {
@@ -303,10 +383,19 @@ class GstPlaybackEngine private constructor(
         private const val READ_CHUNK_BYTES = 64 * 1024
         private const val APPSRC_MAX_BYTES = 2L * 1024 * 1024
 
+        private const val SILENCE_THRESHOLD_DB = -50
+        private const val SILENCE_MIN_NANOS = 100_000_000L
+
         /** Every element the pipeline names. A missing one means fall back, not crash. */
         private val REQUIRED_ELEMENTS = listOf(
-            "appsrc", "decodebin", "audioconvert", "scaletempo", "audioresample",
+            "appsrc", "decodebin", "audioconvert", "scaletempo", "audioresample", "volume",
         )
+
+        /**
+         * The optional one. In `gst-plugins-bad`, so its absence is the normal case and gates the
+         * [EngineCapabilities.skipSilence] flag rather than the engine.
+         */
+        private const val SKIP_SILENCE_ELEMENT = "removesilence"
 
         @Volatile private var initialised: Boolean? = null
 
@@ -321,7 +410,10 @@ class GstPlaybackEngine private constructor(
         fun createOrNull(sinkElement: String = "autoaudiosink"): GstPlaybackEngine? = runCatching {
             if (!ensureInitialised()) return@runCatching null
             if (!hasEveryElement(REQUIRED_ELEMENTS + sinkElement)) return@runCatching null
-            GstPlaybackEngine(sinkElement)
+            GstPlaybackEngine(
+                sinkElement = sinkElement,
+                canSkipSilence = hasEveryElement(listOf(SKIP_SILENCE_ELEMENT)),
+            )
         }.getOrNull()
 
         /** Whether this machine can run the GStreamer backend at all. */

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/JavaSoundPlaybackEngine.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/JavaSoundPlaybackEngine.kt
@@ -26,7 +26,18 @@ class JavaSoundPlaybackEngine(
     private val engine: AudioEngine = JavaSoundAudioEngine(),
 ) : PlaybackEngine {
 
-    override val capabilities = EngineCapabilities.FixedSpeed
+    /**
+     * No rate control and no silence removal, but gain *is* honoured — see [applyGain].
+     *
+     * That asymmetry is deliberate. Speed needs a resampler this backend does not have, but gain
+     * is a multiply over PCM this loop is already copying, and the sleep timer's fade depends on
+     * it working everywhere.
+     */
+    override val capabilities = EngineCapabilities(
+        variableSpeed = false,
+        volumeBoost = true,
+        skipSilence = false,
+    )
 
     @Volatile private var listener: PlaybackEngineListener? = null
 
@@ -47,6 +58,10 @@ class JavaSoundPlaybackEngine(
     @Volatile private var positionMs: Long = 0
     @Volatile private var wantsPlaying = false
     @Volatile private var seekRequestMs: Long? = null
+
+    /** Boost × fade, as one multiplier. Survives across chapters, like the GStreamer engine's. */
+    @Volatile private var gain: Double = 1.0
+
     private val stopping = AtomicBoolean(false)
 
     override fun prepare(source: MediaSource, startPositionMs: Long) {
@@ -95,6 +110,10 @@ class JavaSoundPlaybackEngine(
 
     /** Always 1.0: this backend has no rate control, and saying so is the point. */
     override fun setRate(rate: Float): Float = 1f
+
+    override fun setGain(gain: Double) {
+        this.gain = gain.coerceIn(EngineCapabilities.GainRange)
+    }
 
     override fun positionMs(): Long = positionMs
 
@@ -180,6 +199,7 @@ class JavaSoundPlaybackEngine(
                     if (!stopping.get()) emit(EngineEvent.Completed)
                     return
                 }
+                applyGain(buffer, n, gain, activeFormat)
                 line.write(buffer, 0, n)
                 bytesPlayed += n
                 positionMs = bytesToMs(bytesPlayed, activeFormat)
@@ -210,6 +230,37 @@ class JavaSoundPlaybackEngine(
         return target
     }
 
+    /**
+     * Scales [length] bytes of PCM in place by [gain], saturating instead of wrapping.
+     *
+     * Saturation is the whole reason this is hand-written rather than a `MASTER_GAIN` control:
+     * an overflowing 16-bit sample wraps from full positive to full negative, which is not "loud",
+     * it is a click on every peak. `MASTER_GAIN` also has a device-dependent range that is
+     * frequently absent altogether, so a fade built on it would silently do nothing on some
+     * machines — the one outcome the sleep timer cannot have.
+     *
+     * Anything that is not 16-bit signed PCM is left alone. [JavaSoundAudioEngine] always decodes
+     * to that, but [AudioEngine] is a seam and a substitute is not required to.
+     */
+    private fun applyGain(buffer: ByteArray, length: Int, gain: Double, format: AudioFormat) {
+        if (gain == 1.0) return
+        if (format.sampleSizeInBits != 16 || format.encoding != AudioFormat.Encoding.PCM_SIGNED) return
+
+        val bigEndian = format.isBigEndian
+        var i = 0
+        while (i + 1 < length) {
+            val lowIndex = if (bigEndian) i + 1 else i
+            val highIndex = if (bigEndian) i else i + 1
+            // The high byte keeps Byte.toInt()'s sign extension, so the shift rebuilds a signed
+            // 16-bit value without a separate sign fix-up.
+            val sample = (buffer[highIndex].toInt() shl 8) or (buffer[lowIndex].toInt() and 0xFF)
+            val scaled = (sample * gain).toInt().coerceIn(MIN_SAMPLE, MAX_SAMPLE)
+            buffer[lowIndex] = (scaled and 0xFF).toByte()
+            buffer[highIndex] = ((scaled shr 8) and 0xFF).toByte()
+            i += 2
+        }
+    }
+
     private fun durationOf(stream: AudioInputStream): Long {
         val frames = stream.frameLength
         if (frames <= 0) return 0
@@ -233,5 +284,7 @@ class JavaSoundPlaybackEngine(
     private companion object {
         const val PAUSE_POLL_MILLIS = 80L
         const val STOP_JOIN_MILLIS = 2_000L
+        const val MIN_SAMPLE = -32_768
+        const val MAX_SAMPLE = 32_767
     }
 }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/MprisService.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/MprisService.kt
@@ -1,0 +1,379 @@
+package dk.perspektiva.ttsroad.desktop.player
+
+import dk.perspektiva.ttsroad.desktop.data.AppLog
+import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.VolumeBoost
+import org.freedesktop.dbus.DBusPath
+import org.freedesktop.dbus.annotations.DBusInterfaceName
+import org.freedesktop.dbus.connections.impl.DBusConnection
+import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder
+import org.freedesktop.dbus.interfaces.DBusInterface
+import org.freedesktop.dbus.interfaces.Properties
+import org.freedesktop.dbus.messages.DBusSignal
+import org.freedesktop.dbus.types.Variant
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+
+/**
+ * `org.mpris.MediaPlayer2` — Raise and Quit, and the flags saying whether they work.
+ *
+ * Method names are capitalised because D-Bus member names are, and dbus-java derives them from the
+ * Kotlin/Java method name directly.
+ */
+@DBusInterfaceName(Mpris.RootInterface)
+interface MprisRoot : DBusInterface {
+    fun Raise()
+    fun Quit()
+}
+
+/** `org.mpris.MediaPlayer2.Player` — the transport the panel applet and the media keys drive. */
+@DBusInterfaceName(Mpris.PlayerInterface)
+interface MprisPlayer : DBusInterface {
+    fun Next()
+    fun Previous()
+    fun Pause()
+    fun PlayPause()
+    fun Stop()
+    fun Play()
+
+    /** Relative, in microseconds; negative seeks backwards. */
+    fun Seek(offsetMicros: Long)
+
+    /** Absolute, in microseconds, for a track the caller last saw. */
+    fun SetPosition(trackId: DBusPath, positionMicros: Long)
+
+    fun OpenUri(uri: String)
+
+    /**
+     * Emitted when the position jumps for a reason the client did not cause.
+     *
+     * Without it a panel applet's progress bar keeps interpolating from where it thought it was,
+     * so a ±30 s skip in the app shows up as a bar that is wrong until the next poll.
+     */
+    class Seeked(path: String, positionMicros: Long) : DBusSignal(path, positionMicros)
+}
+
+/**
+ * The MPRIS presence: one exported object answering both interfaces plus `Properties`.
+ *
+ * Everything here is best-effort by construction. [createOrNull] returns null when there is no
+ * session bus — a headless box, a `su` shell, macOS, Windows — and every callback into the
+ * controller is wrapped, because a media player that fails to start because the desktop's media
+ * applet is absent would be a worse bug than having no applet integration at all.
+ *
+ * Threading: dbus-java calls these methods on its own reader thread, so they land on the engine
+ * from a third thread alongside the Compose thread and the controller's own scope. That is already
+ * the situation the engine implementations are written for — both of the real ones synchronise
+ * their transport internally — and nothing here holds a lock while calling out.
+ */
+class MprisService private constructor(
+    private val connection: DBusConnection,
+    private val busName: String,
+    private val controller: PlaybackController,
+    private val preferences: PlaybackPreferencesStore,
+    private val onRaise: () -> Unit,
+    private val onQuit: () -> Unit,
+) : AutoCloseable {
+
+    private var publisher: Job? = null
+
+    /** The exported object. One instance answers root, player and properties at the same path. */
+    private inner class ExportedPlayer : MprisRoot, MprisPlayer, Properties {
+
+        override fun getObjectPath(): String = Mpris.ObjectPath
+
+        override fun Raise() = guard { onRaise() }
+
+        override fun Quit() = guard { onQuit() }
+
+        override fun Next() = guard { controller.skipToNextChapter() }
+
+        override fun Previous() = guard { controller.skipToPreviousChapter() }
+
+        override fun Pause() = guard {
+            if (controller.state.value.isPlaying) controller.togglePlayPause()
+        }
+
+        override fun Play() = guard {
+            val current = controller.state.value
+            if (current.hasMedia && !current.isPlaying) controller.togglePlayPause()
+        }
+
+        override fun PlayPause() = guard { controller.togglePlayPause() }
+
+        override fun Stop() = guard { controller.stop() }
+
+        override fun Seek(offsetMicros: Long) = guard {
+            controller.skipBy(offsetMicros / Mpris.MicrosPerMilli)
+        }
+
+        override fun SetPosition(trackId: DBusPath, positionMicros: Long) = guard {
+            // A stale track id means the chapter changed since the client read it; honouring it
+            // would seek the new chapter to the old one's offset.
+            if (Mpris.acceptsSeekFor(controller.state.value, trackId.path)) {
+                controller.seekTo(positionMicros / Mpris.MicrosPerMilli)
+            }
+        }
+
+        /**
+         * Not supported, and it says so by doing nothing.
+         *
+         * Every URI this player can open is bearer-protected and belongs to the signed-in server;
+         * accepting an arbitrary one from the session bus would be an open redirect into the
+         * authenticated client.
+         */
+        override fun OpenUri(uri: String) = Unit
+
+        /**
+         * Returns the [Variant] itself, **not** `variant.value`.
+         *
+         * `Get` is declared to return `v`, and dbus-java re-wraps a bare value in an *unqualified*
+         * Variant — which throws for `Metadata`, whose `a{sv}` signature only exists because
+         * [playerProperties] attached it. Handing back the already-qualified Variant keeps the
+         * signature all the way to the wire. `GetAll` never had the problem: its return type is
+         * `a{sv}` and the Variants survive in the map.
+         */
+        @Suppress("UNCHECKED_CAST")
+        override fun <A : Any?> Get(interfaceName: String, propertyName: String): A =
+            allProperties(interfaceName)[propertyName] as A
+
+        override fun <A : Any?> Set(interfaceName: String, propertyName: String, value: A) = guard {
+            when (propertyName) {
+                "Rate" -> (value as? Double)?.let { controller.setSpeed(it.toFloat()) }
+                // The shell's slider is continuous and the app's boost is a four-step ladder, so
+                // this snaps. Reporting the snapped value back (below) is what keeps the slider
+                // from drifting away from what is actually being played.
+                "Volume" -> (value as? Double)?.let { requested ->
+                    val nearest = VolumeBoost.entries.minByOrNull { kotlin.math.abs(it.gain - requested) }
+                    if (nearest != null) preferences.update { it.copy(volumeBoost = nearest) }
+                }
+                else -> Unit
+            }
+        }
+
+        override fun GetAll(interfaceName: String): Map<String, Variant<*>> = allProperties(interfaceName)
+    }
+
+    private val exported = ExportedPlayer()
+
+    private fun allProperties(interfaceName: String): Map<String, Variant<*>> =
+        when (interfaceName) {
+            Mpris.RootInterface -> rootProperties()
+            Mpris.PlayerInterface -> playerProperties()
+            else -> emptyMap()
+        }
+
+    private fun rootProperties(): Map<String, Variant<*>> = mapOf(
+        "CanQuit" to Variant(true),
+        "CanRaise" to Variant(true),
+        "HasTrackList" to Variant(false),
+        "Identity" to Variant(Mpris.Identity),
+        "DesktopEntry" to Variant(Mpris.DesktopEntry),
+        // Empty, and deliberately so: OpenUri is not implemented, and advertising a scheme the
+        // player will silently ignore is how a file manager ends up "opening" audio into nothing.
+        "SupportedUriSchemes" to Variant(emptyList<String>(), "as"),
+        "SupportedMimeTypes" to Variant(emptyList<String>(), "as"),
+    )
+
+    private fun playerProperties(): Map<String, Variant<*>> {
+        val state = controller.state.value
+        val track = Mpris.trackOf(state)
+        return mapOf(
+            "PlaybackStatus" to Variant(Mpris.statusOf(state).wireName),
+            "LoopStatus" to Variant("None"),
+            "Rate" to Variant(state.speed.toDouble()),
+            "Shuffle" to Variant(false),
+            "Metadata" to Variant(metadataOf(track), "a{sv}"),
+            "Volume" to Variant(preferences.preferences.value.volumeBoost.gain),
+            "Position" to Variant(Mpris.positionMicros(state)),
+            // A backend with no rate control reports a degenerate range rather than a range it
+            // cannot honour, so a client that offers a rate slider does not offer a dead one.
+            "MinimumRate" to Variant(if (state.canChangeSpeed) MinRate else 1.0),
+            "MaximumRate" to Variant(if (state.canChangeSpeed) MaxRate else 1.0),
+            "CanGoNext" to Variant(state.hasNext),
+            "CanGoPrevious" to Variant(state.hasPrevious),
+            "CanPlay" to Variant(state.hasMedia),
+            "CanPause" to Variant(state.hasMedia),
+            "CanSeek" to Variant(state.hasMedia && state.durationMs > 0),
+            "CanControl" to Variant(true),
+        )
+    }
+
+    private fun metadataOf(track: MprisTrack?): Map<String, Variant<*>> {
+        if (track == null) {
+            // The spec's "nothing loaded" shape: a valid trackid and nothing else. An empty map
+            // makes some shells keep displaying the previous track indefinitely.
+            return mapOf("mpris:trackid" to Variant(DBusPath(Mpris.NoTrackPath), "o"))
+        }
+        return buildMap {
+            put("mpris:trackid", Variant(DBusPath(track.trackId), "o"))
+            put("xesam:title", Variant(track.title))
+            put("mpris:length", Variant(track.lengthMicros))
+            track.album?.takeIf { it.isNotBlank() }?.let { put("xesam:album", Variant(it)) }
+            if (track.artists.isNotEmpty()) {
+                put("xesam:artist", Variant(ArrayList(track.artists), "as"))
+            }
+            track.artUrl?.takeIf { it.isNotBlank() }?.let { put("mpris:artUrl", Variant(it)) }
+        }
+    }
+
+    /**
+     * Starts mirroring [PlaybackController.state] onto the bus.
+     *
+     * Only the properties that actually changed are announced. `Position` is deliberately never in
+     * a `PropertiesChanged` — the spec excludes it, because a player emitting it on every tick is
+     * a signal storm — so a discontinuity is reported as `Seeked` instead and clients interpolate
+     * between the two.
+     */
+    private fun startPublishing(scope: CoroutineScope) {
+        publisher = scope.launch {
+            var previous: PlayerUiState? = null
+            controller.state.collect { state ->
+                val last = previous
+                previous = state
+                if (last == null) return@collect
+
+                val changed = changedProperties(last, state)
+                if (changed.isNotEmpty()) emitPropertiesChanged(changed)
+                if (isDiscontinuity(last, state)) emitSeeked(Mpris.positionMicros(state))
+            }
+        }
+    }
+
+    private fun changedProperties(before: PlayerUiState, after: PlayerUiState): Map<String, Variant<*>> {
+        val all = playerProperties()
+        return buildMap {
+            if (Mpris.statusOf(before) != Mpris.statusOf(after)) {
+                all["PlaybackStatus"]?.let { put("PlaybackStatus", it) }
+            }
+            if (Mpris.trackOf(before) != Mpris.trackOf(after)) {
+                all["Metadata"]?.let { put("Metadata", it) }
+            }
+            if (before.speed != after.speed) all["Rate"]?.let { put("Rate", it) }
+            if (before.hasNext != after.hasNext) all["CanGoNext"]?.let { put("CanGoNext", it) }
+            if (before.hasPrevious != after.hasPrevious) {
+                all["CanGoPrevious"]?.let { put("CanGoPrevious", it) }
+            }
+            if (before.hasMedia != after.hasMedia) {
+                all["CanPlay"]?.let { put("CanPlay", it) }
+                all["CanPause"]?.let { put("CanPause", it) }
+                all["CanSeek"]?.let { put("CanSeek", it) }
+            }
+        }
+    }
+
+    /**
+     * Whether the position moved by more than playback alone explains.
+     *
+     * The tick is 250 ms and the rate tops out at 3×, so anything past a second is a seek, a skip,
+     * or a chapter change rather than time passing.
+     */
+    private fun isDiscontinuity(before: PlayerUiState, after: PlayerUiState): Boolean {
+        if (!after.hasMedia) return false
+        if (before.currentIndex != after.currentIndex) return true
+        val delta = after.positionMs - before.positionMs
+        return delta < 0 || delta > DiscontinuityMs
+    }
+
+    private fun emitPropertiesChanged(changed: Map<String, Variant<*>>) {
+        runCatching {
+            connection.sendMessage(
+                Properties.PropertiesChanged(
+                    Mpris.ObjectPath,
+                    Mpris.PlayerInterface,
+                    changed,
+                    emptyList(),
+                ),
+            )
+        }.onFailure { AppLog.warn("could not publish an MPRIS property change", it) }
+    }
+
+    private fun emitSeeked(positionMicros: Long) {
+        runCatching { connection.sendMessage(MprisPlayer.Seeked(Mpris.ObjectPath, positionMicros)) }
+            .onFailure { AppLog.warn("could not publish an MPRIS seek", it) }
+    }
+
+    /**
+     * Runs [body], swallowing anything it throws.
+     *
+     * An exception escaping into dbus-java's reader thread is returned to the caller as a D-Bus
+     * error and, worse, can take the thread down — which would silently end MPRIS for the rest of
+     * the session. Nothing the applet asks for is important enough to risk that.
+     */
+    private inline fun guard(body: () -> Unit) {
+        runCatching { body() }.onFailure { AppLog.warn("an MPRIS request failed", it) }
+    }
+
+    override fun close() {
+        publisher?.cancel()
+        runCatching { connection.unExportObject(Mpris.ObjectPath) }
+        runCatching { connection.releaseBusName(busName) }
+        runCatching { connection.disconnect() }
+    }
+
+    companion object {
+        private const val MinRate = 0.5
+        private const val MaxRate = 3.0
+        private const val DiscontinuityMs = 1_500L
+
+        /**
+         * Connects to the session bus and exports the player, or returns null.
+         *
+         * Null is a normal outcome, not a failure: there is no session bus on Windows or macOS, in
+         * a bare SSH session, or under some sandboxes. The diagnostic goes to [AppLog] so a
+         * developer can see *why* the panel shows nothing, and the app carries on with a fully
+         * working player that simply is not on the bus.
+         */
+        fun createOrNull(
+            controller: PlaybackController,
+            preferences: PlaybackPreferencesStore,
+            scope: CoroutineScope,
+            onRaise: () -> Unit = {},
+            onQuit: () -> Unit = {},
+        ): MprisService? {
+            // Catching Throwable, not Exception: a missing transport provider surfaces as a
+            // ServiceConfigurationError, and an incompatible JDK as a LinkageError. Neither is an
+            // Exception, and either would otherwise abort startup.
+            return runCatching {
+                val connection = DBusConnectionBuilder.forSessionBus().build()
+                val busName = claimBusName(connection)
+                    ?: run {
+                        runCatching { connection.disconnect() }
+                        return@runCatching null
+                    }
+                val service = MprisService(connection, busName, controller, preferences, onRaise, onQuit)
+                connection.exportObject(Mpris.ObjectPath, service.exported)
+                service.startPublishing(scope)
+                service
+            }.getOrElse { error ->
+                AppLog.warn("no MPRIS integration on this desktop (${error.javaClass.simpleName})", error)
+                null
+            }
+        }
+
+        /**
+         * Takes `org.mpris.MediaPlayer2.TTSRoad`, or the spec's per-instance variant if a second
+         * copy of the app already holds it.
+         *
+         * Two windows both publishing under one name would fight over the panel's display, which
+         * is exactly what the `.instanceN` suffix in the MPRIS spec exists to prevent.
+         */
+        private fun claimBusName(connection: DBusConnection): String? {
+            val preferred = "${Mpris.BusNamePrefix}.${Mpris.Identity}"
+            runCatching {
+                connection.requestBusName(preferred)
+                return preferred
+            }
+            val instance = "$preferred.instance${ProcessHandle.current().pid()}"
+            return runCatching {
+                connection.requestBusName(instance)
+                instance
+            }.getOrElse {
+                AppLog.warn("could not claim an MPRIS bus name", it)
+                null
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/MprisService.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/MprisService.kt
@@ -229,39 +229,41 @@ class MprisService private constructor(
      */
     private fun startPublishing(scope: CoroutineScope) {
         publisher = scope.launch {
-            var previous: PlayerUiState? = null
-            controller.state.collect { state ->
-                val last = previous
-                previous = state
-                if (last == null) return@collect
+            launch {
+                var previous: PlayerUiState? = null
+                controller.state.collect { state ->
+                    val last = previous
+                    previous = state
+                    if (last == null) return@collect
 
-                val changed = changedProperties(last, state)
-                if (changed.isNotEmpty()) emitPropertiesChanged(changed)
-                if (isDiscontinuity(last, state)) emitSeeked(Mpris.positionMicros(state))
+                    val changed = changedProperties(last, state)
+                    if (changed.isNotEmpty()) emitPropertiesChanged(changed)
+                    if (isDiscontinuity(last, state)) emitSeeked(Mpris.positionMicros(state))
+                }
+            }
+
+            // Volume is the one published property that does not live in PlayerUiState, so the
+            // state collector above can never see it change. Without this a shell that asks for a
+            // continuous 1.5 keeps displaying 1.5 while playback actually uses the snapped 1.6 —
+            // and a boost changed in Settings never reaches the panel at all.
+            launch {
+                var previous: VolumeBoost? = null
+                preferences.preferences.collect { current ->
+                    val last = previous
+                    previous = current.volumeBoost
+                    if (last == null || last == current.volumeBoost) return@collect
+                    emitPropertiesChanged(mapOf("Volume" to Variant(current.volumeBoost.gain)))
+                }
             }
         }
     }
 
+    /** Names from the pure mapping, paired with the current wire values. */
     private fun changedProperties(before: PlayerUiState, after: PlayerUiState): Map<String, Variant<*>> {
+        val names = Mpris.changedPropertyNames(before, after)
+        if (names.isEmpty()) return emptyMap()
         val all = playerProperties()
-        return buildMap {
-            if (Mpris.statusOf(before) != Mpris.statusOf(after)) {
-                all["PlaybackStatus"]?.let { put("PlaybackStatus", it) }
-            }
-            if (Mpris.trackOf(before) != Mpris.trackOf(after)) {
-                all["Metadata"]?.let { put("Metadata", it) }
-            }
-            if (before.speed != after.speed) all["Rate"]?.let { put("Rate", it) }
-            if (before.hasNext != after.hasNext) all["CanGoNext"]?.let { put("CanGoNext", it) }
-            if (before.hasPrevious != after.hasPrevious) {
-                all["CanGoPrevious"]?.let { put("CanGoPrevious", it) }
-            }
-            if (before.hasMedia != after.hasMedia) {
-                all["CanPlay"]?.let { put("CanPlay", it) }
-                all["CanPause"]?.let { put("CanPause", it) }
-                all["CanSeek"]?.let { put("CanSeek", it) }
-            }
-        }
+        return names.mapNotNull { name -> all[name]?.let { name to it } }.toMap()
     }
 
     /**

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/MprisState.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/MprisState.kt
@@ -100,6 +100,36 @@ object Mpris {
     fun positionMicros(state: PlayerUiState): Long =
         state.positionMs.coerceAtLeast(0L) * MicrosPerMilli
 
+    /** `CanSeek`: seeking needs a known duration, not merely a loaded chapter. */
+    fun canSeek(state: PlayerUiState): Boolean = state.hasMedia && state.durationMs > 0
+
+    /**
+     * Which player properties a state transition should announce.
+     *
+     * Pure, and here rather than in [MprisService], because *which* transitions are worth a signal
+     * is the interesting decision and the plumbing needs a session bus to instantiate. The two easy
+     * mistakes it exists to pin down:
+     *
+     * - `CanSeek` is not a function of `hasMedia`. A chapter whose API metadata carries no duration
+     *   starts unseekable and becomes seekable when the engine reports one, with `hasMedia`
+     *   unchanged the whole time. Clients cache these flags, so missing that edge leaves seeking
+     *   greyed out for the entire chapter.
+     * - `Position` is never here. The spec excludes it from `PropertiesChanged`; a discontinuity is
+     *   a `Seeked` signal instead.
+     */
+    fun changedPropertyNames(before: PlayerUiState, after: PlayerUiState): Set<String> = buildSet {
+        if (statusOf(before) != statusOf(after)) add("PlaybackStatus")
+        if (trackOf(before) != trackOf(after)) add("Metadata")
+        if (before.speed != after.speed) add("Rate")
+        if (before.hasNext != after.hasNext) add("CanGoNext")
+        if (before.hasPrevious != after.hasPrevious) add("CanGoPrevious")
+        if (before.hasMedia != after.hasMedia) {
+            add("CanPlay")
+            add("CanPause")
+        }
+        if (canSeek(before) != canSeek(after)) add("CanSeek")
+    }
+
     /**
      * Whether a seek request is worth honouring.
      *

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/MprisState.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/MprisState.kt
@@ -1,0 +1,112 @@
+package dk.perspektiva.ttsroad.desktop.player
+
+/**
+ * MPRIS `PlaybackStatus`, which is a closed set of three strings on the wire.
+ *
+ * Modelled rather than inlined because the mapping from [PlayerUiState] is the part worth testing,
+ * and a test that asserts on an enum is not also asserting on a spelling.
+ */
+enum class MprisPlaybackStatus(val wireName: String) {
+    Playing("Playing"),
+    Paused("Paused"),
+    Stopped("Stopped"),
+}
+
+/**
+ * The subset of `xesam:`/`mpris:` metadata this player publishes, as plain Kotlin.
+ *
+ * Deliberately free of any D-Bus type. The mapping below is the interesting half of MPRIS — an
+ * audiobook chapter is not a song, and deciding that the *chapter* is the title while the *serial*
+ * is the album is a product decision that should be unit-tested on a machine with no session bus.
+ * Converting this to `Variant`s is mechanical and lives in [MprisService].
+ */
+data class MprisTrack(
+    /** A D-Bus object path, because that is what `mpris:trackid` is typed as. */
+    val trackId: String,
+    val title: String,
+    val album: String?,
+    val artists: List<String>,
+    /** `mpris:length`, in **microseconds** — MPRIS's unit throughout, and not the app's. */
+    val lengthMicros: Long,
+    val artUrl: String?,
+)
+
+object Mpris {
+    const val BusNamePrefix: String = "org.mpris.MediaPlayer2"
+    const val ObjectPath: String = "/org/mpris/MediaPlayer2"
+    const val RootInterface: String = "org.mpris.MediaPlayer2"
+    const val PlayerInterface: String = "org.mpris.MediaPlayer2.Player"
+
+    /** What the desktop shows as the application's name. */
+    const val Identity: String = "TTSRoad"
+
+    /**
+     * Ties the MPRIS entry to the installed `.desktop` file, which is where Cinnamon's applet
+     * takes the icon from. It is the basename without `.desktop`; the Linux packaging in phase 9
+     * (#3) installs `TTSRoad.desktop` under that name.
+     */
+    const val DesktopEntry: String = "TTSRoad"
+
+    /** The spec's placeholder path for "nothing is loaded". */
+    const val NoTrackPath: String = "/org/mpris/MediaPlayer2/TrackList/NoTrack"
+
+    private const val TrackPathPrefix: String = "/dk/perspektiva/ttsroad/chapter/"
+
+    const val MicrosPerMilli: Long = 1_000L
+
+    /**
+     * A valid object path for [chapterId].
+     *
+     * Object paths admit only `[A-Za-z0-9_]` between slashes, so a non-positive or otherwise
+     * unusable id becomes [NoTrackPath] rather than an malformed path — sending one of those makes
+     * the whole `Metadata` property fail to marshal, which takes the applet's display with it.
+     */
+    fun trackPath(chapterId: Int): String =
+        if (chapterId > 0) "$TrackPathPrefix$chapterId" else NoTrackPath
+
+    fun statusOf(state: PlayerUiState): MprisPlaybackStatus = when {
+        !state.hasMedia -> MprisPlaybackStatus.Stopped
+        state.isPlaying -> MprisPlaybackStatus.Playing
+        else -> MprisPlaybackStatus.Paused
+    }
+
+    /**
+     * The loaded chapter as MPRIS metadata, or null when nothing is loaded.
+     *
+     * The audiobook mapping, which is the decision this function exists to record:
+     * - `xesam:title` is the **chapter**, because that is what the panel shows in one line;
+     * - `xesam:album` is the **serial**, which is what an album is;
+     * - `xesam:artist` is also the serial. There is no author in the mobile API's payload, and an
+     *   empty artist renders as a dangling separator in several shells, so repeating the serial
+     *   reads better than a blank. It is a display choice, not a claim about authorship.
+     */
+    fun trackOf(state: PlayerUiState): MprisTrack? {
+        if (!state.hasMedia) return null
+        val chapterId = state.queue.getOrNull(state.currentIndex)?.chapterId ?: 0
+        return MprisTrack(
+            trackId = trackPath(chapterId),
+            title = state.title,
+            album = state.fictionTitle,
+            artists = listOfNotNull(state.fictionTitle?.takeIf { it.isNotBlank() }),
+            lengthMicros = state.durationMs.coerceAtLeast(0L) * MicrosPerMilli,
+            // The cover is served unauthenticated, and the session bus is the user's own login
+            // session — the same place the window itself is drawn. It does name the private
+            // server's host to other processes in that session, which is the cost of the desktop
+            // being able to draw artwork at all; nothing authenticating travels with it.
+            artUrl = state.coverImageUrl,
+        )
+    }
+
+    fun positionMicros(state: PlayerUiState): Long =
+        state.positionMs.coerceAtLeast(0L) * MicrosPerMilli
+
+    /**
+     * Whether a seek request is worth honouring.
+     *
+     * MPRIS clients send absolute positions for a track id they last saw, and a stale id means the
+     * chapter changed under them — applying it would seek the *new* chapter to the old one's
+     * offset.
+     */
+    fun acceptsSeekFor(state: PlayerUiState, trackId: String): Boolean =
+        state.hasMedia && trackId == trackOf(state)?.trackId
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackController.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackController.kt
@@ -41,6 +41,15 @@ data class PlayerUiState(
      * from showing a control that did nothing was not drawing one at all.
      */
     val canChangeSpeed: Boolean = false,
+    /**
+     * Whether this backend can drop silent passages.
+     *
+     * Same rule as [canChangeSpeed]: the control is drawn only where the engine can honour it.
+     */
+    val canSkipSilence: Boolean = false,
+    /** The skip preference, resolved to milliseconds, so the transport buttons can label themselves. */
+    val skipIntervalMs: Long = 30_000L,
+    val sleepTimer: SleepTimerState = SleepTimerState(),
     val error: String? = null,
     /** Set when playback stopped for a reason another attempt could plausibly fix. */
     val canRetry: Boolean = false,
@@ -87,6 +96,17 @@ interface PlaybackController {
 
     fun skipBy(deltaMs: Long)
 
+    /**
+     * Skips by the listener's configured interval.
+     *
+     * The interval lives here rather than in the button that calls it, so the player, the
+     * now-playing bar, the keyboard shortcut and a media key all move by the same amount without
+     * each having to read the preference for itself.
+     */
+    fun skipForward() = skipBy(DefaultSkipMs)
+
+    fun skipBackward() = skipBy(-DefaultSkipMs)
+
     fun skipToNextChapter()
 
     fun skipToPreviousChapter()
@@ -95,6 +115,17 @@ interface PlaybackController {
 
     /** Requests a playback rate. What the backend actually applied appears in [state]. */
     fun setSpeed(speed: Float)
+
+    /** Arms, re-arms or (with [SleepTimerMode.Off]) cancels the sleep timer. */
+    fun setSleepTimer(mode: SleepTimerMode) = Unit
+
+    /**
+     * The "+5 min" action, which is mainly reached during the fade.
+     *
+     * Separate from [setSleepTimer] because re-arming would restart from the chosen duration; this
+     * adds to whatever is left, which is what a listener who is still awake actually wants.
+     */
+    fun extendSleepTimer() = Unit
 
     /** Retries the current chapter after the automatic attempts have been exhausted. */
     fun retry() = Unit
@@ -106,4 +137,14 @@ interface PlaybackController {
      * window closes; the default no-op keeps test fakes from having to care.
      */
     fun release() = Unit
+
+    companion object {
+        /**
+         * Fallback for the interface's default [skipForward]/[skipBackward].
+         *
+         * Only reached by implementations that do not override them — the test fakes. The real
+         * controller reads the listener's preference.
+         */
+        const val DefaultSkipMs: Long = 30_000L
+    }
 }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackEngine.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackEngine.kt
@@ -13,6 +13,22 @@ import dk.perspektiva.ttsroad.desktop.data.SessionEnd
 data class EngineCapabilities(
     val variableSpeed: Boolean,
     val speedRange: ClosedFloatingPointRange<Float> = 1f..1f,
+    /**
+     * Whether a gain **above** unity is honoured.
+     *
+     * Attenuation is not gated on this and every backend must support it, because the sleep
+     * timer's fade is an attenuation: a timer that cut the audio off abruptly on the fallback
+     * engine and faded it on the production one would be a worse bug than no boost at all.
+     */
+    val volumeBoost: Boolean = false,
+    /**
+     * Whether silent passages can be dropped.
+     *
+     * Gated because it needs a GStreamer element (`removesilence`) that ships in `plugins-bad` and
+     * is absent from most installs, this repository's CI included. The UI draws the control only
+     * where the backend can honour it — the same rule that already governs the speed control.
+     */
+    val skipSilence: Boolean = false,
 ) {
     /** Nearest speed this engine can actually deliver — what the UI should display. */
     fun coerceSpeed(speed: Float): Float =
@@ -21,6 +37,9 @@ data class EngineCapabilities(
     companion object {
         /** A backend with no rate control, e.g. the `SourceDataLine` fallback. */
         val FixedSpeed = EngineCapabilities(variableSpeed = false)
+
+        /** The widest gain any backend applies, boost and fade included. */
+        val GainRange: ClosedFloatingPointRange<Double> = 0.0..2.0
     }
 }
 
@@ -117,6 +136,28 @@ interface PlaybackEngine : AutoCloseable {
      * it displays is what is being played.
      */
     fun setRate(rate: Float): Float
+
+    /**
+     * Sets the output gain, where 1.0 is unmodified.
+     *
+     * One number for both the volume-boost preference and the sleep timer's fade, multiplied by
+     * the caller — two independent volume controls fighting over one element is how a fade ends up
+     * being undone by a preference change mid-fade.
+     *
+     * Values below 1.0 must be honoured by every backend; values above it only where
+     * [EngineCapabilities.volumeBoost] is set. Implementations clamp rather than reject, and must
+     * tolerate being called before [prepare].
+     */
+    fun setGain(gain: Double) = Unit
+
+    /**
+     * Enables or disables dropping silent passages.
+     *
+     * A no-op where [EngineCapabilities.skipSilence] is false. Takes effect on the next [prepare]
+     * rather than mid-chapter: the element sits in the pipeline or it does not, and rebuilding the
+     * graph under a playing stream to honour a toggle is not worth the glitch.
+     */
+    fun setSkipSilence(enabled: Boolean) = Unit
 
     /** Current position. Cheap enough to poll; never blocks on I/O. */
     fun positionMs(): Long

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
@@ -243,6 +243,12 @@ class QueuePlaybackController(
 
     override fun setSleepTimer(mode: SleepTimerMode) {
         sleepTimer.arm(mode)
+        // Arming while already paused has to start out frozen. The tick loop keeps running through
+        // a pause — it is what notices the engine's events — so a timer armed at that moment would
+        // count down against silence and expire without a second of audio having played. The
+        // freeze-on-pause path cannot cover this: it ran when the user pressed pause, back when
+        // there was no deadline to freeze.
+        if (!_state.value.isPlaying) sleepTimer.onPlaybackPaused()
     }
 
     override fun extendSleepTimer() {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
@@ -2,9 +2,15 @@ package dk.perspektiva.ttsroad.desktop.player
 
 import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackHistoryStore
+import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.PlaybackHistoryStore
+import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.PlaybackSnapshot
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.data.describeNetworkFailure
 import dk.perspektiva.ttsroad.desktop.data.playbackOrder
+import dk.perspektiva.ttsroad.desktop.data.skipIntervalMs
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CoroutineDispatcher
@@ -52,13 +58,22 @@ class QueuePlaybackController(
     private val sources: MediaSourceFactory,
     private val engine: PlaybackEngine,
     ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    /**
+     * Listening settings. Observed here rather than read by the player screen, because the issue's
+     * requirement is that a media-key start and an auto-advanced chapter use the same values as a
+     * chapter the user pressed play on — and only the controller sees all three.
+     */
+    private val preferencesStore: PlaybackPreferencesStore = InMemoryPlaybackPreferencesStore(),
+    private val historyStore: PlaybackHistoryStore = InMemoryPlaybackHistoryStore(),
+    private val sleepTimer: SleepTimer = SleepTimer(),
+    private val clock: () -> Long = System::currentTimeMillis,
     /** Overridable so tests do not wait real seconds for the retry ladder. */
     private val retryDelaysMs: List<Long> = listOf(2_000, 5_000, 15_000),
     private val tickIntervalMs: Long = 250,
     private val progressIntervalMs: Long = 10_000,
 ) : PlaybackController {
 
-    private val _state = MutableStateFlow(PlayerUiState(canChangeSpeed = engine.capabilities.variableSpeed))
+    private val _state = MutableStateFlow(emptyState())
     override val state: StateFlow<PlayerUiState> = _state.asStateFlow()
 
     private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
@@ -72,7 +87,7 @@ class QueuePlaybackController(
     /** Last position actually reported by the engine — what a save or a retry resumes from. */
     @Volatile private var lastKnownPositionMs = 0L
 
-    @Volatile private var speed = 1f
+    @Volatile private var speed = preferencesStore.preferences.value.speed
 
     /**
      * Engine events, queued for the attempt loop to consume.
@@ -85,7 +100,50 @@ class QueuePlaybackController(
 
     init {
         engine.setListener { event -> engineEvents.add(event) }
+
+        // Applied immediately and on every later change. The first application matters as much as
+        // the rest: the engine has to know the saved speed and gain *before* the first prepare, or
+        // the restored preferences would take effect one chapter late.
+        scope.launch {
+            preferencesStore.preferences.collect { preferences ->
+                speed = preferences.speed
+                val applied = engine.setRate(preferences.speed)
+                engine.setSkipSilence(preferences.skipSilence)
+                applyGain()
+                _state.update {
+                    it.copy(
+                        speed = applied,
+                        skipIntervalMs = preferences.skipIntervalMs,
+                    )
+                }
+            }
+        }
+
+        // The fade is an engine gain, and the gain is boost × fade, so a fade tick has to go
+        // through the same multiplication as a preference change rather than writing the element
+        // directly — otherwise cancelling a fade would reset a boosted listener to unity.
+        scope.launch {
+            sleepTimer.state.collect { timer ->
+                applyGain()
+                _state.update { it.copy(sleepTimer = timer) }
+            }
+        }
     }
+
+    /** Boost and fade multiplied into the single number the engine takes. */
+    private fun applyGain() {
+        val boost = preferencesStore.preferences.value.volumeBoost.gain
+        val fade = sleepTimer.state.value.fadeGain.toDouble()
+        engine.setGain(boost * fade)
+    }
+
+    private fun emptyState() = PlayerUiState(
+        canChangeSpeed = engine.capabilities.variableSpeed,
+        canSkipSilence = engine.capabilities.skipSilence,
+        speed = engine.capabilities.coerceSpeed(preferencesStore.preferences.value.speed),
+        skipIntervalMs = preferencesStore.preferences.value.skipIntervalMs,
+        sleepTimer = sleepTimer.state.value,
+    )
 
     override suspend fun play(chapter: ChapterSummary, fiction: FictionSummary?) {
         if (chapter.audio == null) {
@@ -124,12 +182,17 @@ class QueuePlaybackController(
         if (current.isPlaying) {
             engine.pause()
             _state.update { it.copy(isPlaying = false) }
+            // A manual pause freezes a countdown; a listener who stops to answer the door should
+            // not come back to a timer that ran out while nothing was playing.
+            sleepTimer.onPlaybackPaused()
             // Pausing is a natural place to lose a session or a laptop lid, so it is one of the
             // moments issue #4 requires a save at.
             saveCurrentProgress()
+            recordHistory()
         } else {
             engine.play()
             _state.update { it.copy(isPlaying = true) }
+            sleepTimer.onPlaybackResumed()
         }
     }
 
@@ -143,6 +206,10 @@ class QueuePlaybackController(
     }
 
     override fun skipBy(deltaMs: Long) = seekTo(_state.value.positionMs + deltaMs)
+
+    override fun skipForward() = skipBy(preferencesStore.preferences.value.skipIntervalMs)
+
+    override fun skipBackward() = skipBy(-preferencesStore.preferences.value.skipIntervalMs)
 
     override fun skipToNextChapter() {
         val next = queueIndex + 1
@@ -165,11 +232,21 @@ class QueuePlaybackController(
     }
 
     override fun setSpeed(speed: Float) {
-        // The engine gets the last word, and the UI shows what it said — an engine that cannot
-        // resample answers 1.0 and the display stays honest.
-        val applied = engine.setRate(speed)
-        this.speed = applied
-        _state.update { it.copy(speed = applied) }
+        // Persisted rather than held: the preference is the source of truth, and the collector in
+        // `init` is what pushes it to the engine and to the UI state. Writing the engine here too
+        // would mean two paths to the same setting, one of which does not survive a restart.
+        //
+        // An engine that cannot resample still stores the wish — a listener who set 1.5× on a
+        // machine without GStreamer and later installs it should find 1.5× waiting.
+        preferencesStore.update { it.copy(speed = speed) }
+    }
+
+    override fun setSleepTimer(mode: SleepTimerMode) {
+        sleepTimer.arm(mode)
+    }
+
+    override fun extendSleepTimer() {
+        sleepTimer.extendBy(SleepTimer.ExtensionMinutes)
     }
 
     override fun retry() {
@@ -190,6 +267,9 @@ class QueuePlaybackController(
         // not wait for it. The save below reads `lastKnownPositionMs`, which the job has already
         // published, so it does not need the job to finish first.
         playJob?.cancel()
+        // Local and synchronous, so it happens whether or not the server is reachable — the whole
+        // point of a local history is that closing the lid on a dead network still remembers.
+        recordHistory()
         runBlocking {
             withTimeoutOrNull(RELEASE_TIMEOUT_MS) { saveProgressNow() }
         }
@@ -204,13 +284,17 @@ class QueuePlaybackController(
         playJob?.cancelAndJoin()
         playJob = null
         saveProgressNow()
+        recordHistory()
         runCatching { engine.stop() }
         if (clearQueue) {
             queue = emptyList()
             queueFiction = null
             queueIndex = 0
             lastKnownPositionMs = 0
-            _state.value = PlayerUiState(canChangeSpeed = engine.capabilities.variableSpeed)
+            // A stop is also the end of any sleep timer: the thing it was counting down to has
+            // already happened, and leaving it armed would silence the *next* chapter.
+            sleepTimer.cancel()
+            _state.value = emptyState()
         }
     }
 
@@ -224,6 +308,7 @@ class QueuePlaybackController(
         playJob?.cancelAndJoin()
         // Leaving the previous chapter is one of the required save points.
         saveProgressNow()
+        recordHistory()
         queueIndex = startIndex
         lastKnownPositionMs = startMs
         publishMetadata(startIndex, startMs)
@@ -242,6 +327,14 @@ class QueuePlaybackController(
                 // Reaching here means the chapter ended on its own.
                 val duration = _state.value.durationMs
                 saveProgress(chapter, duration.takeIf { it > 0 } ?: lastKnownPositionMs, isPlayed = true)
+
+                // Checked before the advance, which is the whole requirement: "end of current
+                // chapter" has to prevent auto-advance, not stop the next one a moment after it
+                // has already started playing.
+                if (sleepTimer.shouldStopAtChapterEnd()) {
+                    _state.update { it.copy(isPlaying = false, positionMs = duration) }
+                    return@launch
+                }
                 if (index == queue.lastIndex) {
                     _state.update { it.copy(isPlaying = false, positionMs = duration) }
                     return@launch
@@ -269,6 +362,16 @@ class QueuePlaybackController(
 
                 // The job was cancelled: a new chapter, a stop, or shutdown superseded this.
                 is AttemptResult.Stopped -> return ChapterOutcome.Stopped
+
+                is AttemptResult.SleptOff -> {
+                    // A pause, not a stop: the queue and the position stay exactly where they are
+                    // so the morning's "resume" is one keypress, not a search for the chapter.
+                    engine.pause()
+                    _state.update { it.copy(isPlaying = false) }
+                    saveProgressNow()
+                    recordHistory()
+                    return ChapterOutcome.Stopped
+                }
 
                 is AttemptResult.SessionExpired -> {
                     _state.update { it.copy(isPlaying = false, error = result.failure.message, canRetry = false) }
@@ -302,6 +405,9 @@ class QueuePlaybackController(
     private sealed interface AttemptResult {
         data object Completed : AttemptResult
         data object Stopped : AttemptResult
+
+        /** The sleep timer ran out mid-chapter. Distinct from [Stopped] so it can pause, not tear down. */
+        data object SleptOff : AttemptResult
         data class Transient(val message: String) : AttemptResult
         data class Fatal(val message: String) : AttemptResult
         data class SessionExpired(val failure: PlaybackFailure.SessionExpired) : AttemptResult
@@ -342,6 +448,11 @@ class QueuePlaybackController(
         while (coroutineContext[Job]?.isActive != false) {
             delay(tickIntervalMs)
             drainEngineEvents()?.let { return it }
+
+            // The timer is driven by this tick rather than by a scheduler of its own, which is
+            // what makes the fade and the expiry deterministic in tests: no wall-clock race, and
+            // the fade gain is recomputed on exactly the cadence the position is.
+            if (sleepTimer.tick() == SleepTimerEvent.Expired) return AttemptResult.SleptOff
 
             val position = engine.positionMs()
             if (position > 0) lastKnownPositionMs = position
@@ -399,6 +510,12 @@ class QueuePlaybackController(
         positionMs = positionMs,
         speed = engine.capabilities.coerceSpeed(speed),
         canChangeSpeed = engine.capabilities.variableSpeed,
+        canSkipSilence = engine.capabilities.skipSilence,
+        // Rebuilt from the live values rather than copied from the previous state: this function
+        // constructs a whole PlayerUiState, so anything not named here would silently revert to a
+        // default every time the chapter changed.
+        skipIntervalMs = preferencesStore.preferences.value.skipIntervalMs,
+        sleepTimer = sleepTimer.state.value,
         queue = queue.map { QueueItem(it.resolvedChapterId, it.resolvedTitle, it.resolvedDisplayNumber) },
         currentIndex = index,
         hasNext = index < queue.lastIndex,
@@ -414,6 +531,36 @@ class QueuePlaybackController(
      */
     private fun fictionIdOf(chapter: ChapterSummary, fiction: FictionSummary?): Int =
         fiction?.id?.takeIf { it > 0 } ?: chapter.resolvedFictionId
+
+    /**
+     * Files a local "you were here" snapshot for the chapter currently loaded.
+     *
+     * Called at transitions — pause, chapter change, sleep, stop, shutdown — and deliberately
+     * *not* on the progress tick. Recording every ten seconds would be a write amplification for
+     * no extra information, and, more importantly, it would undo a dismissal within one tick of
+     * the user making it.
+     */
+    private fun recordHistory() {
+        val chapter = queue.getOrNull(queueIndex) ?: return
+        val current = _state.value
+        if (!current.hasMedia) return
+        val fictionId = chapter.resolvedFictionId
+        if (fictionId <= 0) return
+
+        historyStore.record(
+            PlaybackSnapshot(
+                fictionId = fictionId,
+                chapterId = chapter.resolvedChapterId,
+                // Titles only. Nothing here reconstructs the server, the audio object or the
+                // account — see PlaybackSnapshot's own note on what this file may hold.
+                fictionTitle = current.fictionTitle ?: chapter.resolvedFictionTitle.orEmpty(),
+                chapterTitle = chapter.resolvedTitle,
+                positionSeconds = lastKnownPositionMs / 1000.0,
+                durationSeconds = current.durationMs / 1000.0,
+                recordedAtMs = clock(),
+            ),
+        )
+    }
 
     /** Fire-and-forget save for the transitions that happen on the UI thread. */
     private fun saveCurrentProgress() {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/SleepTimer.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/SleepTimer.kt
@@ -1,0 +1,224 @@
+package dk.perspektiva.ttsroad.desktop.player
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * What the listener asked the timer to do.
+ *
+ * [EndOfChapter] is not a duration in disguise: a chapter's remaining time changes under a seek and
+ * a rate change, and expressing it as "stop at the boundary" rather than "stop in 14 minutes" is
+ * what keeps it correct when either happens.
+ */
+sealed interface SleepTimerMode {
+    data object Off : SleepTimerMode
+
+    /** A wall-clock countdown. [minutes] is the *initial* length; extensions do not change it. */
+    data class Duration(val minutes: Int) : SleepTimerMode
+
+    data object EndOfChapter : SleepTimerMode
+
+    companion object {
+        /** The durations the UI offers. "+5 min" can push an armed timer past the last of them. */
+        val OfferedMinutes: List<Int> = listOf(5, 15, 30, 45, 60)
+    }
+}
+
+/**
+ * The timer as the UI and the engine see it.
+ *
+ * [fadeGain] is a multiplier the engine applies *on top of* the volume-boost preference, so a fade
+ * and a boost compose instead of one overwriting the other — and cancelling a fade restores the
+ * boost rather than resetting the output to unity.
+ */
+data class SleepTimerState(
+    val mode: SleepTimerMode = SleepTimerMode.Off,
+    /** Milliseconds left, for a [SleepTimerMode.Duration]. Zero in every other mode. */
+    val remainingMs: Long = 0L,
+    val isFading: Boolean = false,
+    val fadeGain: Float = 1f,
+) {
+    val isArmed: Boolean get() = mode != SleepTimerMode.Off
+}
+
+/** What a [SleepTimer.tick] found. */
+enum class SleepTimerEvent {
+    /** The countdown reached zero. The controller pauses and disarms. */
+    Expired,
+}
+
+/**
+ * The sleep timer, as a state machine over an injected clock.
+ *
+ * Deliberately *not* a coroutine with a `delay`. The acceptance criteria require deterministic
+ * behaviour across pause, resume, seek, chapter boundary and manual stop, and a real timer makes
+ * every one of those a race against a scheduler. Here the controller's existing 250 ms tick drives
+ * it, `now` is a parameter, and a test can step a whole hour in one line.
+ *
+ * Threading: every method is synchronised on the instance. The controller ticks from its own
+ * coroutine while the UI arms and cancels from the Compose thread, and both mutate the deadline.
+ */
+class SleepTimer(private val now: () -> Long = System::currentTimeMillis) {
+
+    private val _state = MutableStateFlow(SleepTimerState())
+    val state: StateFlow<SleepTimerState> = _state.asStateFlow()
+
+    /** Absolute deadline while running; null when disarmed or frozen by a pause. */
+    private var deadlineMs: Long? = null
+
+    /** What is left while frozen, so a resume continues rather than restarts. */
+    private var frozenRemainingMs: Long? = null
+
+    private var mode: SleepTimerMode = SleepTimerMode.Off
+
+    @Synchronized
+    fun arm(mode: SleepTimerMode) {
+        this.mode = mode
+        when (mode) {
+            is SleepTimerMode.Off -> disarmInternal()
+
+            is SleepTimerMode.Duration -> {
+                deadlineMs = now() + mode.minutes * MillisPerMinute
+                frozenRemainingMs = null
+                publish()
+            }
+
+            is SleepTimerMode.EndOfChapter -> {
+                // Nothing to count down: the chapter's own end is the deadline.
+                deadlineMs = null
+                frozenRemainingMs = null
+                publish()
+            }
+        }
+    }
+
+    fun cancel() = arm(SleepTimerMode.Off)
+
+    /**
+     * Pushes an armed countdown out by [minutes] and restores full volume.
+     *
+     * Works during the fade — that is its main use, and the reason it clears [SleepTimerState
+     * .isFading] explicitly rather than waiting for the next tick to notice: a listener who reaches
+     * for "+5 min" while the audio is already fading should hear it come back immediately.
+     *
+     * Extending a [SleepTimerMode.EndOfChapter] timer converts it to a countdown, because "end of
+     * chapter, plus five minutes" is not a thing the boundary can express.
+     */
+    @Synchronized
+    fun extendBy(minutes: Int) {
+        if (!_state.value.isArmed) return
+        val extra = minutes * MillisPerMinute
+        when {
+            frozenRemainingMs != null -> frozenRemainingMs = frozenRemainingMs!! + extra
+            deadlineMs != null -> deadlineMs = deadlineMs!! + extra
+            else -> {
+                // End-of-chapter: becomes a countdown of exactly the extension.
+                mode = SleepTimerMode.Duration(minutes)
+                deadlineMs = now() + extra
+            }
+        }
+        publish()
+    }
+
+    /**
+     * Freezes a countdown.
+     *
+     * Called for a *manual* pause only. A pause the timer itself caused must not freeze anything —
+     * it has already expired and disarmed by then, so there is no deadline left to freeze.
+     */
+    @Synchronized
+    fun onPlaybackPaused() {
+        val deadline = deadlineMs ?: return
+        frozenRemainingMs = (deadline - now()).coerceAtLeast(0L)
+        deadlineMs = null
+        publish()
+    }
+
+    @Synchronized
+    fun onPlaybackResumed() {
+        val remaining = frozenRemainingMs ?: return
+        deadlineMs = now() + remaining
+        frozenRemainingMs = null
+        publish()
+    }
+
+    /**
+     * Whether the chapter that just finished should be the last one.
+     *
+     * Returns true exactly once per armed [SleepTimerMode.EndOfChapter] — the timer disarms itself
+     * here, so a controller that keeps the queue loaded does not stop every subsequent chapter too.
+     */
+    @Synchronized
+    fun shouldStopAtChapterEnd(): Boolean {
+        if (mode != SleepTimerMode.EndOfChapter) return false
+        disarmInternal()
+        return true
+    }
+
+    /**
+     * Recomputes the countdown and the fade.
+     *
+     * Returns [SleepTimerEvent.Expired] once, on the tick that crosses zero; the timer disarms
+     * itself first so a caller that ticks again before acting cannot be told twice.
+     */
+    @Synchronized
+    fun tick(): SleepTimerEvent? {
+        val deadline = deadlineMs ?: run {
+            // Frozen, or a mode with no countdown. Publishing keeps the frozen remainder visible.
+            publish()
+            return null
+        }
+        val remaining = deadline - now()
+        if (remaining <= 0) {
+            disarmInternal()
+            return SleepTimerEvent.Expired
+        }
+        publish()
+        return null
+    }
+
+    private fun disarmInternal() {
+        mode = SleepTimerMode.Off
+        deadlineMs = null
+        frozenRemainingMs = null
+        // Full volume on the way out, whether the timer was cancelled or expired: the next thing
+        // the listener plays must not start silent because a fade was in progress when it ended.
+        _state.value = SleepTimerState()
+    }
+
+    private fun publish() {
+        val remaining = remainingMs()
+        val fading = mode is SleepTimerMode.Duration && deadlineMs != null && remaining <= FadeMs
+        _state.value = SleepTimerState(
+            mode = mode,
+            remainingMs = remaining,
+            isFading = fading,
+            fadeGain = if (fading) (remaining.toFloat() / FadeMs).coerceIn(0f, 1f) else 1f,
+        )
+    }
+
+    private fun remainingMs(): Long = when {
+        frozenRemainingMs != null -> frozenRemainingMs!!
+        deadlineMs != null -> (deadlineMs!! - now()).coerceAtLeast(0L)
+        else -> 0L
+    }
+
+    companion object {
+        const val MillisPerMinute: Long = 60_000L
+
+        /** How long the fade lasts. The last 30 s, as the issue specifies. */
+        const val FadeMs: Long = 30_000L
+
+        /** What the "+5 min" action adds. */
+        const val ExtensionMinutes: Int = 5
+    }
+}
+
+/** Human label for a countdown, e.g. `4:05`. Minutes are not zero-padded; seconds always are. */
+fun formatRemaining(remainingMs: Long): String {
+    val totalSeconds = (remainingMs + 999) / 1000
+    val minutes = totalSeconds / 60
+    val seconds = totalSeconds % 60
+    return "$minutes:${seconds.toString().padStart(2, '0')}"
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/LibraryScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/LibraryScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
@@ -31,6 +32,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.itemsIndexed as itemsIndexedInRow
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Button
@@ -57,11 +59,17 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackHistoryStore
 import dk.perspektiva.ttsroad.desktop.data.LibraryCache
+import dk.perspektiva.ttsroad.desktop.data.PlaybackHistory
+import dk.perspektiva.ttsroad.desktop.data.PlaybackHistoryStore
+import dk.perspektiva.ttsroad.desktop.data.PlaybackSnapshot
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.data.chapterKeys
 import dk.perspektiva.ttsroad.desktop.data.fictionKeys
@@ -94,10 +102,17 @@ fun LibraryScreen(
     playback: PlaybackController,
     onOpenFiction: (FictionSummary) -> Unit,
     onOpenPlayer: () -> Unit,
+    /**
+     * Local listening history, for the "Jump back in" strip. Defaulted to an in-memory store so a
+     * screen test never reads or writes the real config directory.
+     */
+    history: PlaybackHistoryStore = remember { InMemoryPlaybackHistoryStore() },
     nowMillis: () -> Long = System::currentTimeMillis,
 ) {
     val scope = rememberCoroutineScope()
     val state by cache.library.collectAsState()
+    val snapshots by history.history.collectAsState()
+    val jumpBack = remember(snapshots) { PlaybackHistory.jumpBackChoices(snapshots) }
     // Keyless on purpose: fires once per screen *appearance*, not per recomposition. Reuses cached
     // content and coalesces with a load already in flight, so Back into the library costs nothing.
     LaunchedEffect(Unit) { cache.ensureLibrary() }
@@ -163,9 +178,30 @@ fun LibraryScreen(
                         }
                     }
 
+                    // Local, and therefore true even when the server's own continue-listening is
+                    // stale or unreachable: this is what *this machine* was playing. Dismissing an
+                    // entry hides that snapshot, not "today" — see PlaybackHistory.
+                    if (jumpBack.isNotEmpty()) {
+                        fullWidthItem("jump-back") {
+                            Column {
+                                Spacer(Modifier.height(20.dp))
+                                SectionTitle("02", "Jump back in")
+                                Spacer(Modifier.height(16.dp))
+                                JumpBackShelf(
+                                    snapshots = jumpBack,
+                                    onOpen = { snapshot ->
+                                        library.fictions.firstOrNull { it.id == snapshot.fictionId }
+                                            ?.let(onOpenFiction)
+                                    },
+                                    onDismiss = { history.dismiss(it.key) },
+                                )
+                            }
+                        }
+                    }
+
                     fullWidthItem("fictions-header") {
                         Column {
-                            SectionTitle("02", "Fictions")
+                            SectionTitle("03", "Fictions")
                             Spacer(Modifier.height(16.dp))
                             if (library.fictions.isNotEmpty()) {
                                 OutlinedTextField(
@@ -206,7 +242,7 @@ fun LibraryScreen(
                         fullWidthItem("recent") {
                             Column {
                                 Spacer(Modifier.height(20.dp))
-                                SectionTitle("03", "Recent")
+                                SectionTitle("04", "Recent")
                                 Spacer(Modifier.height(16.dp))
                                 ContinueShelf(library.recentChapters, repository) { chapter ->
                                     scope.launch { playback.play(chapter, chapter.fiction) }
@@ -223,6 +259,74 @@ fun LibraryScreen(
 
 /** Test handle for the library's scroll container. */
 const val LibraryGridTestTag: String = "libraryGrid"
+
+const val JumpBackCardTestTag: String = "jumpBackCard"
+const val JumpBackDismissTestTag: String = "jumpBackDismiss"
+
+/**
+ * The local "jump back in" strip.
+ *
+ * Opens the fiction rather than starting playback: the snapshot holds an id and a title, not a
+ * `ChapterSummary`, and the honest action for "here is where you were" is to take the listener to
+ * the chapter list that already highlights it — not to guess at a payload and start audio.
+ */
+@Composable
+private fun JumpBackShelf(
+    snapshots: List<PlaybackSnapshot>,
+    onOpen: (PlaybackSnapshot) -> Unit,
+    onDismiss: (PlaybackSnapshot) -> Unit,
+) {
+    Row(
+        Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(GridGap),
+    ) {
+        snapshots.forEach { snapshot ->
+            AarisCard(modifier = Modifier.width(260.dp).testTag(JumpBackCardTestTag)) {
+                Column(Modifier.fillMaxWidth().padding(12.dp)) {
+                    Row(verticalAlignment = Alignment.Top) {
+                        Column(Modifier.weight(1f)) {
+                            MetaText(snapshot.fictionTitle.ifBlank { "Unknown" })
+                            Spacer(Modifier.height(4.dp))
+                            Text(
+                                snapshot.chapterTitle,
+                                style = MaterialTheme.typography.titleSmall,
+                                color = AarisColor.Ink,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                        // Dismissal is per snapshot; a later chapter of the same serial comes back
+                        // on its own, which is the behaviour the issue asks for over "hide today".
+                        Text(
+                            "×",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = AarisColor.Muted,
+                            modifier = Modifier
+                                .testTag(JumpBackDismissTestTag)
+                                .clickable { onDismiss(snapshot) }
+                                .pointerHoverIcon(PointerIcon.Hand)
+                                .semantics { contentDescription = "Dismiss ${snapshot.chapterTitle}" }
+                                .padding(horizontal = 6.dp),
+                        )
+                    }
+                    Spacer(Modifier.height(10.dp))
+                    ThinProgress(snapshot.progress, Modifier.fillMaxWidth())
+                    Spacer(Modifier.height(10.dp))
+                    Text(
+                        "Open",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = AarisColor.Accent,
+                        modifier = Modifier
+                            .clickable { onOpen(snapshot) }
+                            .pointerHoverIcon(PointerIcon.Hand)
+                            .semantics { contentDescription = "Open ${snapshot.fictionTitle}" }
+                            .padding(vertical = 4.dp),
+                    )
+                }
+            }
+        }
+    }
+}
 
 /** Full-width row inside the grid, for heroes, shelves and section headers. */
 private fun LazyGridScope.fullWidthItem(

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreen.kt
@@ -22,13 +22,19 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FastForward
+import androidx.compose.material.icons.filled.FastRewind
+import androidx.compose.material.icons.filled.Forward10
 import androidx.compose.material.icons.filled.Forward30
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Replay10
 import androidx.compose.material.icons.filled.Replay30
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
@@ -53,12 +59,20 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.player.PlaybackController
 import dk.perspektiva.ttsroad.desktop.player.PlayerUiState
+import dk.perspektiva.ttsroad.desktop.player.SleepTimerMode
+import dk.perspektiva.ttsroad.desktop.player.SleepTimerState
+import dk.perspektiva.ttsroad.desktop.player.formatRemaining
 
 /** Whether the mini-player should be visible: something has been loaded (or tried to load). */
 val PlayerUiState.hasSession: Boolean
@@ -68,6 +82,12 @@ val PlayerUiState.hasSession: Boolean
 fun PlayerScreen(
     playback: PlaybackController,
     sizeClass: WindowSizeClass = WindowSizeClass.Expanded,
+    /**
+     * Listening settings, for the one control the player owns that is a *preference* rather than
+     * transport state: skip silence. Defaulted to an in-memory store so a screen test never writes
+     * to the real config directory.
+     */
+    preferences: PlaybackPreferencesStore = remember { InMemoryPlaybackPreferencesStore() },
     onBack: () -> Unit,
 ) {
     val s: PlayerUiState by playback.state.collectAsState()
@@ -84,7 +104,7 @@ fun PlayerScreen(
                 Modifier.fillMaxSize().padding(top = 28.dp).verticalScroll(rememberScrollState()),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                PlayerMain(s, playback, compact = true, modifier = Modifier.fillMaxWidth())
+                PlayerMain(s, playback, preferences, compact = true, modifier = Modifier.fillMaxWidth())
                 if (hasQueue) {
                     Spacer(Modifier.height(20.dp))
                     QueuePanel(s, playback, Modifier.fillMaxWidth().height(260.dp))
@@ -96,6 +116,7 @@ fun PlayerScreen(
                     PlayerMain(
                         s,
                         playback,
+                        preferences,
                         compact = false,
                         modifier = Modifier.align(Alignment.TopCenter).widthIn(max = NarrowMaxWidth)
                             .fillMaxWidth().fillMaxHeight(),
@@ -115,9 +136,11 @@ fun PlayerScreen(
 private fun PlayerMain(
     s: PlayerUiState,
     playback: PlaybackController,
+    preferences: PlaybackPreferencesStore,
     compact: Boolean,
     modifier: Modifier,
 ) {
+    val prefs by preferences.preferences.collectAsState()
     // Track the drag locally and only seek on release — the MP3 backend re-decodes from the
     // start of the file per seek, so seeking on every drag tick would stutter badly.
     var dragMs by remember { mutableStateOf<Float?>(null) }
@@ -174,9 +197,13 @@ private fun PlayerMain(
             TransportButton(Icons.Default.SkipPrevious, "Previous chapter", enabled = s.hasMedia, size = 48.dp) {
                 playback.skipToPreviousChapter()
             }
-            TransportButton(Icons.Default.Replay30, "Back 30 seconds", enabled = s.hasMedia, size = 48.dp) {
-                playback.skipBy(-30_000)
-            }
+            val skipSeconds = (s.skipIntervalMs / 1000).toInt()
+            TransportButton(
+                rewindIconFor(skipSeconds),
+                "Back $skipSeconds seconds",
+                enabled = s.hasMedia,
+                size = 48.dp,
+            ) { playback.skipBackward() }
             TransportButton(
                 if (s.isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
                 if (s.isPlaying) "Pause" else "Play",
@@ -184,9 +211,12 @@ private fun PlayerMain(
                 size = 64.dp,
                 filled = true,
             ) { playback.togglePlayPause() }
-            TransportButton(Icons.Default.Forward30, "Forward 30 seconds", enabled = s.hasMedia, size = 48.dp) {
-                playback.skipBy(30_000)
-            }
+            TransportButton(
+                forwardIconFor(skipSeconds),
+                "Forward $skipSeconds seconds",
+                enabled = s.hasMedia,
+                size = 48.dp,
+            ) { playback.skipForward() }
             TransportButton(Icons.Default.SkipNext, "Next chapter", enabled = s.hasNext, size = 48.dp) {
                 playback.skipToNextChapter()
             }
@@ -197,6 +227,24 @@ private fun PlayerMain(
             Spacer(Modifier.height(18.dp))
             SpeedControl(current = s.speed, enabled = s.hasMedia) { playback.setSpeed(it) }
         }
+        // Skip-silence belongs next to speed rather than only in Settings: both change how long
+        // the chapter takes, and a listener reaching for one is usually reaching for the other.
+        // Same capability rule — absent entirely where the backend cannot do it.
+        if (s.canSkipSilence) {
+            Spacer(Modifier.height(10.dp))
+            SkipSilenceToggle(
+                checked = prefs.skipSilence,
+                enabled = s.hasMedia,
+                onToggle = { value -> preferences.update { it.copy(skipSilence = value) } },
+            )
+        }
+        Spacer(Modifier.height(18.dp))
+        SleepTimerControl(
+            state = s.sleepTimer,
+            enabled = s.hasMedia,
+            onArm = playback::setSleepTimer,
+            onExtend = playback::extendSleepTimer,
+        )
         Spacer(Modifier.height(12.dp))
         val error = s.error
         when {
@@ -261,6 +309,129 @@ private fun SpeedControl(current: Float, enabled: Boolean, onSelect: (Float) -> 
 private fun formatSpeed(speed: Float): String {
     val text = if (speed % 1f == 0f) speed.toInt().toString() else speed.toString().trimEnd('0').trimEnd('.')
     return "${text}x"
+}
+
+/**
+ * The transport icon matching the configured interval, where Material has one.
+ *
+ * 15, 45 and 60 have no numbered icon in the set, and a `Replay30` glyph on a button that skips 45
+ * seconds is a worse answer than an unnumbered one — the content description carries the number
+ * either way, so nothing is lost for a screen reader.
+ */
+private fun rewindIconFor(seconds: Int): ImageVector = when (seconds) {
+    10 -> Icons.Default.Replay10
+    30 -> Icons.Default.Replay30
+    else -> Icons.Default.FastRewind
+}
+
+private fun forwardIconFor(seconds: Int): ImageVector = when (seconds) {
+    10 -> Icons.Default.Forward10
+    30 -> Icons.Default.Forward30
+    else -> Icons.Default.FastForward
+}
+
+const val SleepTimerChipTestTag = "player-sleep-chip"
+const val SleepExtendTestTag = "player-sleep-extend"
+const val SkipSilenceTestTag = "player-skip-silence"
+
+/**
+ * The sleep timer row: the offered modes, the countdown, and "+5 min" while fading.
+ *
+ * The extension only appears during the fade, which is when it is actually needed — a permanently
+ * visible "+5 min" next to an unarmed timer is a button with no meaning.
+ */
+@Composable
+private fun SleepTimerControl(
+    state: SleepTimerState,
+    enabled: Boolean,
+    onArm: (SleepTimerMode) -> Unit,
+    onExtend: () -> Unit,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        MetaText("Sleep", color = AarisColor.Dim)
+        SleepChip("Off", selected = !state.isArmed, enabled = enabled) { onArm(SleepTimerMode.Off) }
+        SleepTimerMode.OfferedMinutes.forEach { minutes ->
+            SleepChip(
+                label = "${minutes}m",
+                // Compared against the *initial* duration, which extending does not change — so a
+                // timer pushed out by "+5 min" still shows which choice it started from.
+                selected = state.mode == SleepTimerMode.Duration(minutes),
+                enabled = enabled,
+            ) { onArm(SleepTimerMode.Duration(minutes)) }
+        }
+        SleepChip(
+            label = "Chapter",
+            selected = state.mode == SleepTimerMode.EndOfChapter,
+            enabled = enabled,
+        ) { onArm(SleepTimerMode.EndOfChapter) }
+
+        if (state.isArmed && state.remainingMs > 0) {
+            MetaText(
+                text = formatRemaining(state.remainingMs),
+                color = if (state.isFading) AarisColor.Warning else AarisColor.Accent,
+            )
+        }
+        if (state.isFading) {
+            Text(
+                "+5 min",
+                style = MaterialTheme.typography.bodyMedium,
+                color = AarisColor.Accent,
+                modifier = Modifier
+                    .testTag(SleepExtendTestTag)
+                    .clickable { onExtend() }
+                    .pointerHoverIcon(PointerIcon.Hand)
+                    .semantics { contentDescription = "Add five minutes to the sleep timer" }
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SleepChip(label: String, selected: Boolean, enabled: Boolean, onClick: () -> Unit) {
+    Text(
+        text = label,
+        style = MaterialTheme.typography.bodyMedium,
+        color = when {
+            !enabled -> AarisColor.Dim
+            selected -> AarisColor.Accent
+            else -> AarisColor.Muted
+        },
+        modifier = Modifier
+            .testTag(SleepTimerChipTestTag)
+            .selectable(
+                selected = selected,
+                enabled = enabled,
+                role = Role.RadioButton,
+                onClick = onClick,
+            )
+            .pointerHoverIcon(PointerIcon.Hand)
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+    )
+}
+
+@Composable
+private fun SkipSilenceToggle(checked: Boolean, enabled: Boolean, onToggle: (Boolean) -> Unit) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        MetaText("Silence", color = AarisColor.Dim)
+        Text(
+            text = if (checked) "Skipping" else "Keeping",
+            style = MaterialTheme.typography.bodyMedium,
+            color = if (!enabled) AarisColor.Dim else if (checked) AarisColor.Accent else AarisColor.Muted,
+            modifier = Modifier
+                .testTag(SkipSilenceTestTag)
+                .toggleable(value = checked, enabled = enabled, role = Role.Switch, onValueChange = onToggle)
+                .pointerHoverIcon(PointerIcon.Hand)
+                .semantics { contentDescription = "Skip silence" }
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+        )
+    }
 }
 
 /**

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
@@ -18,8 +18,17 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.Switch
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -52,10 +61,14 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import dk.perspektiva.ttsroad.desktop.BuildInfo
 import dk.perspektiva.ttsroad.desktop.data.DeviceSession
+import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferences
+import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
 import dk.perspektiva.ttsroad.desktop.data.SessionState
 import dk.perspektiva.ttsroad.desktop.data.SessionStore
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
+import dk.perspektiva.ttsroad.desktop.data.VolumeBoost
 import dk.perspektiva.ttsroad.desktop.data.formatExpiresIn
 import dk.perspektiva.ttsroad.desktop.data.formatServerTimestamp
 import dk.perspektiva.ttsroad.desktop.data.redactSecrets
@@ -81,6 +94,20 @@ fun SettingsScreen(
      * in step — the app uses it to swap the top back-stack entry between Settings and Devices.
      */
     onSectionSelected: (SettingsSection) -> Unit = {},
+    /**
+     * Listening settings. Defaulted to an in-memory store so a screen test — and a preview — never
+     * writes to the real config directory just by rendering the Playback pane.
+     */
+    preferences: PlaybackPreferencesStore = remember { InMemoryPlaybackPreferencesStore() },
+    /**
+     * What the *engine* can do, passed down rather than read here.
+     *
+     * The pane draws a speed or skip-silence control only where the backend can honour it, which
+     * is the same rule the player screen follows — and taking the two flags as parameters keeps
+     * Settings independent of the playback controller.
+     */
+    canChangeSpeed: Boolean = false,
+    canSkipSilence: Boolean = false,
     // Injected so "expires in 42 days" can be asserted without the test depending on wall time.
     nowMs: () -> Long = System::currentTimeMillis,
 ) {
@@ -118,7 +145,7 @@ fun SettingsScreen(
                     when (ui.section) {
                         SettingsSection.Account -> AccountPane(ui, session, capabilities, sessionStore, holder, selectSection, nowMs)
                         SettingsSection.Devices -> DevicesPane(ui, session, holder, nowMs)
-                        SettingsSection.Playback -> PlaybackPane()
+                        SettingsSection.Playback -> PlaybackPane(preferences, canChangeSpeed, canSkipSilence)
                         SettingsSection.Offline -> OfflinePane()
                         SettingsSection.About -> AboutPane(session, capabilities, sessionStore)
                     }
@@ -490,13 +517,173 @@ private fun DeviceDetail(label: String, value: String) {
  * nothing is worse than an honest empty pane, because the user cannot tell it did not work.
  */
 @Composable
-private fun PlaybackPane() {
-    PaneTitle("Playback", "Not available yet")
-    InfoCard(
-        "Playback preferences are not part of this build. Skip interval, playback speed, " +
-            "auto-marking a finished chapter and a sleep timer arrive with the playback-preferences " +
-            "phase; until then the player uses fixed 30-second skips at normal speed.",
-    )
+private fun PlaybackPane(
+    preferences: PlaybackPreferencesStore,
+    canChangeSpeed: Boolean,
+    canSkipSilence: Boolean,
+) {
+    val prefs by preferences.preferences.collectAsState()
+
+    PaneTitle("Playback", "Kept on this computer, not on your account")
+
+    SettingsCard {
+        if (canChangeSpeed) {
+            ChoiceRow(
+                label = "SPEED",
+                // The offered list carries the stored value even when it is not a preset, so a
+                // rate set by another build stays selectable instead of vanishing on first open.
+                options = PlaybackPreferences.speedOptions(prefs.speed),
+                selected = prefs.speed,
+                labelOf = ::formatSpeed,
+                onSelect = { value -> preferences.update { it.copy(speed = value) } },
+            )
+        } else {
+            SettingRow("SPEED", "Fixed at ${formatSpeed(1f)}")
+            MetaText(
+                "The audio backend on this computer cannot resample, so speed is not offered " +
+                    "rather than offered and ignored. Installing GStreamer enables it.",
+            )
+        }
+
+        RowDivider()
+
+        ChoiceRow(
+            label = "SKIP INTERVAL",
+            options = PlaybackPreferences.SkipIntervals,
+            selected = prefs.skipIntervalSeconds,
+            labelOf = { "$it s" },
+            onSelect = { value -> preferences.update { it.copy(skipIntervalSeconds = value) } },
+        )
+
+        RowDivider()
+
+        ChoiceRow(
+            label = "VOLUME BOOST",
+            options = VolumeBoost.entries.toList(),
+            selected = prefs.volumeBoost,
+            labelOf = { it.label },
+            onSelect = { value -> preferences.update { it.copy(volumeBoost = value) } },
+        )
+        MetaText("Boost stops at ${formatSpeed(VolumeBoost.High.gain.toFloat())} — louder than that clips quiet narration instead of raising it.")
+
+        RowDivider()
+
+        if (canSkipSilence) {
+            ToggleRow(
+                label = "SKIP SILENCE",
+                description = "Drops dead air between sentences. Off by default, to match the " +
+                    "mobile app and keep chapter timings where the server put them.",
+                checked = prefs.skipSilence,
+                onCheckedChange = { value -> preferences.update { it.copy(skipSilence = value) } },
+            )
+        } else {
+            SettingRow("SKIP SILENCE", "Not available on this computer")
+            MetaText(
+                "Silence removal needs the GStreamer \"removesilence\" element, which ships in " +
+                    "gst-plugins-bad. It is not installed here, so the control is not shown.",
+            )
+        }
+    }
+}
+
+/** `1.25×`, `1.0×` — one decimal unless the value needs two. */
+private fun formatSpeed(speed: Float): String {
+    val rounded = kotlin.math.round(speed * 100) / 100f
+    val text = if (kotlin.math.abs(rounded * 10 - kotlin.math.round(rounded * 10)) < 0.01f) {
+        String.format(java.util.Locale.ROOT, "%.1f", rounded)
+    } else {
+        String.format(java.util.Locale.ROOT, "%.2f", rounded)
+    }
+    return "$text×"
+}
+
+/**
+ * A labelled row of mutually exclusive choices.
+ *
+ * `selectableGroup` plus `Role.RadioButton` on each entry is what makes this announce as one
+ * choice with N options rather than as N unrelated buttons, and it is why these are not plain
+ * clickable boxes.
+ */
+@Composable
+private fun <T> ChoiceRow(
+    label: String,
+    options: List<T>,
+    selected: T,
+    labelOf: (T) -> String,
+    onSelect: (T) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        MetaText(label)
+        Row(
+            // Nine speeds do not fit a narrow settings pane; scrolling beats wrapping into a grid
+            // whose rows change height as the option list changes.
+            Modifier.horizontalScroll(rememberScrollState()).selectableGroup(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            options.forEach { option ->
+                ChoiceChip(
+                    label = labelOf(option),
+                    selected = option == selected,
+                    onClick = { onSelect(option) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChoiceChip(label: String, selected: Boolean, onClick: () -> Unit) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    val focused by interaction.collectIsFocusedAsState()
+    Box(
+        Modifier
+            .hoverable(interaction)
+            .pointerHoverIcon(PointerIcon.Hand)
+            .background(if (selected) AarisColor.BgHover else Color.Transparent)
+            // The AARIS look has no ripple, so focus has to be drawn explicitly or a keyboard-only
+            // user cannot see where they are.
+            .border(
+                1.dp,
+                when {
+                    focused -> AarisColor.Accent
+                    selected -> AarisColor.Ink
+                    hovered -> AarisColor.Muted
+                    else -> AarisColor.Line
+                },
+            )
+            .selectable(
+                selected = selected,
+                interactionSource = interaction,
+                indication = null,
+                role = Role.RadioButton,
+                onClick = onClick,
+            )
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+    ) {
+        MetaText(label, color = if (selected || hovered || focused) AarisColor.Ink else AarisColor.Muted)
+    }
+}
+
+@Composable
+private fun ToggleRow(
+    label: String,
+    description: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            MetaText(label)
+            Text(description, style = MaterialTheme.typography.bodyMedium, color = AarisColor.Muted)
+        }
+        Spacer(Modifier.width(16.dp))
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            modifier = Modifier.semantics { contentDescription = label },
+        )
+    }
 }
 
 @Composable

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ShortcutsDialog.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ShortcutsDialog.kt
@@ -1,0 +1,98 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.nav.ShortcutHelpTable
+
+/**
+ * The in-app keyboard reference.
+ *
+ * Required by the issue in its own right — a shortcut nobody can discover is not a feature — and
+ * it is also the only place the *alternatives* are written down, since the matcher accepts several
+ * combinations per action.
+ *
+ * The table itself lives next to the matcher in `nav/Shortcuts.kt`, so adding a binding and
+ * documenting it are one edit rather than two.
+ */
+@Composable
+fun ShortcutsDialog(onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = Modifier
+            // Escape closes this before anything else acts on it, matching every other overlay.
+            .onPreviewKeyEvent { event ->
+                if (event.type == KeyEventType.KeyDown && event.key == Key.Escape) {
+                    onDismiss()
+                    true
+                } else {
+                    false
+                }
+            }
+            .semantics { paneTitle = "Keyboard shortcuts" },
+        containerColor = AarisColor.BgRaise,
+        shape = RectangleShape,
+        title = {
+            Column {
+                MetaText(text = "// Keyboard", color = AarisColor.Accent)
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    "Shortcuts",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = AarisColor.Ink,
+                )
+            }
+        },
+        text = {
+            Column(
+                Modifier.heightIn(max = 420.dp).verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                MetaText("Shortcuts that would type into a search box are ignored while you are typing there.")
+                Spacer(Modifier.height(2.dp))
+                ShortcutHelpTable.forEach { row ->
+                    Row(Modifier.fillMaxWidth()) {
+                        MetaText(
+                            text = row.keys,
+                            color = AarisColor.Ink,
+                            modifier = Modifier.width(190.dp),
+                        )
+                        Text(
+                            row.action,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = AarisColor.Muted,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss, shape = RectangleShape) {
+                Text("CLOSE", color = AarisColor.Ink)
+            }
+        },
+    )
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackHistoryTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackHistoryTest.kt
@@ -1,0 +1,229 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Local listening history: what "last heard" picks, how the list is bounded, and what a dismissal
+ * actually applies to.
+ */
+class PlaybackHistoryTest {
+
+    private fun snapshot(
+        fictionId: Int = 1,
+        chapterId: Int = 1,
+        positionSeconds: Double = 60.0,
+        durationSeconds: Double = 600.0,
+        recordedAtMs: Long = 1_000L,
+        dismissed: Boolean = false,
+    ) = PlaybackSnapshot(
+        fictionId = fictionId,
+        chapterId = chapterId,
+        fictionTitle = "Fiction $fictionId",
+        chapterTitle = "Chapter $chapterId",
+        positionSeconds = positionSeconds,
+        durationSeconds = durationSeconds,
+        recordedAtMs = recordedAtMs,
+        dismissed = dismissed,
+    )
+
+    // --- Thinning -------------------------------------------------------------------------------
+
+    @Test
+    fun `listening to one chapter leaves one record, at the furthest point reached`() {
+        var history = PlaybackHistory.record(emptyList(), snapshot(positionSeconds = 10.0, recordedAtMs = 1))
+        history = PlaybackHistory.record(history, snapshot(positionSeconds = 300.0, recordedAtMs = 2))
+
+        assertEquals(1, history.size)
+        assertEquals(300.0, history.single().positionSeconds)
+    }
+
+    @Test
+    fun `the list is capped and drops the oldest`() {
+        var history = emptyList<PlaybackSnapshot>()
+        repeat(PlaybackHistory.MaxEntries + 20) { index ->
+            history = PlaybackHistory.record(
+                history,
+                snapshot(fictionId = index, chapterId = index, recordedAtMs = index.toLong()),
+            )
+        }
+
+        assertEquals(PlaybackHistory.MaxEntries, history.size)
+        // Newest first, and the oldest are the ones gone.
+        assertEquals((PlaybackHistory.MaxEntries + 19).toLong(), history.first().recordedAtMs)
+        assertTrue(history.none { it.recordedAtMs < 20 })
+    }
+
+    @Test
+    fun `records are newest first`() {
+        var history = PlaybackHistory.record(emptyList(), snapshot(chapterId = 1, recordedAtMs = 100))
+        history = PlaybackHistory.record(history, snapshot(chapterId = 2, recordedAtMs = 50))
+        assertEquals(listOf(1, 2), history.map { it.chapterId })
+    }
+
+    // --- Dismissal ------------------------------------------------------------------------------
+
+    @Test
+    fun `a dismissal survives the next progress save for the same chapter`() {
+        // Without this the 10-second progress tick would undo a dismissal the moment it was made.
+        var history = PlaybackHistory.record(emptyList(), snapshot(chapterId = 7, recordedAtMs = 1))
+        history = PlaybackHistory.dismiss(history, "1:7")
+        history = PlaybackHistory.record(history, snapshot(chapterId = 7, positionSeconds = 120.0, recordedAtMs = 2))
+
+        assertTrue(history.single().dismissed)
+        assertNull(PlaybackHistory.lastHeard(history))
+    }
+
+    @Test
+    fun `dismissal applies to the snapshot, so a different chapter still appears`() {
+        // The requirement, stated as a test: this is not "hide for today".
+        var history = PlaybackHistory.record(emptyList(), snapshot(chapterId = 7, recordedAtMs = 1))
+        history = PlaybackHistory.dismiss(history, "1:7")
+        history = PlaybackHistory.record(history, snapshot(chapterId = 8, recordedAtMs = 2))
+
+        val lastHeard = PlaybackHistory.lastHeard(history)
+        assertEquals(8, lastHeard?.chapterId)
+    }
+
+    @Test
+    fun `dismissing one chapter leaves the others alone`() {
+        var history = PlaybackHistory.record(emptyList(), snapshot(chapterId = 1, recordedAtMs = 1))
+        history = PlaybackHistory.record(history, snapshot(chapterId = 2, recordedAtMs = 2))
+        history = PlaybackHistory.dismiss(history, "1:1")
+
+        assertTrue(history.first { it.chapterId == 1 }.dismissed)
+        assertFalse(history.first { it.chapterId == 2 }.dismissed)
+    }
+
+    // --- Last heard and jump-back ---------------------------------------------------------------
+
+    @Test
+    fun `last heard is the most recent resumable snapshot`() {
+        var history = PlaybackHistory.record(emptyList(), snapshot(chapterId = 1, recordedAtMs = 10))
+        history = PlaybackHistory.record(history, snapshot(chapterId = 2, recordedAtMs = 20))
+        assertEquals(2, PlaybackHistory.lastHeard(history)?.chapterId)
+    }
+
+    @Test
+    fun `a finished chapter is not offered as somewhere to continue`() {
+        // At 96% the controller has already marked it played, so "continue" would mean "replay the
+        // last few seconds and auto-advance".
+        val finished = snapshot(positionSeconds = 599.0, durationSeconds = 600.0)
+        assertNull(PlaybackHistory.lastHeard(listOf(finished)))
+    }
+
+    @Test
+    fun `a chapter with an unknown duration is still offered`() {
+        // Progress reads as zero rather than as finished, which is the safe way round.
+        val unknown = snapshot(positionSeconds = 30.0, durationSeconds = 0.0)
+        assertEquals(unknown.chapterId, PlaybackHistory.lastHeard(listOf(unknown))?.chapterId)
+    }
+
+    @Test
+    fun `last heard is null when everything is dismissed`() {
+        val history = listOf(snapshot(dismissed = true))
+        assertNull(PlaybackHistory.lastHeard(history))
+    }
+
+    @Test
+    fun `jump-back offers one entry per fiction, newest first`() {
+        var history = emptyList<PlaybackSnapshot>()
+        // Two chapters of one serial, then one of another. The serial must appear once.
+        history = PlaybackHistory.record(history, snapshot(fictionId = 1, chapterId = 1, recordedAtMs = 1))
+        history = PlaybackHistory.record(history, snapshot(fictionId = 1, chapterId = 2, recordedAtMs = 2))
+        history = PlaybackHistory.record(history, snapshot(fictionId = 2, chapterId = 9, recordedAtMs = 3))
+
+        val choices = PlaybackHistory.jumpBackChoices(history)
+        assertEquals(listOf(2, 1), choices.map { it.fictionId })
+        assertEquals(2, choices.first { it.fictionId == 1 }.chapterId)
+    }
+
+    @Test
+    fun `jump-back is limited and skips dismissed entries`() {
+        var history = emptyList<PlaybackSnapshot>()
+        repeat(10) { index ->
+            history = PlaybackHistory.record(
+                history,
+                snapshot(fictionId = index, chapterId = index, recordedAtMs = index.toLong()),
+            )
+        }
+        history = PlaybackHistory.dismiss(history, "9:9")
+
+        val choices = PlaybackHistory.jumpBackChoices(history, limit = 3)
+        assertEquals(3, choices.size)
+        assertTrue(choices.none { it.fictionId == 9 })
+    }
+
+    @Test
+    fun `progress is bounded to zero and one`() {
+        assertEquals(0f, snapshot(positionSeconds = -5.0).progress)
+        assertEquals(1f, snapshot(positionSeconds = 9_999.0, durationSeconds = 600.0).progress)
+        assertEquals(0f, snapshot(durationSeconds = 0.0).progress)
+    }
+
+    // --- The file store -------------------------------------------------------------------------
+
+    @Test
+    fun `history survives a restart`(@TempDir dir: File) {
+        val file = dir.resolve("history.json")
+        FilePlaybackHistoryStore(file).record(snapshot(chapterId = 4, recordedAtMs = 99))
+
+        val reloaded = FilePlaybackHistoryStore(file).history.value
+        assertEquals(1, reloaded.size)
+        assertEquals(4, reloaded.single().chapterId)
+    }
+
+    @Test
+    fun `a dismissal survives a restart`(@TempDir dir: File) {
+        val file = dir.resolve("history.json")
+        val store = FilePlaybackHistoryStore(file)
+        store.record(snapshot(chapterId = 4))
+        store.dismiss("1:4")
+
+        assertTrue(FilePlaybackHistoryStore(file).history.value.single().dismissed)
+    }
+
+    @Test
+    fun `an oversized file from another build is trimmed on the way in`(@TempDir dir: File) {
+        val file = dir.resolve("history.json")
+        val store = FilePlaybackHistoryStore(file)
+        repeat(PlaybackHistory.MaxEntries + 30) { index ->
+            store.record(snapshot(fictionId = index, chapterId = index, recordedAtMs = index.toLong()))
+        }
+        assertEquals(PlaybackHistory.MaxEntries, FilePlaybackHistoryStore(file).history.value.size)
+    }
+
+    @Test
+    fun `a corrupt file degrades to an empty history`(@TempDir dir: File) {
+        val file = dir.resolve("history.json")
+        file.writeText("not json at all")
+        assertTrue(FilePlaybackHistoryStore(file).history.value.isEmpty())
+    }
+
+    @Test
+    fun `the history file holds no server address and no credential`(@TempDir dir: File) {
+        // The type has nowhere to put one, which is the real guarantee; this asserts the shape of
+        // what actually lands on disk.
+        val file = dir.resolve("history.json")
+        FilePlaybackHistoryStore(file).record(snapshot())
+        val text = file.readText()
+        assertFalse(text.contains("http", ignoreCase = true))
+        assertFalse(text.contains("token", ignoreCase = true))
+        assertFalse(text.contains("bearer", ignoreCase = true))
+    }
+
+    @Test
+    fun `clearing empties the file`(@TempDir dir: File) {
+        val file = dir.resolve("history.json")
+        val store = FilePlaybackHistoryStore(file)
+        store.record(snapshot())
+        store.clear()
+        assertTrue(store.history.value.isEmpty())
+        assertTrue(FilePlaybackHistoryStore(file).history.value.isEmpty())
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackPreferencesTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackPreferencesTest.kt
@@ -1,0 +1,167 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Listening preferences: defaults, the migration rules for a file this build did not write, and
+ * the promise that they are not tied to a session.
+ */
+class PlaybackPreferencesTest {
+
+    // --- Defaults -------------------------------------------------------------------------------
+
+    @Test
+    fun `skip silence is off by default, matching mobile and the web player`() {
+        assertFalse(PlaybackPreferences().skipSilence)
+    }
+
+    @Test
+    fun `the defaults are normal speed, thirty seconds and no boost`() {
+        val defaults = PlaybackPreferences()
+        assertEquals(1f, defaults.speed)
+        assertEquals(30, defaults.skipIntervalSeconds)
+        assertEquals(VolumeBoost.Off, defaults.volumeBoost)
+        assertEquals(30_000L, defaults.skipIntervalMs)
+    }
+
+    @Test
+    fun `volume boost stops below the level that clips`() {
+        // The ladder is deliberately capped; the assertion is here so raising it is a decision
+        // somebody takes on purpose rather than a number that drifts.
+        assertTrue(VolumeBoost.entries.all { it.gain <= 2.0 })
+        assertEquals(1.0, VolumeBoost.Off.gain)
+    }
+
+    // --- Speed options --------------------------------------------------------------------------
+
+    @Test
+    fun `the offered speeds include 1_25x`() {
+        assertTrue(PlaybackPreferences.SpeedPresets.any { kotlin.math.abs(it - 1.25f) < 0.001f })
+    }
+
+    @Test
+    fun `a custom speed from another build stays selectable`() {
+        // The requirement is "preserve an older custom value": a listener on 1.35x must not have it
+        // silently rounded away the first time they open the menu in this build.
+        val options = PlaybackPreferences.speedOptions(1.35f)
+        assertTrue(options.any { kotlin.math.abs(it - 1.35f) < 0.001f })
+        assertEquals(options.sorted(), options)
+        assertEquals(PlaybackPreferences.SpeedPresets.size + 1, options.size)
+    }
+
+    @Test
+    fun `a speed that is already a preset does not duplicate it`() {
+        assertEquals(PlaybackPreferences.SpeedPresets, PlaybackPreferences.speedOptions(1.25f))
+    }
+
+    // --- Migration and clamping -----------------------------------------------------------------
+
+    @Test
+    fun `a stored speed outside the supported range is clamped, not rejected`() {
+        assertEquals(3.0f, PlaybackPreferences.normaliseSpeed(9f))
+        assertEquals(0.5f, PlaybackPreferences.normaliseSpeed(0.01f))
+        assertEquals(1f, PlaybackPreferences.normaliseSpeed(Float.NaN))
+    }
+
+    @Test
+    fun `a skip interval this build does not offer snaps to the nearest one`() {
+        // Snapping rather than defaulting: a stored 20 means somebody chose 20, and 15 is a closer
+        // answer to that than 30 is.
+        assertEquals(15, PlaybackPreferences.normaliseSkipSeconds(20))
+        assertEquals(60, PlaybackPreferences.normaliseSkipSeconds(120))
+        assertEquals(10, PlaybackPreferences.normaliseSkipSeconds(0))
+    }
+
+    @Test
+    fun `a file with no fields at all loads as the defaults`() {
+        assertEquals(PlaybackPreferences(), StoredPlaybackPreferences().toPreferences())
+    }
+
+    @Test
+    fun `an unknown volume boost falls back to off rather than to the loudest step`() {
+        val stored = StoredPlaybackPreferences(volumeBoost = "Deafening")
+        assertEquals(VolumeBoost.Off, stored.toPreferences().volumeBoost)
+    }
+
+    @Test
+    fun `a volume boost is matched case-insensitively`() {
+        assertEquals(
+            VolumeBoost.Medium,
+            StoredPlaybackPreferences(volumeBoost = "medium").toPreferences().volumeBoost,
+        )
+    }
+
+    @Test
+    fun `an out-of-range stored file is migrated on the way in`() {
+        val stored = StoredPlaybackPreferences(speed = 42f, skipIntervalSeconds = 7, skipSilence = true)
+        val loaded = stored.toPreferences()
+        assertEquals(3.0f, loaded.speed)
+        assertEquals(10, loaded.skipIntervalSeconds)
+        assertTrue(loaded.skipSilence)
+    }
+
+    // --- The file store -------------------------------------------------------------------------
+
+    @Test
+    fun `preferences survive a restart`(@TempDir dir: File) {
+        val file = dir.resolve("playback.json")
+        FilePlaybackPreferencesStore(file).update {
+            it.copy(speed = 1.5f, skipIntervalSeconds = 15, skipSilence = true, volumeBoost = VolumeBoost.Low)
+        }
+
+        // A second store over the same file is what "after a restart" means here.
+        val reloaded = FilePlaybackPreferencesStore(file).preferences.value
+        assertEquals(1.5f, reloaded.speed)
+        assertEquals(15, reloaded.skipIntervalSeconds)
+        assertTrue(reloaded.skipSilence)
+        assertEquals(VolumeBoost.Low, reloaded.volumeBoost)
+    }
+
+    @Test
+    fun `a missing file is not an error`(@TempDir dir: File) {
+        val store = FilePlaybackPreferencesStore(dir.resolve("absent.json"))
+        assertEquals(PlaybackPreferences(), store.preferences.value)
+    }
+
+    @Test
+    fun `a corrupt file degrades to the defaults instead of failing startup`(@TempDir dir: File) {
+        val file = dir.resolve("playback.json")
+        file.writeText("{ this is not json")
+        assertEquals(PlaybackPreferences(), FilePlaybackPreferencesStore(file).preferences.value)
+    }
+
+    @Test
+    fun `an unusable stored value is clamped on write as well as on read`(@TempDir dir: File) {
+        val file = dir.resolve("playback.json")
+        val store = FilePlaybackPreferencesStore(file)
+        store.update { it.copy(speed = 99f, skipIntervalSeconds = 3) }
+        // Never in memory either, so nothing hands the engine a rate it cannot honour.
+        assertEquals(3.0f, store.preferences.value.speed)
+        assertEquals(10, store.preferences.value.skipIntervalSeconds)
+    }
+
+    @Test
+    fun `the preferences file holds no credential and no server address`(@TempDir dir: File) {
+        val file = dir.resolve("playback.json")
+        FilePlaybackPreferencesStore(file).update { it.copy(speed = 2f) }
+        val text = file.readText()
+        assertFalse(text.contains("http", ignoreCase = true))
+        assertFalse(text.contains("token", ignoreCase = true))
+    }
+
+    @Test
+    fun `preferences live outside the session file, so signing out cannot reset them`(@TempDir dir: File) {
+        // The guarantee is structural rather than behavioural: this store has no reference to a
+        // session at all, and its file is a different one.
+        val prefsFile = dir.resolve("playback.json")
+        FilePlaybackPreferencesStore(prefsFile).update { it.copy(speed = 2f) }
+        assertTrue(prefsFile.isFile)
+        assertFalse(prefsFile.name.contains("session"))
+        assertEquals(2f, FilePlaybackPreferencesStore(prefsFile).preferences.value.speed)
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/nav/ShortcutsTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/nav/ShortcutsTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
 
 class ShortcutsTest {
@@ -17,10 +18,13 @@ class ShortcutsTest {
     }
 
     @Test
-    fun `left on its own is not Back`() {
-        // Otherwise the arrow key would navigate out of a screen while a slider or a text field is
-        // being driven from the keyboard.
-        assertNull(shortcutFor(Key.DirectionLeft, KeyEventType.KeyDown))
+    fun `left on its own seeks rather than navigating back`() {
+        // Back has to keep its modifier: an arrow key that leaves the screen would fire every time
+        // someone nudged the scrubber from the keyboard.
+        assertEquals(
+            AppShortcut.SeekBackward,
+            shortcutFor(Key.DirectionLeft, KeyEventType.KeyDown),
+        )
     }
 
     @Test
@@ -54,6 +58,107 @@ class ShortcutsTest {
         assertNull(shortcutFor(Key.F5, KeyEventType.KeyUp))
         assertNull(shortcutFor(Key.Escape, KeyEventType.KeyUp))
         assertNull(shortcutFor(Key.DirectionLeft, KeyEventType.KeyUp, alt = true))
+    }
+
+    // --- Transport and navigation shortcuts -----------------------------------------------------
+
+    @Test
+    fun `space is play-pause`() {
+        assertEquals(AppShortcut.PlayPause, shortcutFor(Key.Spacebar, KeyEventType.KeyDown))
+    }
+
+    @Test
+    fun `bare arrows seek and ctrl-arrows change chapter`() {
+        assertEquals(AppShortcut.SeekForward, shortcutFor(Key.DirectionRight, KeyEventType.KeyDown))
+        assertEquals(
+            AppShortcut.PreviousChapter,
+            shortcutFor(Key.DirectionLeft, KeyEventType.KeyDown, ctrl = true),
+        )
+        assertEquals(
+            AppShortcut.NextChapter,
+            shortcutFor(Key.DirectionRight, KeyEventType.KeyDown, ctrl = true),
+        )
+    }
+
+    @Test
+    fun `alt-left stays Back even though ctrl-left is a chapter`() {
+        // The two are one keystroke apart, so the ordering inside the matcher is load-bearing.
+        assertEquals(AppShortcut.Back, shortcutFor(Key.DirectionLeft, KeyEventType.KeyDown, alt = true))
+    }
+
+    @Test
+    fun `ctrl-L opens the library and ctrl-comma opens settings`() {
+        assertEquals(AppShortcut.OpenLibrary, shortcutFor(Key.L, KeyEventType.KeyDown, ctrl = true))
+        assertEquals(AppShortcut.OpenSettings, shortcutFor(Key.Comma, KeyEventType.KeyDown, ctrl = true))
+    }
+
+    @Test
+    fun `F1 and ctrl-slash both open the shortcut list`() {
+        assertEquals(AppShortcut.ShowShortcuts, shortcutFor(Key.F1, KeyEventType.KeyDown))
+        assertEquals(AppShortcut.ShowShortcuts, shortcutFor(Key.Slash, KeyEventType.KeyDown, ctrl = true))
+    }
+
+    @Test
+    fun `the keyboard transport row maps to the same actions`() {
+        assertEquals(AppShortcut.PlayPause, shortcutFor(Key.MediaPlayPause, KeyEventType.KeyDown))
+        assertEquals(AppShortcut.NextChapter, shortcutFor(Key.MediaNext, KeyEventType.KeyDown))
+        assertEquals(AppShortcut.PreviousChapter, shortcutFor(Key.MediaPrevious, KeyEventType.KeyDown))
+    }
+
+    // --- Typing safety --------------------------------------------------------------------------
+
+    @Test
+    fun `editing keys do not fire while a text field has focus`() {
+        // The requirement in one place: a space in the search box types a space.
+        assertNull(shortcutFor(Key.Spacebar, KeyEventType.KeyDown, textInputFocused = true))
+        assertNull(shortcutFor(Key.DirectionLeft, KeyEventType.KeyDown, textInputFocused = true))
+        assertNull(shortcutFor(Key.DirectionRight, KeyEventType.KeyDown, textInputFocused = true))
+        // Ctrl+arrow is word navigation in a text field, so it is suppressed too.
+        assertNull(
+            shortcutFor(Key.DirectionLeft, KeyEventType.KeyDown, ctrl = true, textInputFocused = true),
+        )
+    }
+
+    @Test
+    fun `window shortcuts still work while typing`() {
+        assertEquals(
+            AppShortcut.Refresh,
+            shortcutFor(Key.F5, KeyEventType.KeyDown, textInputFocused = true),
+        )
+        assertEquals(
+            AppShortcut.Dismiss,
+            shortcutFor(Key.Escape, KeyEventType.KeyDown, textInputFocused = true),
+        )
+        assertEquals(
+            AppShortcut.OpenLibrary,
+            shortcutFor(Key.L, KeyEventType.KeyDown, ctrl = true, textInputFocused = true),
+        )
+    }
+
+    @Test
+    fun `every shortcut declares whether it is safe mid-word`() {
+        // Guards the two-handler split in `App`: a new shortcut has to answer this question, and
+        // the answer has to match whether the key is one a text field claims.
+        val editingKeys = setOf(
+            AppShortcut.PlayPause,
+            AppShortcut.SeekBackward,
+            AppShortcut.SeekForward,
+            AppShortcut.PreviousChapter,
+            AppShortcut.NextChapter,
+        )
+        AppShortcut.entries.forEach { shortcut ->
+            assertEquals(
+                shortcut !in editingKeys,
+                shortcut.firesWhileTyping,
+                "$shortcut is classified on the wrong side of the typing guard",
+            )
+        }
+    }
+
+    @Test
+    fun `the help table is not empty and every row is filled in`() {
+        assertTrue(ShortcutHelpTable.isNotEmpty())
+        assertTrue(ShortcutHelpTable.all { it.keys.isNotBlank() && it.action.isNotBlank() })
     }
 
     // --- Escape precedence --------------------------------------------------------------------

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/MprisStateTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/MprisStateTest.kt
@@ -1,0 +1,160 @@
+package dk.perspektiva.ttsroad.desktop.player
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The MPRIS mapping, which is the half of the D-Bus integration worth testing.
+ *
+ * Everything here runs without a session bus: [Mpris] is deliberately free of D-Bus types so the
+ * audiobook-specific decisions — chapter as title, serial as album, what happens when nothing is
+ * loaded — can be asserted on any machine, CI included.
+ */
+class MprisStateTest {
+
+    private fun playing(
+        title: String = "Chapter 12",
+        fictionTitle: String? = "A Long Serial",
+        chapterId: Int = 12,
+        durationMs: Long = 600_000,
+        positionMs: Long = 61_000,
+        isPlaying: Boolean = true,
+        hasMedia: Boolean = true,
+    ) = PlayerUiState(
+        title = title,
+        fictionTitle = fictionTitle,
+        fictionId = 3,
+        coverImageUrl = "https://server.example/covers/3.jpg",
+        isPlaying = isPlaying,
+        hasMedia = hasMedia,
+        positionMs = positionMs,
+        durationMs = durationMs,
+        queue = listOf(QueueItem(chapterId, title)),
+        currentIndex = 0,
+    )
+
+    // --- Playback status ------------------------------------------------------------------------
+
+    @Test
+    fun `status maps the three states the wire has`() {
+        assertEquals(MprisPlaybackStatus.Playing, Mpris.statusOf(playing()))
+        assertEquals(MprisPlaybackStatus.Paused, Mpris.statusOf(playing(isPlaying = false)))
+        assertEquals(MprisPlaybackStatus.Stopped, Mpris.statusOf(PlayerUiState()))
+    }
+
+    @Test
+    fun `a paused player with no media is stopped, not paused`() {
+        // "Paused" with nothing loaded makes a panel applet draw a resume button that cannot work.
+        assertEquals(
+            MprisPlaybackStatus.Stopped,
+            Mpris.statusOf(playing(hasMedia = false, isPlaying = false)),
+        )
+    }
+
+    @Test
+    fun `the wire names are exactly the spec's`() {
+        assertEquals("Playing", MprisPlaybackStatus.Playing.wireName)
+        assertEquals("Paused", MprisPlaybackStatus.Paused.wireName)
+        assertEquals("Stopped", MprisPlaybackStatus.Stopped.wireName)
+    }
+
+    // --- Metadata -------------------------------------------------------------------------------
+
+    @Test
+    fun `the chapter is the title and the serial is the album`() {
+        val track = Mpris.trackOf(playing())
+        assertEquals("Chapter 12", track?.title)
+        assertEquals("A Long Serial", track?.album)
+        assertEquals(listOf("A Long Serial"), track?.artists)
+    }
+
+    @Test
+    fun `length is microseconds, not milliseconds`() {
+        assertEquals(600_000_000L, Mpris.trackOf(playing())?.lengthMicros)
+    }
+
+    @Test
+    fun `position is microseconds and never negative`() {
+        assertEquals(61_000_000L, Mpris.positionMicros(playing()))
+        assertEquals(0L, Mpris.positionMicros(playing(positionMs = -1)))
+    }
+
+    @Test
+    fun `nothing loaded means no track at all`() {
+        assertNull(Mpris.trackOf(PlayerUiState()))
+    }
+
+    @Test
+    fun `a standalone chapter with no serial reports no artist rather than a blank one`() {
+        // An empty string in xesam:artist renders as a dangling separator in several shells.
+        val track = Mpris.trackOf(playing(fictionTitle = null))
+        assertNull(track?.album)
+        assertEquals(emptyList(), track?.artists)
+    }
+
+    @Test
+    fun `a blank serial title is treated as absent`() {
+        assertEquals(emptyList(), Mpris.trackOf(playing(fictionTitle = "   "))?.artists)
+    }
+
+    // --- Track ids ------------------------------------------------------------------------------
+
+    @Test
+    fun `a track id is a valid D-Bus object path`() {
+        val path = Mpris.trackPath(12)
+        assertTrue(path.startsWith("/"))
+        // Object paths admit only these characters between slashes; a malformed one makes the
+        // whole Metadata property fail to marshal and takes the applet's display with it.
+        assertTrue(path.drop(1).split("/").all { segment -> segment.all { it.isLetterOrDigit() || it == '_' } })
+        assertTrue(path.split("/").drop(1).none { it.isEmpty() })
+    }
+
+    @Test
+    fun `an unusable chapter id becomes the spec's no-track path`() {
+        assertEquals(Mpris.NoTrackPath, Mpris.trackPath(0))
+        assertEquals(Mpris.NoTrackPath, Mpris.trackPath(-4))
+    }
+
+    @Test
+    fun `different chapters get different track ids`() {
+        assertTrue(Mpris.trackPath(11) != Mpris.trackPath(12))
+    }
+
+    // --- Seek acceptance ------------------------------------------------------------------------
+
+    @Test
+    fun `a seek for the loaded chapter is accepted`() {
+        val state = playing()
+        assertTrue(Mpris.acceptsSeekFor(state, Mpris.trackPath(12)))
+    }
+
+    @Test
+    fun `a seek for a chapter that has since changed is ignored`() {
+        // Otherwise the new chapter is seeked to the old one's offset.
+        assertFalse(Mpris.acceptsSeekFor(playing(), Mpris.trackPath(11)))
+    }
+
+    @Test
+    fun `no seek is accepted when nothing is loaded`() {
+        assertFalse(Mpris.acceptsSeekFor(PlayerUiState(), Mpris.NoTrackPath))
+    }
+
+    // --- Identity -------------------------------------------------------------------------------
+
+    @Test
+    fun `the bus name and object path match the MPRIS spec`() {
+        assertEquals("org.mpris.MediaPlayer2", Mpris.BusNamePrefix)
+        assertEquals("/org/mpris/MediaPlayer2", Mpris.ObjectPath)
+        assertEquals("org.mpris.MediaPlayer2.Player", Mpris.PlayerInterface)
+        // The name the app claims has to sit under the prefix or no client will find it.
+        assertTrue("${Mpris.BusNamePrefix}.${Mpris.Identity}".startsWith("${Mpris.BusNamePrefix}."))
+    }
+
+    @Test
+    fun `artwork is published so the desktop can draw a cover`() {
+        assertEquals("https://server.example/covers/3.jpg", Mpris.trackOf(playing())?.artUrl)
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/MprisStateTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/MprisStateTest.kt
@@ -157,4 +157,51 @@ class MprisStateTest {
     fun `artwork is published so the desktop can draw a cover`() {
         assertEquals("https://server.example/covers/3.jpg", Mpris.trackOf(playing())?.artUrl)
     }
+
+    // --- Which transitions are announced --------------------------------------------------------
+
+    @Test
+    fun `a chapter that learns its duration announces CanSeek`() {
+        // The API gave no audio_duration, so the chapter starts unseekable; the engine reports a
+        // duration a moment later. hasMedia is true throughout, which is exactly why this edge was
+        // missed: a client that caches the flag would leave seeking greyed out for the whole
+        // chapter.
+        val unknown = playing(durationMs = 0)
+        val known = playing(durationMs = 600_000)
+
+        assertFalse(Mpris.canSeek(unknown))
+        assertTrue(Mpris.canSeek(known))
+        assertTrue("CanSeek" in Mpris.changedPropertyNames(unknown, known))
+    }
+
+    @Test
+    fun `a position tick alone announces nothing`() {
+        // Position is excluded from PropertiesChanged by the spec, so the 250 ms tick must be
+        // silent on the bus or the player becomes a signal storm.
+        val before = playing(positionMs = 61_000)
+        val after = playing(positionMs = 61_250)
+
+        assertEquals(emptySet(), Mpris.changedPropertyNames(before, after))
+    }
+
+    @Test
+    fun `pausing announces the status and nothing else`() {
+        val changed = Mpris.changedPropertyNames(playing(), playing(isPlaying = false))
+        assertEquals(setOf("PlaybackStatus"), changed)
+    }
+
+    @Test
+    fun `loading a chapter announces the transport flags and the metadata`() {
+        val changed = Mpris.changedPropertyNames(PlayerUiState(), playing())
+        assertTrue(changed.containsAll(setOf("PlaybackStatus", "Metadata", "CanPlay", "CanPause", "CanSeek")))
+    }
+
+    @Test
+    fun `changing chapter announces new metadata`() {
+        val changed = Mpris.changedPropertyNames(
+            playing(title = "Chapter 12", chapterId = 12),
+            playing(title = "Chapter 13", chapterId = 13),
+        )
+        assertTrue("Metadata" in changed)
+    }
 }

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackPreferencesApplyTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackPreferencesApplyTest.kt
@@ -1,0 +1,344 @@
+package dk.perspektiva.ttsroad.desktop.player
+
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.data.AudioInfo
+import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
+import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackHistoryStore
+import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.PlaybackInfo
+import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferences
+import dk.perspektiva.ttsroad.desktop.data.VolumeBoost
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Test
+
+/**
+ * That the listening preferences and the sleep timer actually reach the engine.
+ *
+ * The issue's requirement is that they apply "in the playback service/engine, not only the visible
+ * player" — so these drive the controller, not a screen, and assert on what the *engine* was told.
+ */
+class PlaybackPreferencesApplyTest {
+
+    private class FakeClock(var nowMs: Long = 500_000L) : () -> Long {
+        override fun invoke(): Long = nowMs
+    }
+
+    private fun chapter(id: Int, durationSeconds: Double = 600.0) = ChapterSummary(
+        id = id,
+        fictionId = 7,
+        title = "Chapter $id",
+        audioDuration = durationSeconds,
+        playable = true,
+        audio = AudioInfo(url = "/audio/serial/$id.mp3"),
+        playback = PlaybackInfo(positionSeconds = 0.0),
+    )
+
+    private fun controller(
+        engine: FakePlaybackEngine,
+        preferences: InMemoryPlaybackPreferencesStore = InMemoryPlaybackPreferencesStore(),
+        history: InMemoryPlaybackHistoryStore = InMemoryPlaybackHistoryStore(),
+        sleepTimer: SleepTimer = SleepTimer(),
+        clock: () -> Long = System::currentTimeMillis,
+    ) = QueuePlaybackController(
+        repository = FakeRepository(),
+        sources = FakeMediaSourceFactory(),
+        engine = engine,
+        ioDispatcher = Dispatchers.Default,
+        preferencesStore = preferences,
+        historyStore = history,
+        sleepTimer = sleepTimer,
+        clock = clock,
+        retryDelaysMs = emptyList(),
+        tickIntervalMs = 10,
+    )
+
+    /**
+     * Waits for a published state, with a bound.
+     *
+     * A bare `state.first { }` that never matches hangs the whole test run rather than failing
+     * this one test, which is a much worse way to find out something regressed.
+     */
+    private suspend fun PlaybackController.await(
+        description: String,
+        predicate: (PlayerUiState) -> Boolean,
+    ): PlayerUiState = try {
+        withTimeout(10_000) { state.first(predicate) }
+    } catch (_: TimeoutCancellationException) {
+        fail("timed out waiting for: $description; last state was ${state.value}")
+    }
+
+    private suspend fun awaitCondition(what: String, timeoutMs: Long = 10_000, predicate: () -> Boolean) {
+        val deadline = System.nanoTime() + timeoutMs * 1_000_000
+        while (System.nanoTime() < deadline) {
+            if (predicate()) return
+            delay(10)
+        }
+        fail("timed out waiting for: $what")
+    }
+
+    // --- Preferences reaching the engine --------------------------------------------------------
+
+    @Test
+    fun `a saved speed reaches the engine before the first chapter, not one chapter late`() = runBlocking {
+        val engine = FakePlaybackEngine()
+        val preferences = InMemoryPlaybackPreferencesStore(PlaybackPreferences(speed = 1.5f))
+        controller(engine, preferences)
+
+        awaitCondition("the restored rate to be applied") { engine.requestedRates.contains(1.5f) }
+    }
+
+    @Test
+    fun `a saved volume boost reaches the engine as a gain`() = runBlocking {
+        val engine = FakePlaybackEngine()
+        val preferences = InMemoryPlaybackPreferencesStore(
+            PlaybackPreferences(volumeBoost = VolumeBoost.Medium),
+        )
+        controller(engine, preferences)
+
+        awaitCondition("the boost to be applied") {
+            engine.gains.any { kotlin.math.abs(it - VolumeBoost.Medium.gain) < 0.001 }
+        }
+    }
+
+    @Test
+    fun `changing skip silence reaches the engine`() = runBlocking {
+        val engine = FakePlaybackEngine(
+            capabilities = EngineCapabilities(variableSpeed = true, skipSilence = true),
+        )
+        val preferences = InMemoryPlaybackPreferencesStore()
+        controller(engine, preferences)
+        awaitCondition("the initial value") { !engine.skipSilenceEnabled }
+
+        preferences.update { it.copy(skipSilence = true) }
+        awaitCondition("skip silence to be enabled") { engine.skipSilenceEnabled }
+    }
+
+    @Test
+    fun `setting the speed persists it rather than only telling the engine`() = runBlocking {
+        // The preference is the source of truth; without this a restart loses the choice.
+        val engine = FakePlaybackEngine()
+        val preferences = InMemoryPlaybackPreferencesStore()
+        val playback = controller(engine, preferences)
+
+        playback.setSpeed(2f)
+        awaitCondition("the speed to be stored") { preferences.preferences.value.speed == 2f }
+        awaitCondition("the engine to be told") { engine.requestedRates.contains(2f) }
+    }
+
+    @Test
+    fun `an engine that cannot resample still stores the wish`() = runBlocking {
+        // So a listener who set 1.5x without GStreamer finds it waiting once they install it.
+        val engine = FakePlaybackEngine(capabilities = EngineCapabilities.FixedSpeed)
+        val preferences = InMemoryPlaybackPreferencesStore()
+        val playback = controller(engine, preferences)
+
+        playback.setSpeed(1.5f)
+        awaitCondition("the wish to be stored") { preferences.preferences.value.speed == 1.5f }
+        // ...but what is *shown* stays honest about what is playing.
+        awaitCondition("the reported speed to stay at 1x") { playback.state.value.speed == 1f }
+    }
+
+    // --- Skip interval --------------------------------------------------------------------------
+
+    @Test
+    fun `skip forward and back use the configured interval`() = runBlocking {
+        val engine = FakePlaybackEngine()
+        val preferences = InMemoryPlaybackPreferencesStore(PlaybackPreferences(skipIntervalSeconds = 15))
+        val playback = controller(engine, preferences)
+
+        playback.playQueue(listOf(chapter(1)), startChapterId = 1, fiction = null)
+        playback.await("media to load") { it.hasMedia }
+        engine.setDuration(600_000)
+        awaitCondition("a duration") { playback.state.value.durationMs > 0 }
+
+        playback.skipForward()
+        awaitCondition("a 15 second skip") { engine.seeks.contains(15_000L) }
+
+        playback.seekTo(100_000)
+        playback.skipBackward()
+        awaitCondition("a 15 second skip back") { engine.seeks.contains(85_000L) }
+    }
+
+    @Test
+    fun `the skip interval is published so the buttons can label themselves`() = runBlocking {
+        val preferences = InMemoryPlaybackPreferencesStore(PlaybackPreferences(skipIntervalSeconds = 45))
+        val playback = controller(FakePlaybackEngine(), preferences)
+        awaitCondition("the interval to reach the state") { playback.state.value.skipIntervalMs == 45_000L }
+    }
+
+    // --- Sleep timer ----------------------------------------------------------------------------
+
+    @Test
+    fun `the fade multiplies with the boost rather than replacing it`() = runBlocking {
+        val engine = FakePlaybackEngine()
+        val clock = FakeClock()
+        val timer = SleepTimer(clock)
+        val preferences = InMemoryPlaybackPreferencesStore(
+            PlaybackPreferences(volumeBoost = VolumeBoost.Low),
+        )
+        val playback = controller(engine, preferences, sleepTimer = timer, clock = clock)
+
+        playback.playQueue(listOf(chapter(1)), startChapterId = 1, fiction = null)
+        playback.await("media to load") { it.hasMedia }
+
+        playback.setSleepTimer(SleepTimerMode.Duration(5))
+        // Into the fade: half way through the last 30 seconds.
+        clock.nowMs += 5 * 60_000L - SleepTimer.FadeMs / 2
+
+        val expected = VolumeBoost.Low.gain * 0.5
+        awaitCondition("boost times fade") {
+            engine.gains.any { kotlin.math.abs(it - expected) < 0.05 }
+        }
+    }
+
+    @Test
+    fun `an expiring timer pauses without dropping the queue`() = runBlocking {
+        // A stop would mean hunting for the chapter in the morning; a pause means one keypress.
+        val engine = FakePlaybackEngine()
+        val clock = FakeClock()
+        val timer = SleepTimer(clock)
+        val playback = controller(engine, sleepTimer = timer, clock = clock)
+
+        playback.playQueue(listOf(chapter(1), chapter(2)), startChapterId = 1, fiction = null)
+        playback.await("media to load") { it.hasMedia }
+
+        playback.setSleepTimer(SleepTimerMode.Duration(5))
+        clock.nowMs += 5 * 60_000L + 1_000
+
+        playback.await("playback to pause") { !it.isPlaying }
+        assertTrue(engine.pauseCount.get() > 0, "the engine was never paused")
+        assertEquals(2, playback.state.value.queue.size, "the queue was cleared by the sleep timer")
+        assertTrue(playback.state.value.hasMedia)
+    }
+
+    @Test
+    fun `end of chapter stops instead of auto-advancing`() = runBlocking {
+        val engine = FakePlaybackEngine(completeOnPlay = true)
+        val timer = SleepTimer()
+        val playback = controller(engine, sleepTimer = timer)
+
+        // Armed before playback starts, so the first boundary is the one that stops.
+        playback.setSleepTimer(SleepTimerMode.EndOfChapter)
+        playback.playQueue(listOf(chapter(1), chapter(2), chapter(3)), startChapterId = 1, fiction = null)
+
+        playback.await("playback to stop at the chapter boundary") { !it.isPlaying && it.hasMedia }
+        // Give any (incorrect) auto-advance a chance to happen before asserting it did not.
+        delay(200)
+        assertEquals(1, engine.prepareCount.get(), "the queue advanced past the sleep boundary")
+    }
+
+    @Test
+    fun `a queue with no sleep timer still auto-advances`() = runBlocking {
+        // The control for the test above: proves the assertion above is about the timer.
+        val engine = FakePlaybackEngine(completeOnPlay = true)
+        val playback = controller(engine)
+
+        playback.playQueue(listOf(chapter(1), chapter(2)), startChapterId = 1, fiction = null)
+        awaitCondition("the second chapter to start") { engine.prepareCount.get() >= 2 }
+    }
+
+    @Test
+    fun `a manual pause freezes the timer and resuming continues it`() = runBlocking {
+        val engine = FakePlaybackEngine()
+        val clock = FakeClock()
+        val timer = SleepTimer(clock)
+        val playback = controller(engine, sleepTimer = timer, clock = clock)
+
+        playback.playQueue(listOf(chapter(1)), startChapterId = 1, fiction = null)
+        playback.await("playback to start") { it.hasMedia && it.isPlaying }
+
+        playback.setSleepTimer(SleepTimerMode.Duration(30))
+        clock.nowMs += 10 * 60_000L
+        playback.togglePlayPause()
+
+        // An hour of being paused must not run the timer down.
+        clock.nowMs += 60 * 60_000L
+        delay(100)
+        assertTrue(playback.state.value.sleepTimer.isArmed, "the timer expired while paused")
+        assertEquals(20 * 60_000L, playback.state.value.sleepTimer.remainingMs)
+    }
+
+    @Test
+    fun `stopping disarms the timer so the next chapter is not silenced`() = runBlocking {
+        val engine = FakePlaybackEngine()
+        val playback = controller(engine)
+
+        playback.playQueue(listOf(chapter(1)), startChapterId = 1, fiction = null)
+        playback.await("media to load") { it.hasMedia }
+        playback.setSleepTimer(SleepTimerMode.Duration(15))
+        awaitCondition("the timer to arm") { playback.state.value.sleepTimer.isArmed }
+
+        playback.stop()
+        awaitCondition("the timer to disarm") { !playback.state.value.sleepTimer.isArmed }
+    }
+
+    // --- History --------------------------------------------------------------------------------
+
+    @Test
+    fun `pausing files a history snapshot`() = runBlocking {
+        val engine = FakePlaybackEngine()
+        val history = InMemoryPlaybackHistoryStore()
+        val clock = FakeClock()
+        val playback = controller(engine, history = history, clock = clock)
+
+        playback.playQueue(listOf(chapter(1)), startChapterId = 1, fiction = null)
+        playback.await("playback to start") { it.hasMedia && it.isPlaying }
+        engine.setDuration(600_000)
+        engine.setPosition(120_000)
+        awaitCondition("a position") { playback.state.value.positionMs > 0 }
+
+        playback.togglePlayPause()
+        awaitCondition("a snapshot") { history.history.value.isNotEmpty() }
+
+        val snapshot = history.history.value.single()
+        assertEquals(7, snapshot.fictionId)
+        assertEquals(1, snapshot.chapterId)
+        assertEquals(clock.nowMs, snapshot.recordedAtMs)
+    }
+
+    @Test
+    fun `a chapter change files a snapshot for the chapter being left`() = runBlocking {
+        val engine = FakePlaybackEngine()
+        val history = InMemoryPlaybackHistoryStore()
+        val playback = controller(engine, history = history)
+
+        playback.playQueue(listOf(chapter(1), chapter(2)), startChapterId = 1, fiction = null)
+        playback.await("media to load") { it.hasMedia }
+        playback.skipToNextChapter()
+
+        awaitCondition("a snapshot for chapter 1") {
+            history.history.value.any { it.chapterId == 1 }
+        }
+    }
+
+    @Test
+    fun `nothing is recorded when nothing has loaded`() = runBlocking {
+        val history = InMemoryPlaybackHistoryStore()
+        val playback = controller(FakePlaybackEngine(), history = history)
+        playback.stop()
+        delay(100)
+        assertTrue(history.history.value.isEmpty())
+    }
+
+    // --- Capability plumbing --------------------------------------------------------------------
+
+    @Test
+    fun `the engine's skip-silence capability reaches the UI state`() = runBlocking {
+        val without = controller(FakePlaybackEngine())
+        assertFalse(without.state.value.canSkipSilence)
+
+        val with = controller(
+            FakePlaybackEngine(capabilities = EngineCapabilities(variableSpeed = true, skipSilence = true)),
+        )
+        assertTrue(with.state.value.canSkipSilence)
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackPreferencesApplyTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackPreferencesApplyTest.kt
@@ -268,6 +268,36 @@ class PlaybackPreferencesApplyTest {
     }
 
     @Test
+    fun `a timer armed while already paused does not count down`() = runBlocking {
+        val engine = FakePlaybackEngine()
+        val clock = FakeClock()
+        val timer = SleepTimer(clock)
+        val playback = controller(engine, sleepTimer = timer, clock = clock)
+
+        playback.playQueue(listOf(chapter(1)), startChapterId = 1, fiction = null)
+        playback.await("playback to start") { it.hasMedia && it.isPlaying }
+
+        // Pause *first*, then decide to set a timer. The freeze-on-pause path already ran, back
+        // when there was no deadline to freeze, and the tick loop keeps running through a pause —
+        // so without arming into a frozen state this counts down against silence.
+        playback.togglePlayPause()
+        playback.await("the pause to land") { !it.isPlaying }
+        playback.setSleepTimer(SleepTimerMode.Duration(30))
+
+        clock.nowMs += 60 * 60_000L
+        delay(100)
+        assertTrue(playback.state.value.sleepTimer.isArmed, "the timer expired while paused")
+        assertEquals(30 * 60_000L, playback.state.value.sleepTimer.remainingMs)
+
+        // And it starts running only once audio actually resumes.
+        playback.togglePlayPause()
+        playback.await("playback to resume") { it.isPlaying }
+        clock.nowMs += 10 * 60_000L
+        delay(100)
+        assertEquals(20 * 60_000L, playback.state.value.sleepTimer.remainingMs)
+    }
+
+    @Test
     fun `stopping disarms the timer so the next chapter is not silenced`() = runBlocking {
         val engine = FakePlaybackEngine()
         val playback = controller(engine)

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/PlayerFakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/PlayerFakes.kt
@@ -92,6 +92,11 @@ class FakePlaybackEngine(
     val seeks: MutableList<Long> = Collections.synchronizedList(mutableListOf<Long>())
     val requestedRates: MutableList<Float> = Collections.synchronizedList(mutableListOf<Float>())
 
+    /** Gains handed to the engine, in order — boost and the sleep fade multiplied together. */
+    val gains: MutableList<Double> = Collections.synchronizedList(mutableListOf<Double>())
+
+    @Volatile var skipSilenceEnabled: Boolean = false
+
     /** Thrown by `prepare`. Set to a [SessionExpiredException] to model a 401 on the audio path. */
     @Volatile var prepareFailure: Throwable? = null
 
@@ -152,6 +157,14 @@ class FakePlaybackEngine(
     override fun setRate(rate: Float): Float {
         requestedRates += rate
         return capabilities.coerceSpeed(rate)
+    }
+
+    override fun setGain(gain: Double) {
+        gains += gain
+    }
+
+    override fun setSkipSilence(enabled: Boolean) {
+        skipSilenceEnabled = enabled
     }
 
     override fun positionMs(): Long = position

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackControllerTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackControllerTest.kt
@@ -205,8 +205,12 @@ class QueuePlaybackControllerTest {
 
         controller.setSpeed(3.0f)
 
-        assertEquals(2.0f, controller.state.value.speed)
-        assertEquals(listOf(3.0f), engine.requestedRates.toList())
+        // Asynchronous since Phase 6: `setSpeed` writes the preference, and the collector in the
+        // controller is what pushes it to the engine and back into the state. The assertion is
+        // unchanged — the UI shows the rate the engine accepted, never the wish.
+        controller.await("the clamped rate to be published") { it.speed == 2.0f }
+        // 3.0 was asked for and 2.0 came back; the request itself is not pre-clamped by the caller.
+        assertTrue(engine.requestedRates.contains(3.0f), "the engine was never asked for 3.0x")
         controller.release()
     }
 

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/SleepTimerTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/SleepTimerTest.kt
@@ -1,0 +1,247 @@
+package dk.perspektiva.ttsroad.desktop.player
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The sleep timer, driven by a clock the test owns.
+ *
+ * Every assertion here would be a race against a scheduler if the timer ran on a real `delay`, and
+ * "fade/extension is deterministic under a fake clock" is an acceptance criterion rather than a
+ * nicety — which is why [SleepTimer] takes `now` as a parameter and is ticked by its caller.
+ */
+class SleepTimerTest {
+
+    /** A clock the test advances by hand. */
+    private class FakeClock(var nowMs: Long = 1_000_000L) : () -> Long {
+        override fun invoke(): Long = nowMs
+
+        fun advance(ms: Long) {
+            nowMs += ms
+        }
+    }
+
+    private fun minutes(n: Int) = n * 60_000L
+
+    @Test
+    fun `an unarmed timer reports nothing and never expires`() {
+        val timer = SleepTimer(FakeClock())
+        assertFalse(timer.state.value.isArmed)
+        assertNull(timer.tick())
+        assertEquals(1f, timer.state.value.fadeGain)
+    }
+
+    @Test
+    fun `every offered duration counts down and expires exactly once`() {
+        SleepTimerMode.OfferedMinutes.forEach { chosen ->
+            val clock = FakeClock()
+            val timer = SleepTimer(clock)
+            timer.arm(SleepTimerMode.Duration(chosen))
+
+            clock.advance(minutes(chosen) - 1_000)
+            assertNull(timer.tick(), "$chosen-minute timer expired early")
+
+            clock.advance(1_000)
+            assertEquals(SleepTimerEvent.Expired, timer.tick(), "$chosen-minute timer did not expire")
+            // Disarmed by the expiry, so a caller that ticks again is not told twice.
+            assertNull(timer.tick())
+            assertFalse(timer.state.value.isArmed)
+        }
+    }
+
+    @Test
+    fun `a manual pause freezes the countdown and resuming continues it`() {
+        val clock = FakeClock()
+        val timer = SleepTimer(clock)
+        timer.arm(SleepTimerMode.Duration(30))
+
+        clock.advance(minutes(10))
+        timer.tick()
+        timer.onPlaybackPaused()
+
+        // An hour goes by with nothing playing. The timer must not have run down.
+        clock.advance(minutes(60))
+        assertNull(timer.tick())
+        assertEquals(minutes(20), timer.state.value.remainingMs)
+
+        timer.onPlaybackResumed()
+        clock.advance(minutes(19))
+        assertNull(timer.tick())
+        clock.advance(minutes(1))
+        assertEquals(SleepTimerEvent.Expired, timer.tick())
+    }
+
+    @Test
+    fun `the fade covers the last thirty seconds and ramps to silence`() {
+        val clock = FakeClock()
+        val timer = SleepTimer(clock)
+        timer.arm(SleepTimerMode.Duration(5))
+
+        // Just outside the fade window: full volume.
+        clock.advance(minutes(5) - SleepTimer.FadeMs - 1_000)
+        timer.tick()
+        assertFalse(timer.state.value.isFading)
+        assertEquals(1f, timer.state.value.fadeGain)
+
+        // Half way through the fade: half gain.
+        clock.advance(1_000 + SleepTimer.FadeMs / 2)
+        timer.tick()
+        assertTrue(timer.state.value.isFading)
+        assertEquals(0.5f, timer.state.value.fadeGain, 0.01f)
+
+        // Near the end: almost silent, and never negative.
+        clock.advance(SleepTimer.FadeMs / 2 - 100)
+        timer.tick()
+        assertTrue(timer.state.value.fadeGain in 0f..0.05f)
+    }
+
+    @Test
+    fun `expiring restores full volume so the next chapter does not start silent`() {
+        val clock = FakeClock()
+        val timer = SleepTimer(clock)
+        timer.arm(SleepTimerMode.Duration(5))
+        clock.advance(minutes(5) - 5_000)
+        timer.tick()
+        assertTrue(timer.state.value.fadeGain < 1f)
+
+        clock.advance(5_000)
+        assertEquals(SleepTimerEvent.Expired, timer.tick())
+        assertEquals(1f, timer.state.value.fadeGain)
+    }
+
+    @Test
+    fun `cancelling during the fade restores full volume`() {
+        val clock = FakeClock()
+        val timer = SleepTimer(clock)
+        timer.arm(SleepTimerMode.Duration(5))
+        clock.advance(minutes(5) - 10_000)
+        timer.tick()
+        assertTrue(timer.state.value.isFading)
+
+        timer.cancel()
+        assertFalse(timer.state.value.isArmed)
+        assertFalse(timer.state.value.isFading)
+        assertEquals(1f, timer.state.value.fadeGain)
+    }
+
+    @Test
+    fun `plus five minutes during the fade restores volume and pushes the deadline out`() {
+        val clock = FakeClock()
+        val timer = SleepTimer(clock)
+        timer.arm(SleepTimerMode.Duration(15))
+        clock.advance(minutes(15) - 10_000)
+        timer.tick()
+        assertTrue(timer.state.value.isFading)
+
+        timer.extendBy(SleepTimer.ExtensionMinutes)
+        // Immediately, not on the next tick: the audio has to come back as the button is pressed.
+        assertFalse(timer.state.value.isFading)
+        assertEquals(1f, timer.state.value.fadeGain)
+        assertEquals(minutes(5) + 10_000, timer.state.value.remainingMs)
+
+        clock.advance(minutes(5) + 9_000)
+        assertNull(timer.tick())
+        clock.advance(1_000)
+        assertEquals(SleepTimerEvent.Expired, timer.tick())
+    }
+
+    @Test
+    fun `extending keeps the mode, so the chosen duration stays selected in the UI`() {
+        val clock = FakeClock()
+        val timer = SleepTimer(clock)
+        timer.arm(SleepTimerMode.Duration(30))
+        timer.extendBy(5)
+        assertEquals(SleepTimerMode.Duration(30), timer.state.value.mode)
+    }
+
+    @Test
+    fun `extending a frozen timer adds to what is left rather than to a running deadline`() {
+        val clock = FakeClock()
+        val timer = SleepTimer(clock)
+        timer.arm(SleepTimerMode.Duration(30))
+        clock.advance(minutes(10))
+        timer.tick()
+        timer.onPlaybackPaused()
+
+        timer.extendBy(5)
+        assertEquals(minutes(25), timer.state.value.remainingMs)
+
+        // And the extension survives the resume rather than being discarded by it.
+        timer.onPlaybackResumed()
+        clock.advance(minutes(25) - 1_000)
+        assertNull(timer.tick())
+    }
+
+    @Test
+    fun `extending an unarmed timer does nothing`() {
+        val timer = SleepTimer(FakeClock())
+        timer.extendBy(5)
+        assertFalse(timer.state.value.isArmed)
+    }
+
+    @Test
+    fun `end of chapter stops once and then disarms`() {
+        val timer = SleepTimer(FakeClock())
+        timer.arm(SleepTimerMode.EndOfChapter)
+        assertTrue(timer.state.value.isArmed)
+
+        assertTrue(timer.shouldStopAtChapterEnd())
+        // The next chapter boundary must not also stop, or a still-loaded queue would never play.
+        assertFalse(timer.shouldStopAtChapterEnd())
+        assertFalse(timer.state.value.isArmed)
+    }
+
+    @Test
+    fun `a duration timer does not stop at a chapter boundary`() {
+        val timer = SleepTimer(FakeClock())
+        timer.arm(SleepTimerMode.Duration(30))
+        assertFalse(timer.shouldStopAtChapterEnd())
+        assertTrue(timer.state.value.isArmed)
+    }
+
+    @Test
+    fun `end of chapter never fades, because the chapter's own end is the boundary`() {
+        val clock = FakeClock()
+        val timer = SleepTimer(clock)
+        timer.arm(SleepTimerMode.EndOfChapter)
+        clock.advance(minutes(90))
+        assertNull(timer.tick())
+        assertFalse(timer.state.value.isFading)
+        assertEquals(1f, timer.state.value.fadeGain)
+    }
+
+    @Test
+    fun `extending end of chapter turns it into a countdown`() {
+        val clock = FakeClock()
+        val timer = SleepTimer(clock)
+        timer.arm(SleepTimerMode.EndOfChapter)
+        timer.extendBy(5)
+
+        assertEquals(SleepTimerMode.Duration(5), timer.state.value.mode)
+        // And it is no longer waiting for a boundary that may be an hour away.
+        assertFalse(timer.shouldStopAtChapterEnd())
+        clock.advance(minutes(5))
+        assertEquals(SleepTimerEvent.Expired, timer.tick())
+    }
+
+    @Test
+    fun `re-arming replaces the countdown rather than adding to it`() {
+        val clock = FakeClock()
+        val timer = SleepTimer(clock)
+        timer.arm(SleepTimerMode.Duration(60))
+        clock.advance(minutes(30))
+        timer.arm(SleepTimerMode.Duration(5))
+        assertEquals(minutes(5), timer.state.value.remainingMs)
+    }
+
+    @Test
+    fun `formatting pads seconds and rounds up so a countdown never shows a stale zero`() {
+        assertEquals("5:00", formatRemaining(minutes(5)))
+        assertEquals("0:30", formatRemaining(30_000))
+        assertEquals("0:05", formatRemaining(4_100))
+        assertEquals("0:00", formatRemaining(0))
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/NavigationUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/NavigationUiTest.kt
@@ -30,6 +30,8 @@ import dk.perspektiva.ttsroad.desktop.FakeRepository
 import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
 import dk.perspektiva.ttsroad.desktop.data.ChaptersResponse
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackHistoryStore
+import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.InMemorySessionStore
 import dk.perspektiva.ttsroad.desktop.data.LibraryCache
 import dk.perspektiva.ttsroad.desktop.data.LibraryResponse
@@ -80,7 +82,11 @@ class NavigationUiTest {
             SessionState(serverUrl = "https://x/", token = "t", username = "admin", serverName = "Perspektiva"),
         ),
         repositoryFactory = { _, _, _ -> repository },
-        playbackFactory = { _, _, _, _ -> playback },
+        playbackFactory = { _, _, _, _, _, _ -> playback },
+        // In-memory, so rendering a screen in a test never touches the real
+        // ~/.config/TTSRoad files the production stores default to.
+        playbackPreferences = InMemoryPlaybackPreferencesStore(),
+        playbackHistory = InMemoryPlaybackHistoryStore(),
         // See `testLibraryCache`: immediate main dispatch is what makes `waitForIdle` sufficient.
         libraryCacheFactory = { repo, _, now -> LibraryCache(repo, Dispatchers.Main.immediate, now) },
     )

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ScreensUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ScreensUiTest.kt
@@ -15,6 +15,8 @@ import dk.perspektiva.ttsroad.desktop.FakePlaybackController
 import dk.perspektiva.ttsroad.desktop.FakeRepository
 import dk.perspektiva.ttsroad.desktop.ParsedFixtures
 import dk.perspektiva.ttsroad.desktop.testLibraryCache
+import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackHistoryStore
+import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.InMemorySessionStore
 import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
 import dk.perspektiva.ttsroad.desktop.data.SessionEnd
@@ -44,7 +46,11 @@ class ScreensUiTest {
     ) = AppContainer(
         sessionStore = InMemorySessionStore(session),
         repositoryFactory = { _, _, _ -> repository },
-        playbackFactory = { _, _, _, _ -> playback },
+        playbackFactory = { _, _, _, _, _, _ -> playback },
+        // In-memory, so rendering a screen in a test never touches the real
+        // ~/.config/TTSRoad files the production stores default to.
+        playbackPreferences = InMemoryPlaybackPreferencesStore(),
+        playbackHistory = InMemoryPlaybackHistoryStore(),
     )
 
     // --- App: the login gate --------------------------------------------------------------
@@ -139,7 +145,11 @@ class ScreensUiTest {
         val app = AppContainer(
             sessionStore = store,
             repositoryFactory = { _, _, _ -> repository },
-            playbackFactory = { _, _, _, _ -> playback },
+            playbackFactory = { _, _, _, _, _, _ -> playback },
+            // In-memory, so rendering a screen in a test never touches the real
+            // ~/.config/TTSRoad files the production stores default to.
+            playbackPreferences = InMemoryPlaybackPreferencesStore(),
+            playbackHistory = InMemoryPlaybackHistoryStore(),
         )
         compose.setContent { TtsRoadTheme { App(app) } }
         compose.waitForIdle()
@@ -212,7 +222,11 @@ class ScreensUiTest {
         val app = AppContainer(
             sessionStore = store,
             repositoryFactory = { _, _, _ -> repository },
-            playbackFactory = { _, _, _, _ -> FakePlaybackController() },
+            playbackFactory = { _, _, _, _, _, _ -> FakePlaybackController() },
+            // In-memory, so rendering a screen in a test never touches the real
+            // ~/.config/TTSRoad files the production stores default to.
+            playbackPreferences = InMemoryPlaybackPreferencesStore(),
+            playbackHistory = InMemoryPlaybackHistoryStore(),
         )
         compose.setContent { TtsRoadTheme { App(app) } }
         compose.waitForIdle()

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreenUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreenUiTest.kt
@@ -24,10 +24,14 @@ import androidx.compose.ui.unit.dp
 import dk.perspektiva.ttsroad.desktop.FakeRepository
 import dk.perspektiva.ttsroad.desktop.ParsedFixtures
 import dk.perspektiva.ttsroad.desktop.ServerFixtures
+import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.InMemorySessionStore
+import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferences
 import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
 import dk.perspektiva.ttsroad.desktop.data.SessionState
+import dk.perspektiva.ttsroad.desktop.data.VolumeBoost
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
@@ -71,11 +75,27 @@ class SettingsScreenUiTest {
         repository: FakeRepository,
         session: SessionState = signedIn,
         capabilities: ServerCapabilities = capable,
+        // What the *engine* can do. The playback pane draws a control only where the backend can
+        // honour it, so these two flags decide which half of that pane is under test.
+        preferences: InMemoryPlaybackPreferencesStore = InMemoryPlaybackPreferencesStore(),
+        canChangeSpeed: Boolean = true,
+        canSkipSilence: Boolean = true,
     ) {
         val store = InMemorySessionStore(session)
         repository.capabilitiesResult = capabilities
         runBlocking { repository.refreshCurrentCapabilities(forceRefresh = true) }
-        compose.setContent { TtsRoadTheme { SettingsScreen(store, repository, nowMs = { now }) } }
+        compose.setContent {
+            TtsRoadTheme {
+                SettingsScreen(
+                    store,
+                    repository,
+                    preferences = preferences,
+                    canChangeSpeed = canChangeSpeed,
+                    canSkipSilence = canSkipSilence,
+                    nowMs = { now },
+                )
+            }
+        }
         compose.waitForIdle()
     }
 
@@ -191,19 +211,102 @@ class SettingsScreenUiTest {
         compose.onNodeWithText("Pixel 9").assertIsDisplayed()
     }
 
-    // --- Panes for phases that do not exist yet ----------------------------------------------
+    // MetaText uppercases what it renders, so matches against it are case-insensitive here
+    // rather than asserting on the presentation.
+    // --- Playback pane -------------------------------------------------------------------------
 
-    @Test
-    fun `the playback pane says it is unavailable instead of showing dead controls`() {
-        setContent(FakeRepository())
-
+    private fun openPlayback() {
         navEntry("PLAYBACK").performClick()
         compose.waitForIdle()
-
-        compose.onNodeWithText("NOT AVAILABLE YET").assertIsDisplayed()
-        compose.onNodeWithText("Playback preferences are not part of this build.", substring = true)
-            .assertIsDisplayed()
     }
+
+    @Test
+    fun `the playback pane offers the speed presets including 1_25x`() {
+        setContent(FakeRepository())
+        openPlayback()
+
+        compose.onNodeWithText("1.25×").assertExists()
+        compose.onNodeWithText("30 s", ignoreCase = true).assertExists()
+    }
+
+    @Test
+    fun `choosing a skip interval stores it`() {
+        val preferences = InMemoryPlaybackPreferencesStore()
+        setContent(FakeRepository(), preferences = preferences)
+        openPlayback()
+
+        compose.onNodeWithText("15 s", ignoreCase = true).performScrollTo().performClick()
+        compose.waitForIdle()
+
+        assertEquals(15, preferences.preferences.value.skipIntervalSeconds)
+    }
+
+    @Test
+    fun `choosing a speed stores it`() {
+        val preferences = InMemoryPlaybackPreferencesStore()
+        setContent(FakeRepository(), preferences = preferences)
+        openPlayback()
+
+        compose.onNodeWithText("1.5×").performScrollTo().performClick()
+        compose.waitForIdle()
+
+        assertEquals(1.5f, preferences.preferences.value.speed)
+    }
+
+    @Test
+    fun `a custom speed from another build is still offered`() {
+        // The stored value is not one of this build's presets; it must not be rounded away.
+        val preferences = InMemoryPlaybackPreferencesStore(PlaybackPreferences(speed = 1.35f))
+        setContent(FakeRepository(), preferences = preferences)
+        openPlayback()
+
+        compose.onNodeWithText("1.35×").assertExists()
+    }
+
+    @Test
+    fun `an engine that cannot resample gets no speed control at all`() {
+        // The Phase 5 rule, applied to Settings: no control rather than one that does nothing.
+        setContent(FakeRepository(), canChangeSpeed = false)
+        openPlayback()
+
+        compose.onNodeWithText("1.25×").assertDoesNotExist()
+        compose.onNodeWithText("cannot resample", substring = true, ignoreCase = true).assertExists()
+    }
+
+    @Test
+    fun `an engine without removesilence gets no skip-silence toggle`() {
+        setContent(FakeRepository(), canSkipSilence = false)
+        openPlayback()
+
+        compose.onNodeWithText("Not available on this computer", ignoreCase = true).assertExists()
+        compose.onNodeWithText("gst-plugins-bad", substring = true, ignoreCase = true).assertExists()
+    }
+
+    @Test
+    fun `skip silence is off by default and can be turned on`() {
+        val preferences = InMemoryPlaybackPreferencesStore()
+        setContent(FakeRepository(), preferences = preferences)
+        openPlayback()
+
+        assertFalse(preferences.preferences.value.skipSilence)
+        compose.onNodeWithContentDescription("SKIP SILENCE").performScrollTo().performClick()
+        compose.waitForIdle()
+        assertTrue(preferences.preferences.value.skipSilence)
+    }
+
+    @Test
+    fun `choosing a volume boost stores it`() {
+        val preferences = InMemoryPlaybackPreferencesStore()
+        setContent(FakeRepository(), preferences = preferences)
+        openPlayback()
+
+        compose.onNodeWithText("Medium", ignoreCase = true).performScrollTo().performClick()
+        compose.waitForIdle()
+
+        assertEquals(VolumeBoost.Medium, preferences.preferences.value.volumeBoost)
+    }
+
+    // --- Panes for phases that do not exist yet ----------------------------------------------
 
     @Test
     fun `the offline pane promises nothing and says signing out deletes nothing`() {


### PR DESCRIPTION
Closes #9.

Adds the listening features mobile users rely on plus the Linux desktop integration expected of a media app.

## What's here

- **`data/PlaybackPreferences.kt`** — speed, skip interval, skip silence and volume boost in `playback.json`. Machine-local, with no reference to a session, so signing out cannot reset them and a second account on a shared machine cannot inherit them. The on-disk type is separate and fully nullable, so a file from another build loads degraded rather than throwing; out-of-range values are *snapped*, not defaulted. The offered speed list always includes the stored value even when it isn't a preset.
- **The controller applies the preferences, not the player screen.** `QueuePlaybackController` collects the store and pushes rate/gain/skip-silence to the engine, so an auto-advanced chapter and a media-key start use the same values as one the user pressed play on.
- **`player/SleepTimer.kt`** — a state machine over an injected clock, ticked by the controller's existing 250 ms loop. No coroutine and no `delay`, because determinism under a fake clock is an acceptance criterion. Fade gain is combined with the volume boost in one place, so cancelling a fade restores the boost rather than unity. End-of-chapter is checked *before* the auto-advance and disarms itself.
- **`data/PlaybackHistory.kt`** — bounded to 60 entries, one per chapter, with no URL field of any kind; covers are re-resolved from the library cache by fiction id. Dismissal is per snapshot and is inherited when the same chapter is re-recorded, or the next progress save would undo it.
- **MPRIS**, split into a pure mapping (`MprisState.kt`, unit-tested with no bus) and the D-Bus plumbing (`MprisService.kt`). No session bus is a normal outcome, not a failure.
- **`nav/Shortcuts.kt`** installs on two handlers so typing safety is structural rather than a focus tracker, and the table is listed in an in-app shortcuts dialog.

Reasoning and rejected alternatives are in `docs/adr/0006-listening-preferences-and-desktop-integration.md`.

## Two bugs found by running the packaged image against a real session bus

Both were invisible to the existing gates, and both are the kind that only show up in the shipped artifact:

1. **`jdk.security.auth` was missing from the jlink module list.** dbus-java reads the uid through `com.sun.security.auth.module.UnixSystem` by reflection, so module inference missed it. The packaged app started, played audio, and reported *"no MPRIS integration on this desktop"* — indistinguishable from a machine with genuinely no session bus — while the same code worked fine from `./gradlew run`, where a full JDK is on the module path. `--smoke-test` now asserts the class resolves; it deliberately does not claim a bus name, so it could never have caught this by connecting. "No session bus" stays a passing configuration; "no module" does not.

2. **`Properties.Get` returned `variant.value`**, dropping the `a{sv}` signature that only `playerProperties` attached. dbus-java then re-wrapped the bare value in an unqualified `Variant`, which cannot marshal `Metadata`. Every scalar property worked and `Metadata` alone failed — so `GetAll` looked fine while a client that reads properties one at a time got an error instead of a title.

## Verification

- `clean check --warning-mode fail -Pttsroad.warningsAsErrors=true` under Xvfb: **561 tests, 0 failures**, 2 skips (Windows-only credential tests). The GStreamer integration test ran for real against GStreamer 1.22.12 rather than skipping.
- `createDistributable` + the packaged `--smoke-test`.
- **Live against a real session bus with `busctl`**: the bus name appears, root and player properties read correctly, `Get Metadata` returns the spec's `NoTrack` shape, the transport methods answer without error, and the name is released on exit.

Not verified here: the Cinnamon applet and hardware media keys against a signed-in session with real audio — that needs the private server and a physical desktop. The bus-level contract those consume is verified above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)