### PR TITLE
Phase 6 follow-up: review fixes that landed after #24 merged

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -277,6 +277,7 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                     repository = repository,
                                     playback = playback,
                                     history = container.playbackHistory,
+                                    historyOwnerKey = container.historyOwnerKey(),
                                     onOpenFiction = { nav.open(Destination.Fiction(it)) },
                                     onOpenPlayer = { nav.open(Destination.Player) },
                                 )

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackHistory.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackHistory.kt
@@ -30,14 +30,26 @@ data class PlaybackSnapshot(
     val durationSeconds: Double,
     val recordedAtMs: Long,
     val dismissed: Boolean = false,
+    /**
+     * Which signed-in account this snapshot belongs to — see [PlaybackHistory.ownerKeyFor].
+     *
+     * The file is machine-local and outlives every session, but its *contents* are not: fiction and
+     * chapter titles are the second user's business only if they are the second user's titles.
+     * Without this, signing out and signing in as somebody else on the same desktop showed them the
+     * previous account's reading history in the "Jump back in" strip. It is a hash, so it scopes
+     * without naming the server or the person.
+     */
+    val ownerKey: String = "",
 ) {
     /**
      * Identity for thinning and for dismissal.
      *
-     * A chapter, not a playback session: listening to chapter 12 twice is one thing to offer to
-     * resume, and a dismissal of it should survive the position moving.
+     * A chapter *of one account's library*, not a playback session: listening to chapter 12 twice
+     * is one thing to offer to resume, and a dismissal of it should survive the position moving.
+     * The owner is part of it because fiction ids are only unique within a server, so two accounts
+     * can hold the same id for different content.
      */
-    val key: String get() = "$fictionId:$chapterId"
+    val key: String get() = "$ownerKey:$fictionId:$chapterId"
 
     /** How far in, 0..1. Zero when the duration is unknown, so a bar cannot render nonsense. */
     val progress: Float
@@ -97,13 +109,32 @@ object PlaybackHistory {
         existing.map { if (it.key == key) it.copy(dismissed = true) else it }
 
     /**
-     * The single thing to offer as "last heard", or null.
+     * The owner key for a session: a hash of the server and the account.
+     *
+     * Hashed rather than stored plainly so the file scopes history without also becoming a record
+     * of which servers this machine talks to and under what name — the same reasoning that keeps
+     * URLs out of [PlaybackSnapshot] entirely.
+     */
+    fun ownerKeyFor(serverUrl: String, username: String?): String {
+        val identity = "${serverUrl.trim().trimEnd('/').lowercase()}|${username?.trim()?.lowercase().orEmpty()}"
+        return java.security.MessageDigest.getInstance("SHA-256")
+            .digest(identity.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+            .take(32)
+    }
+
+    /**
+     * The single thing to offer as "last heard" to [ownerKey], or null.
      *
      * Skips dismissed entries and ones that are effectively finished, so the card is always an
      * offer the listener can act on rather than one they have to dismiss again.
+     *
+     * A snapshot written before this build carries no owner and is therefore shown to nobody. That
+     * is deliberate: losing the strip once is a far better outcome than showing one account's
+     * reading history to the next person who signs in on the same desktop.
      */
-    fun lastHeard(existing: List<PlaybackSnapshot>): PlaybackSnapshot? =
-        existing.filter { it.isResumable }.maxByOrNull { it.recordedAtMs }
+    fun lastHeard(existing: List<PlaybackSnapshot>, ownerKey: String): PlaybackSnapshot? =
+        existing.filter { it.isOwnedBy(ownerKey) && it.isResumable }.maxByOrNull { it.recordedAtMs }
 
     /**
      * Up to [limit] things to jump back to, newest first, at most one per fiction.
@@ -114,15 +145,20 @@ object PlaybackHistory {
      */
     fun jumpBackChoices(
         existing: List<PlaybackSnapshot>,
+        ownerKey: String,
         limit: Int = JumpBackChoices,
     ): List<PlaybackSnapshot> =
-        existing.filter { it.isResumable }
+        existing.filter { it.isOwnedBy(ownerKey) && it.isResumable }
             .sortedByDescending { it.recordedAtMs }
             .distinctBy { it.fictionId }
             .take(limit)
 
     private val PlaybackSnapshot.isResumable: Boolean
         get() = !dismissed && progress < ResumableCeiling
+
+    /** Never true for a blank key on either side, so an unowned snapshot is shown to nobody. */
+    private fun PlaybackSnapshot.isOwnedBy(ownerKey: String): Boolean =
+        ownerKey.isNotBlank() && this.ownerKey == ownerKey
 }
 
 /** Seam so tests never touch the real user config directory. */

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackHistory.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackHistory.kt
@@ -143,14 +143,17 @@ class InMemoryPlaybackHistoryStore(
     private val _history = MutableStateFlow(initial)
     override val history: StateFlow<List<PlaybackSnapshot>> = _history.asStateFlow()
 
+    @Synchronized
     override fun record(snapshot: PlaybackSnapshot) {
         _history.value = PlaybackHistory.record(_history.value, snapshot)
     }
 
+    @Synchronized
     override fun dismiss(key: String) {
         _history.value = PlaybackHistory.dismiss(_history.value, key)
     }
 
+    @Synchronized
     override fun clear() {
         _history.value = emptyList()
     }
@@ -176,14 +179,25 @@ class FilePlaybackHistoryStore(
     private val _history = MutableStateFlow(read())
     override val history: StateFlow<List<PlaybackSnapshot>> = _history.asStateFlow()
 
+    /**
+     * Every mutation is read-modify-write, and the readers and writers are on different threads:
+     * the controller records from its own scope while the UI dismisses from the Compose thread.
+     * Unsynchronised, two of them can derive from the same list and the later write wins outright —
+     * which loses a dismissal, because a stale `record` carries `dismissed = false` and the whole
+     * point of the inheritance rule is that a progress save must never undo one. Synchronising the
+     * mutation *and* the file write also keeps the file ordered the same way as the flow.
+     */
+    @Synchronized
     override fun record(snapshot: PlaybackSnapshot) {
         write(PlaybackHistory.record(_history.value, snapshot))
     }
 
+    @Synchronized
     override fun dismiss(key: String) {
         write(PlaybackHistory.dismiss(_history.value, key))
     }
 
+    @Synchronized
     override fun clear() {
         write(emptyList())
     }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackHistory.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackHistory.kt
@@ -116,11 +116,38 @@ object PlaybackHistory {
      * URLs out of [PlaybackSnapshot] entirely.
      */
     fun ownerKeyFor(serverUrl: String, username: String?): String {
-        val identity = "${serverUrl.trim().trimEnd('/').lowercase()}|${username?.trim()?.lowercase().orEmpty()}"
+        // The username is *not* case-folded: it is `response.user.username` as the server spelled
+        // it, so it is already canonical, and folding it would merge two genuinely distinct
+        // accounts on a server that treats case as significant (Django's default). Throughout this
+        // function the rule is that merging two identities is far worse than splitting one —
+        // splitting costs a lost strip, merging discloses one person's reading to another.
+        val identity = "${canonicalServer(serverUrl)}|${username?.trim().orEmpty()}"
         return java.security.MessageDigest.getInstance("SHA-256")
             .digest(identity.toByteArray(Charsets.UTF_8))
             .joinToString("") { "%02x".format(it) }
             .take(32)
+    }
+
+    /**
+     * Lowercases only the parts of a URL that are genuinely case-insensitive.
+     *
+     * Scheme and host are; **the path is not**. `normalizeBaseUrl` keeps whatever path the user
+     * configured and Retrofit supports path-based base URLs, so `https://host/TTSRoad/` and
+     * `https://host/ttsroad/` are two different deployments. Folding the whole URL made them one
+     * owner, and two people with the same username on those instances would have seen and dismissed
+     * each other's history.
+     */
+    private fun canonicalServer(serverUrl: String): String {
+        val trimmed = serverUrl.trim().trimEnd('/')
+        val schemeEnd = trimmed.indexOf("://")
+        if (schemeEnd <= 0) return trimmed
+
+        val scheme = trimmed.substring(0, schemeEnd).lowercase(java.util.Locale.ROOT)
+        val rest = trimmed.substring(schemeEnd + 3)
+        val authorityEnd = rest.indexOf('/').takeIf { it >= 0 } ?: rest.length
+        val authority = rest.substring(0, authorityEnd).lowercase(java.util.Locale.ROOT)
+        val path = rest.substring(authorityEnd)
+        return "$scheme://$authority$path"
     }
 
     /**

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackPreferences.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackPreferences.kt
@@ -148,6 +148,7 @@ class InMemoryPlaybackPreferencesStore(
     private val _preferences = MutableStateFlow(initial)
     override val preferences: StateFlow<PlaybackPreferences> = _preferences.asStateFlow()
 
+    @Synchronized
     override fun update(transform: (PlaybackPreferences) -> PlaybackPreferences) {
         _preferences.value = transform(_preferences.value).sanitised()
     }
@@ -171,6 +172,13 @@ class FilePlaybackPreferencesStore(
     private val _preferences = MutableStateFlow(read())
     override val preferences: StateFlow<PlaybackPreferences> = _preferences.asStateFlow()
 
+    /**
+     * Synchronised because `update` is read-modify-write and three threads reach it: the Compose
+     * thread from Settings, the controller when it stores a speed, and dbus-java's reader thread
+     * when a shell sets the volume. Two overlapping updates would otherwise each derive from the
+     * same value and the later write would drop the other's field entirely.
+     */
+    @Synchronized
     override fun update(transform: (PlaybackPreferences) -> PlaybackPreferences) {
         val next = transform(_preferences.value).sanitised()
         if (next == _preferences.value) return

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/di/AppContainer.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/di/AppContainer.kt
@@ -5,6 +5,7 @@ import dk.perspektiva.ttsroad.desktop.data.FilePlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.FileSessionStore
 import dk.perspektiva.ttsroad.desktop.data.FileWindowPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.LibraryCache
+import dk.perspektiva.ttsroad.desktop.data.PlaybackHistory
 import dk.perspektiva.ttsroad.desktop.data.PlaybackHistoryStore
 import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.RetrofitTtsRoadRepository
@@ -88,9 +89,10 @@ class AppContainer(
         AppDispatchers,
         PlaybackPreferencesStore,
         PlaybackHistoryStore,
+        () -> String,
     ) -> PlaybackController =
-        { repo, mediaSources, engine, d, prefs, history ->
-            QueuePlaybackController(repo, mediaSources, engine, d.io, prefs, history)
+        { repo, mediaSources, engine, d, prefs, history, owner ->
+            QueuePlaybackController(repo, mediaSources, engine, d.io, prefs, history, ownerKey = owner)
         },
     libraryCacheFactory: (TtsRoadRepository, AppDispatchers, () -> Long) -> LibraryCache =
         { repo, d, now -> LibraryCache(repo, d.main, now) },
@@ -101,8 +103,26 @@ class AppContainer(
     val repository: TtsRoadRepository = repositoryFactory(sessionStore, httpClient, dispatchers)
     val mediaSources: MediaSourceFactory = mediaSourceFactory(httpClient, repository)
     val audioEngine: PlaybackEngine = audioEngineFactory()
-    val playback: PlaybackController =
-        playbackFactory(repository, mediaSources, audioEngine, dispatchers, playbackPreferences, playbackHistory)
+    /**
+     * Which account's history is being written or shown.
+     *
+     * Derived from the live session rather than captured once: signing out and signing in as
+     * somebody else on the same desktop must change the answer without rebuilding the container.
+     */
+    val historyOwnerKey: () -> String = {
+        val session = sessionStore.current()
+        if (session.serverUrl.isBlank()) "" else PlaybackHistory.ownerKeyFor(session.serverUrl, session.username)
+    }
+
+    val playback: PlaybackController = playbackFactory(
+        repository,
+        mediaSources,
+        audioEngine,
+        dispatchers,
+        playbackPreferences,
+        playbackHistory,
+        historyOwnerKey,
+    )
 
     /**
      * The scope MPRIS publishes from. Its own, not the controller's: the bus mirror has to keep

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
@@ -67,6 +67,11 @@ class QueuePlaybackController(
     private val historyStore: PlaybackHistoryStore = InMemoryPlaybackHistoryStore(),
     private val sleepTimer: SleepTimer = SleepTimer(),
     private val clock: () -> Long = System::currentTimeMillis,
+    /**
+     * Which account a history snapshot belongs to. Read at record time rather than at construction,
+     * because a sign-out and a sign-in as somebody else happen without rebuilding this controller.
+     */
+    private val ownerKey: () -> String = { "" },
     /** Overridable so tests do not wait real seconds for the retry ladder. */
     private val retryDelaysMs: List<Long> = listOf(2_000, 5_000, 15_000),
     private val tickIntervalMs: Long = 250,
@@ -463,6 +468,10 @@ class QueuePlaybackController(
         drainEngineEvents()?.let { return it }
 
         engine.play()
+        // Audio is starting here, not only in togglePlayPause, so this is where a frozen countdown
+        // has to start running again. Without it, a timer armed while paused stays frozen while a
+        // newly-started or retried chapter plays on indefinitely. A no-op when nothing is frozen.
+        sleepTimer.onPlaybackResumed()
         // A successful attempt clears whatever the previous one complained about.
         _state.update {
             it.copy(
@@ -588,6 +597,7 @@ class QueuePlaybackController(
                 positionSeconds = lastKnownPositionMs / 1000.0,
                 durationSeconds = current.durationMs / 1000.0,
                 recordedAtMs = clock(),
+                ownerKey = ownerKey(),
             ),
         )
     }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
@@ -153,9 +153,12 @@ class QueuePlaybackController(
                 .copy(error = "This chapter has no audio yet")
             return
         }
+        // Before the queue changes, not after: `leaveCurrentChapter` reads queue[queueIndex], and
+        // once the new queue is in place that index names a different chapter — or nothing at all.
+        leaveCurrentChapter()
         queue = listOf(chapter)
         queueFiction = fiction
-        begin(0, resumeMsOf(chapter))
+        begin(0, resumeMsOf(chapter), leaveCurrent = false)
     }
 
     override suspend fun playQueue(
@@ -170,10 +173,13 @@ class QueuePlaybackController(
             _state.update { it.copy(error = "No playable chapters yet") }
             return
         }
+        // See `play`: the chapter being left has to be recorded while it is still the one the queue
+        // and the index point at.
+        leaveCurrentChapter()
         queue = playable
         queueFiction = fiction
         val startIndex = playable.indexOfFirst { it.resolvedChapterId == startChapterId }.coerceAtLeast(0)
-        begin(startIndex, resumeMsOf(playable[startIndex]))
+        begin(startIndex, resumeMsOf(playable[startIndex]), leaveCurrent = false)
     }
 
     override fun togglePlayPause() {
@@ -310,11 +316,29 @@ class QueuePlaybackController(
      * One job owns a chapter from prepare to end-of-stream, including its retries, so cancelling
      * it is all that is needed to abandon everything in flight.
      */
-    private suspend fun begin(startIndex: Int, startMs: Long) {
+    /**
+     * Stops the current chapter and files what the listener had reached.
+     *
+     * Must be called while `queue` and `queueIndex` still describe the chapter being left. A caller
+     * that is about to *replace* the queue has to do this first and pass `leaveCurrent = false` to
+     * [begin] — otherwise the save and the snapshot are attributed to whatever chapter now happens
+     * to sit at the old index, which is a different chapter or none.
+     */
+    private suspend fun leaveCurrentChapter() {
         playJob?.cancelAndJoin()
+        playJob = null
         // Leaving the previous chapter is one of the required save points.
         saveProgressNow()
         recordHistory()
+    }
+
+    private suspend fun begin(startIndex: Int, startMs: Long, leaveCurrent: Boolean = true) {
+        if (leaveCurrent) {
+            leaveCurrentChapter()
+        } else {
+            playJob?.cancelAndJoin()
+            playJob = null
+        }
         queueIndex = startIndex
         lastKnownPositionMs = startMs
         publishMetadata(startIndex, startMs)

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
@@ -87,6 +87,18 @@ class QueuePlaybackController(
     private var queue: List<ChapterSummary> = emptyList()
     private var queueFiction: FictionSummary? = null
 
+    /**
+     * Which account this queue was loaded for, captured at load time rather than read at record
+     * time.
+     *
+     * `recordHistory` runs *after* a suspending progress save, and `stop()` is fire-and-forget. If
+     * the session changes while that request is in flight — account A signs out, B signs in — then
+     * resolving the owner live would file A's chapter titles under B's key, which is precisely the
+     * cross-account disclosure the owner key exists to prevent. The queue and its owner belong
+     * together, so they are captured together.
+     */
+    @Volatile private var queueOwnerKey: String = ""
+
     @Volatile private var queueIndex = 0
 
     /** Last position actually reported by the engine — what a save or a retry resumes from. */
@@ -163,6 +175,7 @@ class QueuePlaybackController(
         leaveCurrentChapter()
         queue = listOf(chapter)
         queueFiction = fiction
+        queueOwnerKey = ownerKey()
         begin(0, resumeMsOf(chapter), leaveCurrent = false)
     }
 
@@ -183,6 +196,7 @@ class QueuePlaybackController(
         leaveCurrentChapter()
         queue = playable
         queueFiction = fiction
+        queueOwnerKey = ownerKey()
         val startIndex = playable.indexOfFirst { it.resolvedChapterId == startChapterId }.coerceAtLeast(0)
         begin(startIndex, resumeMsOf(playable[startIndex]), leaveCurrent = false)
     }
@@ -306,6 +320,7 @@ class QueuePlaybackController(
         if (clearQueue) {
             queue = emptyList()
             queueFiction = null
+            queueOwnerKey = ""
             queueIndex = 0
             lastKnownPositionMs = 0
             // A stop is also the end of any sleep timer: the thing it was counting down to has
@@ -597,7 +612,7 @@ class QueuePlaybackController(
                 positionSeconds = lastKnownPositionMs / 1000.0,
                 durationSeconds = current.durationMs / 1000.0,
                 recordedAtMs = clock(),
-                ownerKey = ownerKey(),
+                ownerKey = queueOwnerKey,
             ),
         )
     }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/LibraryScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/LibraryScreen.kt
@@ -107,12 +107,19 @@ fun LibraryScreen(
      * screen test never reads or writes the real config directory.
      */
     history: PlaybackHistoryStore = remember { InMemoryPlaybackHistoryStore() },
+    /**
+     * Which account's snapshots may be shown. Blank means "nobody's", which is what a signed-out
+     * screen and a history file from an older build both get — see [PlaybackHistory.jumpBackChoices].
+     */
+    historyOwnerKey: String = "",
     nowMillis: () -> Long = System::currentTimeMillis,
 ) {
     val scope = rememberCoroutineScope()
     val state by cache.library.collectAsState()
     val snapshots by history.history.collectAsState()
-    val jumpBack = remember(snapshots) { PlaybackHistory.jumpBackChoices(snapshots) }
+    val jumpBack = remember(snapshots, historyOwnerKey) {
+        PlaybackHistory.jumpBackChoices(snapshots, historyOwnerKey)
+    }
     // Keyless on purpose: fires once per screen *appearance*, not per recomposition. Reuses cached
     // content and coalesces with a load already in flight, so Back into the library costs nothing.
     LaunchedEffect(Unit) { cache.ensureLibrary() }

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackHistoryTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackHistoryTest.kt
@@ -280,8 +280,37 @@ class PlaybackHistoryTest {
         assertFalse(key.contains("host.example"))
         assertFalse(key.contains("alice"))
         assertTrue(key.all { it in "0123456789abcdef" })
-        // Same session, same key; a different account, a different key.
-        assertEquals(key, PlaybackHistory.ownerKeyFor("https://host.example/", "Alice"))
         assertFalse(key == PlaybackHistory.ownerKeyFor("https://host.example", "bob"))
+    }
+
+    @Test
+    fun `scheme and host are case-insensitive but the path is not`() {
+        val canonical = PlaybackHistory.ownerKeyFor("https://host.example", "alice")
+        // Scheme, host and a trailing slash are noise.
+        assertEquals(canonical, PlaybackHistory.ownerKeyFor("HTTPS://Host.Example/", "alice"))
+
+        // The path is not. Retrofit supports path-based base URLs and normalizeBaseUrl keeps
+        // whatever the user configured, so these are two deployments — and folding them together
+        // would let two people with the same username read and dismiss each other's history.
+        assertFalse(
+            PlaybackHistory.ownerKeyFor("https://host.example/TTSRoad/", "alice") ==
+                PlaybackHistory.ownerKeyFor("https://host.example/ttsroad/", "alice"),
+        )
+        // A path still identifies one deployment consistently.
+        assertEquals(
+            PlaybackHistory.ownerKeyFor("https://host.example/TTSRoad/", "alice"),
+            PlaybackHistory.ownerKeyFor("https://HOST.example/TTSRoad", "alice"),
+        )
+    }
+
+    @Test
+    fun `usernames differing only in case are different accounts`() {
+        // The stored username is what the server called the account, so it is already canonical;
+        // folding it would merge two real accounts on a case-sensitive server. Splitting one
+        // identity costs a lost strip, merging two discloses one person's reading to another.
+        assertFalse(
+            PlaybackHistory.ownerKeyFor("https://host.example", "Alice") ==
+                PlaybackHistory.ownerKeyFor("https://host.example", "alice"),
+        )
     }
 }

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackHistoryTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackHistoryTest.kt
@@ -14,6 +14,11 @@ import org.junit.jupiter.api.io.TempDir
  */
 class PlaybackHistoryTest {
 
+    /** The signed-in account these snapshots belong to. */
+    private val Owner = PlaybackHistory.ownerKeyFor("https://host.example", "alice")
+
+    private val OtherOwner = PlaybackHistory.ownerKeyFor("https://host.example", "bob")
+
     private fun snapshot(
         fictionId: Int = 1,
         chapterId: Int = 1,
@@ -21,6 +26,7 @@ class PlaybackHistoryTest {
         durationSeconds: Double = 600.0,
         recordedAtMs: Long = 1_000L,
         dismissed: Boolean = false,
+        ownerKey: String = Owner,
     ) = PlaybackSnapshot(
         fictionId = fictionId,
         chapterId = chapterId,
@@ -30,6 +36,7 @@ class PlaybackHistoryTest {
         durationSeconds = durationSeconds,
         recordedAtMs = recordedAtMs,
         dismissed = dismissed,
+        ownerKey = ownerKey,
     )
 
     // --- Thinning -------------------------------------------------------------------------------
@@ -72,21 +79,21 @@ class PlaybackHistoryTest {
     fun `a dismissal survives the next progress save for the same chapter`() {
         // Without this the 10-second progress tick would undo a dismissal the moment it was made.
         var history = PlaybackHistory.record(emptyList(), snapshot(chapterId = 7, recordedAtMs = 1))
-        history = PlaybackHistory.dismiss(history, "1:7")
+        history = PlaybackHistory.dismiss(history, "$Owner:1:7")
         history = PlaybackHistory.record(history, snapshot(chapterId = 7, positionSeconds = 120.0, recordedAtMs = 2))
 
         assertTrue(history.single().dismissed)
-        assertNull(PlaybackHistory.lastHeard(history))
+        assertNull(PlaybackHistory.lastHeard(history, Owner))
     }
 
     @Test
     fun `dismissal applies to the snapshot, so a different chapter still appears`() {
         // The requirement, stated as a test: this is not "hide for today".
         var history = PlaybackHistory.record(emptyList(), snapshot(chapterId = 7, recordedAtMs = 1))
-        history = PlaybackHistory.dismiss(history, "1:7")
+        history = PlaybackHistory.dismiss(history, "$Owner:1:7")
         history = PlaybackHistory.record(history, snapshot(chapterId = 8, recordedAtMs = 2))
 
-        val lastHeard = PlaybackHistory.lastHeard(history)
+        val lastHeard = PlaybackHistory.lastHeard(history, Owner)
         assertEquals(8, lastHeard?.chapterId)
     }
 
@@ -94,7 +101,7 @@ class PlaybackHistoryTest {
     fun `dismissing one chapter leaves the others alone`() {
         var history = PlaybackHistory.record(emptyList(), snapshot(chapterId = 1, recordedAtMs = 1))
         history = PlaybackHistory.record(history, snapshot(chapterId = 2, recordedAtMs = 2))
-        history = PlaybackHistory.dismiss(history, "1:1")
+        history = PlaybackHistory.dismiss(history, "$Owner:1:1")
 
         assertTrue(history.first { it.chapterId == 1 }.dismissed)
         assertFalse(history.first { it.chapterId == 2 }.dismissed)
@@ -106,7 +113,7 @@ class PlaybackHistoryTest {
     fun `last heard is the most recent resumable snapshot`() {
         var history = PlaybackHistory.record(emptyList(), snapshot(chapterId = 1, recordedAtMs = 10))
         history = PlaybackHistory.record(history, snapshot(chapterId = 2, recordedAtMs = 20))
-        assertEquals(2, PlaybackHistory.lastHeard(history)?.chapterId)
+        assertEquals(2, PlaybackHistory.lastHeard(history, Owner)?.chapterId)
     }
 
     @Test
@@ -114,20 +121,20 @@ class PlaybackHistoryTest {
         // At 96% the controller has already marked it played, so "continue" would mean "replay the
         // last few seconds and auto-advance".
         val finished = snapshot(positionSeconds = 599.0, durationSeconds = 600.0)
-        assertNull(PlaybackHistory.lastHeard(listOf(finished)))
+        assertNull(PlaybackHistory.lastHeard(listOf(finished), Owner))
     }
 
     @Test
     fun `a chapter with an unknown duration is still offered`() {
         // Progress reads as zero rather than as finished, which is the safe way round.
         val unknown = snapshot(positionSeconds = 30.0, durationSeconds = 0.0)
-        assertEquals(unknown.chapterId, PlaybackHistory.lastHeard(listOf(unknown))?.chapterId)
+        assertEquals(unknown.chapterId, PlaybackHistory.lastHeard(listOf(unknown), Owner)?.chapterId)
     }
 
     @Test
     fun `last heard is null when everything is dismissed`() {
         val history = listOf(snapshot(dismissed = true))
-        assertNull(PlaybackHistory.lastHeard(history))
+        assertNull(PlaybackHistory.lastHeard(history, Owner))
     }
 
     @Test
@@ -138,7 +145,7 @@ class PlaybackHistoryTest {
         history = PlaybackHistory.record(history, snapshot(fictionId = 1, chapterId = 2, recordedAtMs = 2))
         history = PlaybackHistory.record(history, snapshot(fictionId = 2, chapterId = 9, recordedAtMs = 3))
 
-        val choices = PlaybackHistory.jumpBackChoices(history)
+        val choices = PlaybackHistory.jumpBackChoices(history, Owner)
         assertEquals(listOf(2, 1), choices.map { it.fictionId })
         assertEquals(2, choices.first { it.fictionId == 1 }.chapterId)
     }
@@ -152,9 +159,9 @@ class PlaybackHistoryTest {
                 snapshot(fictionId = index, chapterId = index, recordedAtMs = index.toLong()),
             )
         }
-        history = PlaybackHistory.dismiss(history, "9:9")
+        history = PlaybackHistory.dismiss(history, "$Owner:9:9")
 
-        val choices = PlaybackHistory.jumpBackChoices(history, limit = 3)
+        val choices = PlaybackHistory.jumpBackChoices(history, Owner, limit = 3)
         assertEquals(3, choices.size)
         assertTrue(choices.none { it.fictionId == 9 })
     }
@@ -183,7 +190,7 @@ class PlaybackHistoryTest {
         val file = dir.resolve("history.json")
         val store = FilePlaybackHistoryStore(file)
         store.record(snapshot(chapterId = 4))
-        store.dismiss("1:4")
+        store.dismiss("$Owner:1:4")
 
         assertTrue(FilePlaybackHistoryStore(file).history.value.single().dismissed)
     }
@@ -225,5 +232,56 @@ class PlaybackHistoryTest {
         store.clear()
         assertTrue(store.history.value.isEmpty())
         assertTrue(FilePlaybackHistoryStore(file).history.value.isEmpty())
+    }
+
+    // --- Account scoping ------------------------------------------------------------------------
+
+    @Test
+    fun `one account never sees another's reading history`() {
+        // The file is machine-local and outlives every session, but its contents are not: signing
+        // out and signing in as somebody else on the same desktop must not expose what the previous
+        // person was reading.
+        var history = PlaybackHistory.record(emptyList(), snapshot(fictionId = 1, ownerKey = Owner))
+        history = PlaybackHistory.record(history, snapshot(fictionId = 2, ownerKey = OtherOwner))
+
+        assertEquals(listOf(1), PlaybackHistory.jumpBackChoices(history, Owner).map { it.fictionId })
+        assertEquals(listOf(2), PlaybackHistory.jumpBackChoices(history, OtherOwner).map { it.fictionId })
+        assertEquals(1, PlaybackHistory.lastHeard(history, Owner)?.fictionId)
+        assertEquals(2, PlaybackHistory.lastHeard(history, OtherOwner)?.fictionId)
+    }
+
+    @Test
+    fun `a snapshot from an older build belongs to nobody`() {
+        // Losing the strip once is a much better outcome than showing one account's titles to the
+        // next person who signs in.
+        val history = PlaybackHistory.record(emptyList(), snapshot(ownerKey = ""))
+
+        assertTrue(PlaybackHistory.jumpBackChoices(history, Owner).isEmpty())
+        assertNull(PlaybackHistory.lastHeard(history, Owner))
+        // And a blank *current* owner — a signed-out screen — sees nothing either.
+        assertTrue(PlaybackHistory.jumpBackChoices(history, "").isEmpty())
+    }
+
+    @Test
+    fun `two accounts holding the same fiction id keep separate rows and dismissals`() {
+        // Fiction ids are unique only within a server, so the identity has to carry the owner.
+        var history = PlaybackHistory.record(emptyList(), snapshot(fictionId = 5, chapterId = 5, ownerKey = Owner))
+        history = PlaybackHistory.record(history, snapshot(fictionId = 5, chapterId = 5, ownerKey = OtherOwner))
+        assertEquals(2, history.size, "one account's snapshot replaced the other's")
+
+        history = PlaybackHistory.dismiss(history, "$Owner:5:5")
+        assertEquals(1, PlaybackHistory.jumpBackChoices(history, OtherOwner).size)
+        assertTrue(PlaybackHistory.jumpBackChoices(history, Owner).isEmpty())
+    }
+
+    @Test
+    fun `the owner key names neither the server nor the account`() {
+        val key = PlaybackHistory.ownerKeyFor("https://host.example", "alice")
+        assertFalse(key.contains("host.example"))
+        assertFalse(key.contains("alice"))
+        assertTrue(key.all { it in "0123456789abcdef" })
+        // Same session, same key; a different account, a different key.
+        assertEquals(key, PlaybackHistory.ownerKeyFor("https://host.example/", "Alice"))
+        assertFalse(key == PlaybackHistory.ownerKeyFor("https://host.example", "bob"))
     }
 }

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackPreferencesApplyTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackPreferencesApplyTest.kt
@@ -298,6 +298,39 @@ class PlaybackPreferencesApplyTest {
     }
 
     @Test
+    fun `starting another chapter unfreezes a timer armed while paused`() = runBlocking {
+        // Only togglePlayPause used to resume a frozen countdown, but audio also starts when a new
+        // chapter begins or a failed one is retried. Without unfreezing there, the timer sat still
+        // while playback ran on indefinitely — the display frozen and the sleep never arriving.
+        val engine = FakePlaybackEngine()
+        val clock = FakeClock()
+        val timer = SleepTimer(clock)
+        val playback = controller(engine, sleepTimer = timer, clock = clock)
+
+        playback.playQueue(listOf(chapter(1), chapter(2)), startChapterId = 1, fiction = null)
+        playback.await("playback to start") { it.hasMedia && it.isPlaying }
+
+        playback.togglePlayPause()
+        playback.await("the pause to land") { !it.isPlaying }
+        playback.setSleepTimer(SleepTimerMode.Duration(30))
+        // Read from the timer rather than the published state: the controller mirrors it through a
+        // collector, which has not necessarily run yet on this line.
+        assertEquals(30 * 60_000L, timer.state.value.remainingMs)
+
+        // Starting a different chapter is a resume as far as the timer is concerned.
+        playback.skipToNextChapter()
+        playback.await("the next chapter to play") { it.isPlaying && it.currentIndex == 1 }
+
+        clock.nowMs += 10 * 60_000L
+        delay(100)
+        assertEquals(
+            20 * 60_000L,
+            playback.state.value.sleepTimer.remainingMs,
+            "the timer stayed frozen while a new chapter played",
+        )
+    }
+
+    @Test
     fun `stopping disarms the timer so the next chapter is not silenced`() = runBlocking {
         val engine = FakePlaybackEngine()
         val playback = controller(engine)

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackPreferencesApplyTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackPreferencesApplyTest.kt
@@ -48,6 +48,7 @@ class PlaybackPreferencesApplyTest {
         history: InMemoryPlaybackHistoryStore = InMemoryPlaybackHistoryStore(),
         sleepTimer: SleepTimer = SleepTimer(),
         clock: () -> Long = System::currentTimeMillis,
+        ownerKey: () -> String = { "owner-a" },
     ) = QueuePlaybackController(
         repository = FakeRepository(),
         sources = FakeMediaSourceFactory(),
@@ -57,6 +58,7 @@ class PlaybackPreferencesApplyTest {
         historyStore = history,
         sleepTimer = sleepTimer,
         clock = clock,
+        ownerKey = ownerKey,
         retryDelaysMs = emptyList(),
         tickIntervalMs = 10,
     )
@@ -418,6 +420,33 @@ class PlaybackPreferencesApplyTest {
             assertTrue(
                 history.history.value.none { it.chapterId == 99 && it.positionSeconds > 0 },
                 "the old position was recorded against the new chapter",
+            )
+        }
+
+    @Test
+    fun `a snapshot is filed under the account that was listening, not the one signed in now`() =
+        runBlocking {
+            // stop() is fire-and-forget and records history *after* a suspending server save. If
+            // account A signs out and B signs in while that request is in flight, resolving the
+            // owner live would file A's chapter titles under B's key — the exact cross-account
+            // disclosure the owner key exists to prevent.
+            val engine = FakePlaybackEngine()
+            val history = InMemoryPlaybackHistoryStore()
+            var signedIn = "owner-a"
+            val playback = controller(engine, history = history, ownerKey = { signedIn })
+
+            playback.playQueue(listOf(chapter(1)), startChapterId = 1, fiction = null)
+            playback.await("media to load") { it.hasMedia }
+
+            // The session changes underneath a queue that is still A's.
+            signedIn = "owner-b"
+            playback.togglePlayPause()
+            awaitCondition("a snapshot") { history.history.value.isNotEmpty() }
+
+            assertEquals(
+                "owner-a",
+                history.history.value.single().ownerKey,
+                "the chapter was filed under whoever happened to be signed in at record time",
             )
         }
 

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackPreferencesApplyTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackPreferencesApplyTest.kt
@@ -351,6 +351,44 @@ class PlaybackPreferencesApplyTest {
     }
 
     @Test
+    fun `switching to another fiction records the chapter being left, not one from the new queue`() =
+        runBlocking {
+            // playQueue replaces the queue before begin() runs, so anything that reads
+            // queue[queueIndex] afterwards is describing the *new* queue with the *old* index —
+            // which is a different chapter, or none at all when the new queue is shorter.
+            val engine = FakePlaybackEngine()
+            val history = InMemoryPlaybackHistoryStore()
+            val playback = controller(engine, history = history)
+
+            // Start deep enough into the first serial that the old index does not exist in the new
+            // queue: index 2 here, and the serial we switch to has a single chapter.
+            playback.playQueue(
+                listOf(chapter(1), chapter(2), chapter(3)),
+                startChapterId = 3,
+                fiction = null,
+            )
+            playback.await("the third chapter to load") { it.hasMedia }
+            engine.setDuration(600_000)
+            engine.setPosition(90_000)
+            awaitCondition("a position") { playback.state.value.positionMs > 0 }
+
+            playback.play(chapter(99), fiction = null)
+            playback.await("the new chapter to load") { it.queue.singleOrNull()?.chapterId == 99 }
+
+            val left = history.history.value.firstOrNull { it.chapterId == 3 }
+            assertTrue(
+                left != null,
+                "the chapter being left was never recorded; history was ${history.history.value}",
+            )
+            assertEquals(90.0, left.positionSeconds, 0.001)
+            // And the position must not have been filed against the chapter we switched *to*.
+            assertTrue(
+                history.history.value.none { it.chapterId == 99 && it.positionSeconds > 0 },
+                "the old position was recorded against the new chapter",
+            )
+        }
+
+    @Test
     fun `nothing is recorded when nothing has loaded`() = runBlocking {
         val history = InMemoryPlaybackHistoryStore()
         val playback = controller(FakePlaybackEngine(), history = history)

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/NavigationUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/NavigationUiTest.kt
@@ -82,7 +82,7 @@ class NavigationUiTest {
             SessionState(serverUrl = "https://x/", token = "t", username = "admin", serverName = "Perspektiva"),
         ),
         repositoryFactory = { _, _, _ -> repository },
-        playbackFactory = { _, _, _, _, _, _ -> playback },
+        playbackFactory = { _, _, _, _, _, _, _ -> playback },
         // In-memory, so rendering a screen in a test never touches the real
         // ~/.config/TTSRoad files the production stores default to.
         playbackPreferences = InMemoryPlaybackPreferencesStore(),

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ScreensUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ScreensUiTest.kt
@@ -46,7 +46,7 @@ class ScreensUiTest {
     ) = AppContainer(
         sessionStore = InMemorySessionStore(session),
         repositoryFactory = { _, _, _ -> repository },
-        playbackFactory = { _, _, _, _, _, _ -> playback },
+        playbackFactory = { _, _, _, _, _, _, _ -> playback },
         // In-memory, so rendering a screen in a test never touches the real
         // ~/.config/TTSRoad files the production stores default to.
         playbackPreferences = InMemoryPlaybackPreferencesStore(),
@@ -145,7 +145,7 @@ class ScreensUiTest {
         val app = AppContainer(
             sessionStore = store,
             repositoryFactory = { _, _, _ -> repository },
-            playbackFactory = { _, _, _, _, _, _ -> playback },
+            playbackFactory = { _, _, _, _, _, _, _ -> playback },
             // In-memory, so rendering a screen in a test never touches the real
             // ~/.config/TTSRoad files the production stores default to.
             playbackPreferences = InMemoryPlaybackPreferencesStore(),
@@ -222,7 +222,7 @@ class ScreensUiTest {
         val app = AppContainer(
             sessionStore = store,
             repositoryFactory = { _, _, _ -> repository },
-            playbackFactory = { _, _, _, _, _, _ -> FakePlaybackController() },
+            playbackFactory = { _, _, _, _, _, _, _ -> FakePlaybackController() },
             // In-memory, so rendering a screen in a test never touches the real
             // ~/.config/TTSRoad files the production stores default to.
             playbackPreferences = InMemoryPlaybackPreferencesStore(),


### PR DESCRIPTION
#24 was merged while the round-3 review fixes were still in flight, so master is missing them. This carries that commit plus the two findings from round 4 that are genuinely new.

## What master is missing (cherry-picked from #24's branch)

**History and progress were attributed to the wrong chapter.** `play()` and `playQueue()` replace `queue` before `begin()` runs, so the save and the snapshot read `queue[queueIndex]` — the *new* queue at the *old* index. Switching fiction filed the position against whichever chapter happened to sit at that index, or nothing at all when the new queue was shorter.

Codex flagged the history half. `saveProgressNow()` has the same shape and is the more damaging one: switching serials wrote the old position to the **server** against the wrong chapter id, corrupting the resume point rather than losing a local snapshot. Both now go through `leaveCurrentChapter()`, called while the queue and index still describe the chapter being left.

**Read-modify-write races.** The history store's mutations reach it from the controller and the Compose thread; unsynchronised, the later write wins outright, and a stale `record` carries `dismissed = false` — which defeats the inheritance rule whose whole purpose is that a progress save must never undo a dismissal. `FilePlaybackPreferencesStore.update` has the identical defect with three writers (Settings, the controller, and dbus-java's reader thread on a volume change). Both are synchronised. *This is round 4's third finding — already fixed here, just not visible to the review.*

## New in round 4

**A frozen sleep timer never restarted.** A timer armed while paused stayed frozen when playback resumed through any path other than `togglePlayPause` — starting a different chapter or retrying a failed one goes through `attemptChapter`, which calls `engine.play()` directly. The audio ran on indefinitely with the countdown standing still. The resume now happens where audio actually starts, and is a no-op when nothing is frozen.

**Playback history leaked across accounts.** The history file is machine-local but was not account-scoped, so signing out and signing in as somebody else on the same desktop showed the previous account's fiction and chapter titles in the "Jump back in" strip. Snapshots now carry a hashed owner key and the read paths filter by it:

- The key is **hashed**, so scoping the file does not also turn it into a record of which servers this machine talks to and under what name — the same reasoning that keeps URLs out of `PlaybackSnapshot` entirely.
- The **dismissal identity includes the owner**, because fiction ids are unique only within a server. Two accounts can hold the same id for different content, and without this one account's dismissal would hide the other's row.
- A snapshot from an older build has **no owner and is shown to nobody**. Losing the strip once is a much better outcome than showing one person's reading history to the next.

## Verification

`clean check --warning-mode fail -Pttsroad.warningsAsErrors=true` under Xvfb: **573 tests, 0 failures**. Both new regression tests were confirmed by reverting their fixes — one fails with `the timer stayed frozen while a new chapter played`, the other with `expected: <[1]> but was: <[2, 1]>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)