### PR TITLE
Phase 8: add audio-synchronized read-along

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,24 @@ apply to audio.
   refreshes underneath. Settings measures real files, groups downloads by fiction, and keeps
   confirmed Delete all downloads separate from Clear streaming cache.
 
+### Read-along
+
+- `ReadAlongDocument` validates compact server offsets once, then resolves active cue, sentence,
+  paragraph and word seeks with binary lookup. Its only timing input is `PlayerUiState.positionMs` —
+  never extrapolate with wall time or scale by playback speed. Disable highlighting when timing
+  rows are malformed, requested/returned chapter ids differ, or audio duration is stale.
+- `ReadAlongCache` is memory → identity-scoped disk → authenticated conditional network. A 304
+  reuses the parsed object, 404 is normal no-text, and network/5xx falls back to disk. A 401 never
+  falls back because the session no longer authorizes account content. `App` clears memory and
+  `DownloadCoordinator` makes the retained disk namespace unreachable on sign-out.
+- `ReaderScreen` renders one lazy item per paragraph, not one composable per word. Wheel, drag and
+  scrollbar input permanently surrender follow until Back to current. Highlighting a chapter other
+  than the one playing is forbidden; queue advance changes the document only after the reader has
+  actually followed its own chapter.
+- Reader appearance is local-first in `reader.json` and synchronized only through the four known
+  `/api/me/preferences` keys. PATCH must never echo unrelated account settings. Preserve the server
+  ranges (font 14–30, line height 1.3–2.4) and dark/sepia/light + sentence/word/off vocabularies.
+
 ### MPRIS
 
 `player/MprisState.kt` is pure Kotlin with no D-Bus type in it — that's where the audiobook mapping
@@ -231,8 +249,8 @@ can't quietly skip its way to green.
 credential storage and capability discovery (0002), the playback engine (0002-playback-engine),
 device sessions and Settings (0003), navigation (0004), chapter browsing (0005), and listening
 preferences / sleep timer / MPRIS / shortcuts (0006). Read the relevant one before changing any of
-the invariants above; offline storage and caching are in 0007. They exist because the alternative
-was tried or measured.
+the invariants above; offline storage and caching are in 0007, and read-along is in 0008. They exist
+because the alternative was tried or measured.
 
 ## CI
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Built with Compose for Desktop — real Skia-rendered UI, real OS installers, no
 | App shortcuts — Space, arrows, Ctrl+arrows, Ctrl+L, Ctrl+, plus an F1 list | ✅ |
 | Offline downloads — per chapter, next 10, restart-safe queue, storage controls | ✅ |
 | Bounded streaming cache and previously loaded library browsing while offline | ✅ |
+| Audio-synchronized read-along — offline text, word seek, find, themes and zoom | ✅ |
 | Streaming playback — audio starts before the chapter has downloaded | ✅ Linux |
 | Seeking without decoding from the start of the chapter | ✅ Linux |
 | Variable-rate playback ("speed"), pitch-preserving 0.5×–3.0× | ✅ Linux |
@@ -103,6 +104,8 @@ Listening preferences, the sleep timer, local history, MPRIS and the shortcut ta
 [`docs/adr/0006-listening-preferences-and-desktop-integration.md`](docs/adr/0006-listening-preferences-and-desktop-integration.md).
 Offline namespaces, resumable downloads, streamed-audio retention and disk metadata are in
 [`docs/adr/0007-offline-downloads-and-streaming-cache.md`](docs/adr/0007-offline-downloads-and-streaming-cache.md).
+Read-along parsing, ETag caching, media-time highlighting and account preference sync are in
+[`docs/adr/0008-audio-synchronized-read-along.md`](docs/adr/0008-audio-synchronized-read-along.md).
 
 ## 🚀 Bootstrap
 
@@ -180,6 +183,12 @@ src/main/kotlin/dk/perspektiva/ttsroad/desktop/
 │   ├── Cached.kt                 value + error + isRefreshing + last success, independently
 │   ├── LibraryCache.kt           library/chapter state held above the screens
 │   ├── LibraryDiskCache.kt       account-scoped rebuildable metadata for offline browsing
+│   ├── ReadAlongModels.kt        compact text/cue and account-preference API models
+│   ├── ReadAlongDocument.kt      validated spans + binary highlight/seek/find lookup
+│   ├── ReadAlongSentences.kt     paragraph-bounded sentence segmentation
+│   ├── ReadAlongCache.kt         ETag revalidation + offline fallback
+│   ├── ReadAlongDiskCache.kt     bounded identity-scoped text cache
+│   ├── ReaderPreferences.kt      local fallback + account synchronization
 │   ├── AppDirectories.kt         platform config/data/cache roots
 │   ├── StorageIdentity.kt        stable server/account disk namespace + generated audio names
 │   ├── ChapterLists.kt           filter/sort, bulk id selection, status, played patch + rollback
@@ -225,6 +234,7 @@ src/main/kotlin/dk/perspektiva/ttsroad/desktop/
     ├── SettingsStateHolder.kt    settings panes, device sessions, confirmations
     ├── LibraryScreen.kt          LazyVerticalGrid: hero, shelves, search, fictions
     ├── FictionDetailScreen.kt    LazyColumn: one header item, then chapter rows + bulk controls
+    ├── ReaderScreen.kt           lazy selectable reader, follow/find/zoom/theme controls
     ├── SettingsScreen.kt         two-pane control centre
     ├── ShortcutsDialog.kt        the in-app keyboard reference (F1)
     └── PlayerScreen.kt           full player + NowPlayingBar (stacked when narrow)
@@ -280,9 +290,10 @@ There are three deliberately different kinds of disk state:
   A sequential stream is retained only after clean EOF and the same validation. Seeking abandons
   that cache attempt rather than promoting a file with a hole. The cache is bounded to 1 GiB and
   evicts least-recently-used completed entries.
-- **Library/chapter metadata** is rebuildable cache too. It lets a restart show previously loaded
-  fictions and chapters immediately, with the original last-refresh time and an offline refresh
-  error above retained content. Server-local file paths and backend error details are stripped.
+- **Library/chapter metadata and read-along documents** are rebuildable cache too. They let a
+  restart show previously loaded fictions and chapters immediately and keep previously opened
+  narration readable offline. Read-along text/cues retain their ETag and are bounded separately
+  from audio to 64 MiB / 80 chapters. Server-local paths and backend errors are stripped.
 
 All three use `<stable-server>/<account>/<generated-chapter-id>` namespaces. Capability discovery's
 advertised `server.base_url` is the preferred server identity, so changing from a LAN address to a
@@ -297,6 +308,27 @@ worker to release its handles and removes the partial. Settings measures request
 and keeps **Delete all downloads** separate from **Clear streaming cache**, each behind confirmation.
 Signing out keeps bytes but closes the account's index and fiction titles until that account signs
 in again.
+
+## 📖 Read-along reader
+
+The reader is offered only when capability discovery reports `readalong`. `has_timings` changes the
+mode, not whether useful text exists: timed chapters follow audio; older chapters remain selectable,
+searchable plain narration. The player and each chapter row can open it, and opening a chapter that
+is not playing never highlights it against unrelated audio.
+
+- Compact cue arrays are validated into half-open text spans. Malformed/non-monotonic cues, a
+  mismatched chapter id, or an audio-duration mismatch disable highlighting with an explanation
+  instead of confidently pointing at stale text.
+- Cue, sentence, paragraph and word-seek lookup are binary. Highlighting consumes the playback
+  engine's reported **media position**, so 2× playback needs no wall-clock scaling and cannot drift.
+- Paragraphs are lazy items, never one composable per word. Text stays selectable/copyable, Ctrl+F
+  finds within the chapter, and Page Up/Down plus Home/End work without a pointer.
+- Follow mode holds the active paragraph roughly one-third down. Wheel, drag, or scrollbar input
+  yields until **Back to current**; queue auto-advance loads the next document and restores follow.
+  The next queue chapter is prefetched at 80%.
+- Font size (14–30), line height (1.3–2.4), dark/sepia/light theme, and sentence/word/off highlight
+  are saved locally first and synchronized through `GET/PATCH /api/me/preferences` when supported.
+  An older or offline server leaves the last-known local values usable.
 
 ## 🎚️ Listening preferences, the sleep timer and the desktop
 
@@ -414,9 +446,8 @@ what makes "scroll to the chapter that is playing" arithmetic rather than a gues
 - **Every row action is keyboard-reachable**: play, mark played/unplayed, mark all previous, and
   read-along are always in the semantics tree with a content description, and merely dim when the
   row is not hovered or focused.
-- **Read-along** appears only when the server reports the `readalong` capability *and* the chapter
-  has timings. It currently navigates to the reader placeholder; the reader itself lands in a later
-  phase.
+- **Read-along** appears when the server reports the `readalong` capability. `has_timings` chooses
+  synchronized versus text-only mode; it does not hide narration text from older chapters.
 - The **up-next panel** grows a search box once a queue passes eight chapters. Filtering it never
   reorders or renumbers anything.
 

--- a/docs/adr/0004-stateful-adaptive-navigation.md
+++ b/docs/adr/0004-stateful-adaptive-navigation.md
@@ -37,9 +37,9 @@ Two rules are load-bearing:
   `Fiction(fresherSummaryFromChaptersEndpoint)` are the same screen. Without that, a refreshed
   summary would read as a new destination and drop the scroll position.
 
-`Reader` is declared and keyed but has no UI in this build. It is here so the retention rules and,
+`Reader` was declared and keyed but had no UI in this phase (superseded by ADR 0008). It was added so the retention rules and,
 in particular, the `Reader:7` / `Fiction:7` key separation are settled before the read-along phase,
-and so nothing has to change shape later. It renders an honest placeholder; nothing navigates to it.
+and so nothing had to change shape later. It rendered an honest placeholder; nothing navigated to it then.
 
 `Devices` is a real destination rather than a pane flag, so a future "manage sessions" link
 anywhere in the app lands somewhere addressable. Selecting a pane inside Settings **replaces** the

--- a/docs/adr/0005-chapter-browsing-and-bulk-controls.md
+++ b/docs/adr/0005-chapter-browsing-and-bulk-controls.md
@@ -164,9 +164,9 @@ jumps to its real position.
 
 **Costs and things deliberately not done.**
 
-- **Read-along still has no reader.** The row action is gated on `capabilities.readalong` *and*
+- **Read-along still had no reader in this phase (superseded by ADR 0008).** The row action was gated on `capabilities.readalong` *and*
   per-chapter `has_timings`, so it only appears where the server could actually serve it — but it
-  navigates to the `Reader` destination, which is still the honest placeholder from Phase 3. This
+  navigated to the `Reader` destination, which was still the honest placeholder from Phase 3. This
   is the one place in this phase where a control leads somewhere unfinished; it is wired now so
   that the reader phase is a screen swap rather than a change to the chapter list.
 - **The download slot draws nothing (superseded by ADR 0007).** `ChapterDownloadState` and

--- a/docs/adr/0008-audio-synchronized-read-along.md
+++ b/docs/adr/0008-audio-synchronized-read-along.md
@@ -1,0 +1,87 @@
+# ADR 0008: Audio-synchronized read-along
+
+- Status: Accepted
+- Date: 2026-08-09
+- Issue: #5 (Phase 8)
+
+## Context
+
+The server exposes one bearer-protected read-along document per chapter. Its narration text is
+indexed by compact paragraph `[start,end]` and cue `[start,end,time]` arrays, supports ETag
+revalidation, and returns 404 normally when no narration text exists. Timing data may be absent for
+older conversions or malformed/stale after an audio replacement. The reader must remain responsive
+for long chapters, work offline for previously opened content, and never show one account's text in
+another session.
+
+Playback already publishes the engine's media position. That position, rather than elapsed wall
+time, is the only clock that remains correct under pause, seek, speed changes, and skip-silence.
+
+## Decision
+
+### Validate once, look up with binary search
+
+`ReadAlongDocument.from` validates and clamps paragraph spans, rejects malformed/non-monotonic cue
+sets, derives paragraph-bounded sentence spans once, and keeps cue order safe for binary lookup.
+Active cue, sentence, paragraph, find range, and clicked-word seek are pure operations over the
+validated document. A duration mismatch greater than five seconds or two percent disables timing.
+The reader states why instead of highlighting stale text confidently.
+
+The reader consumes `PlayerUiState.positionMs` directly. Playback rate is deliberately absent from
+the algorithm: 40 seconds of media remains cue time 40 at both 1× and 2×.
+
+### Cache raw responses under the offline identity
+
+`ReadAlongCache` resolves memory, then `ReadAlongDiskCache`, then an authenticated conditional
+request. The raw response and ETag are stored so parsing improvements apply to old cache entries.
+A 304 reuses the same parsed memory object; network/5xx falls back to cached content; 404 removes a
+stale cache entry and becomes the normal no-text UI. A 401 ends the session and is never hidden by
+fallback content.
+
+Disk content lives below `cache/readalong/<stable-server>/<account>/chapter-<id>.json`, using the
+same `StorageIdentity` as offline audio. Directories/files are owner-only, generated names defend
+against traversal, and symlink roots are refused. The cache is bounded independently from audio to
+64 MiB and 80 chapters using last access as its LRU signal. Signing out clears in-memory documents
+and closes the live identity while leaving rebuildable disk bytes for the same account's return.
+
+### One lazy item per paragraph
+
+`ReaderScreen` renders a paragraph as one selectable `Text`; words are annotated spans, not
+composables. This bounds live composition for a 10,000-word chapter while preserving sentence-band,
+word, and find highlighting. Paragraph and heading semantics remain visible to assistive technology.
+
+Auto-follow places the active paragraph approximately one-third down. Wheel, drag, scrollbar,
+Page Up/Down, Home/End, and find navigation permanently surrender follow until **Back to current**.
+Opening non-playing text never follows unrelated audio. Once the reader has followed its own
+playing chapter, queue auto-advance replaces the document and restores follow. The next queue entry
+is prefetched at 80 percent.
+
+### Local-first, account-synchronized appearance
+
+Font size, line height, theme, and highlight mode are immediately persisted in `reader.json`, then
+synchronized through only these server keys:
+
+- `reader_font_size` (14–30)
+- `reader_line_height` (1.3–2.4)
+- `reader_theme` (`dark`, `sepia`, `light`)
+- `reader_highlight` (`sentence`, `word`, `off`)
+
+GET merges supported values over the local fallback. PATCH contains exactly those four keys, so it
+cannot overwrite unrelated preferences in the account JSON blob. A 404 or offline server leaves the
+last-known local values active.
+
+## Rejected alternatives
+
+- Advancing highlights from a frame/wall clock: drifts after speed, pause, seek, and skip-silence.
+- One composable per cue/word: makes long chapters retain thousands of live nodes.
+- Hiding chapters without `has_timings`: discards useful narration text from older conversions.
+- Serving cached text after 401: treats retained login hints as authority and exposes protected
+  account content after revocation.
+- A global chapter-id cache: collides across servers/accounts with overlapping database ids.
+- Persisting only derived spans: freezes old parsing bugs into cache entries across upgrades.
+
+## Consequences
+
+Read-along remains useful without audio or timings, reopens offline, and tracks playback without
+rate-specific logic. The cache adds another protected identity-scoped tree and the reader preference
+file adds non-secret local state. Server preference synchronization is best effort by design; local
+reading controls never wait on a network round trip.

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -77,6 +77,7 @@ import dk.perspektiva.ttsroad.desktop.ui.MetaText
 import dk.perspektiva.ttsroad.desktop.ui.NowPlayingBar
 import dk.perspektiva.ttsroad.desktop.ui.PageGutter
 import dk.perspektiva.ttsroad.desktop.ui.PlayerScreen
+import dk.perspektiva.ttsroad.desktop.ui.ReaderScreen
 import dk.perspektiva.ttsroad.desktop.ui.SettingsScreen
 import dk.perspektiva.ttsroad.desktop.ui.SettingsSection
 import dk.perspektiva.ttsroad.desktop.ui.SettingsStateHolder
@@ -215,6 +216,7 @@ fun App(container: AppContainer = remember { AppContainer() }) {
             // The library belonged to the account that just ended; the next person to sign in on
             // this machine must not be shown it.
             cache.clear()
+            container.readAlongCache.clear()
             settings.sessionEnded()
         } else {
             // Cheap, and it is what makes optional UI correct after a restart, where login did
@@ -225,6 +227,9 @@ fun App(container: AppContainer = remember { AppContainer() }) {
             // startup in an address-derived directory.
             container.downloads.advertisedBaseUrl = discovered.serverBaseUrl
             container.downloads.refresh()
+            // Local values are already usable; a capable server can now replace them with this
+            // account's cross-device reader settings. Older/offline servers leave them alone.
+            container.readerPreferences.refreshFromServer()
         }
     }
 
@@ -311,9 +316,8 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                         chapters = cache.chapters(destination.fiction.id)
                                             .collectAsState().value.value?.chapters.orEmpty(),
                                     ),
-                                    // Offered only for chapters the *server* holds timings for, so
-                                    // the row action cannot appear on a chapter the reader could
-                                    // never open.
+                                    // Capability-gated at the row. A chapter without timings still
+                                    // opens as selectable plain narration text.
                                     onOpenReader = { chapter ->
                                         nav.open(
                                             Destination.Reader(chapter.resolvedChapterId, chapter.resolvedTitle),
@@ -325,6 +329,10 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                     playback = playback,
                                     sizeClass = sizeClass,
                                     preferences = container.playbackPreferences,
+                                    readAlongAvailable = capabilities.readAlong,
+                                    onOpenReader = { chapterId, title ->
+                                        nav.open(Destination.Reader(chapterId, title))
+                                    },
                                     onBack = { nav.back() },
                                 )
 
@@ -352,7 +360,17 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                     },
                                 )
 
-                                is Destination.Reader -> ReaderPlaceholder(destination.title)
+                                is Destination.Reader -> ReaderScreen(
+                                    chapterId = destination.chapterId,
+                                    fallbackTitle = destination.title,
+                                    cache = container.readAlongCache,
+                                    preferences = container.readerPreferences,
+                                    playback = playback,
+                                    onBack = { nav.back() },
+                                    onChapterAdvanced = { chapterId, title ->
+                                        nav.replaceTop(Destination.Reader(chapterId, title))
+                                    },
+                                )
                             }
                         }
                     }
@@ -383,26 +401,6 @@ private val Destination.isRefreshable: Boolean
         Destination.Library, is Destination.Fiction, Destination.Settings, Destination.Devices -> true
         Destination.Player, is Destination.Reader -> false
     }
-
-/**
- * Read-along is not part of this build.
- *
- * Nothing navigates here — the destination exists so the back stack's keys and retention rules are
- * settled before the reader phase lands. An honest pane beats a half-wired screen if something
- * ever does reach it.
- */
-@Composable
-private fun ReaderPlaceholder(title: String) {
-    Box(Modifier.fillMaxSize().padding(PageGutter), contentAlignment = Alignment.Center) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            MetaText(text = "// Read-along", color = AarisColor.Accent)
-            Spacer(Modifier.height(8.dp))
-            Text(title, style = MaterialTheme.typography.titleLarge, color = AarisColor.Ink)
-            Spacer(Modifier.height(8.dp))
-            MetaText("Read-along arrives in a later build")
-        }
-    }
-}
 
 @Composable
 private fun HeaderBar(

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ReadAlongCache.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ReadAlongCache.kt
@@ -1,0 +1,81 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import retrofit2.HttpException
+
+/**
+ * Memory/disk/network read-along cache with conditional revalidation and offline fallback.
+ *
+ * Memory is explicitly session-scoped via [clear]. Disk is supplied by the live download
+ * coordinator, so it is unreachable while signed out and cannot cross a server/account boundary.
+ */
+class ReadAlongCache(
+    private val repository: TtsRoadRepository,
+) {
+    private data class MemoryEntry(val cached: CachedReadAlong, val document: ReadAlongDocument)
+
+    private val memory = ConcurrentHashMap<Int, MemoryEntry>()
+    private val locks = ConcurrentHashMap<Int, Mutex>()
+    @Volatile private var diskCache: () -> ReadAlongDiskCache? = { null }
+
+    fun attachDiskCache(supplier: () -> ReadAlongDiskCache?): ReadAlongCache = apply {
+        diskCache = supplier
+    }
+
+    suspend fun load(chapterId: Int): ReadAlongDocument? {
+        require(chapterId > 0) { "invalid chapter id" }
+        return locks.getOrPut(chapterId) { Mutex() }.withLock { loadLocked(chapterId) }
+    }
+
+    /** Best effort and intentionally silent: prefetch must never disturb playback. */
+    suspend fun prefetch(chapterId: Int) {
+        runCatching { load(chapterId) }
+    }
+
+    fun clear() {
+        memory.clear()
+        locks.clear()
+    }
+
+    private suspend fun loadLocked(chapterId: Int): ReadAlongDocument? {
+        val disk = diskCache()
+        val available = memory[chapterId] ?: disk?.read(chapterId)?.toMemory(chapterId)?.also {
+            memory[chapterId] = it
+        }
+        return try {
+            when (val fetched = repository.readAlong(chapterId, available?.cached?.etag)) {
+                is ReadAlongFetchResult.Modified -> {
+                    if (fetched.response.chapter.id != chapterId) {
+                        error("The server returned read-along text for a different chapter")
+                    }
+                    val cached = CachedReadAlong(etag = fetched.etag, response = fetched.response)
+                    val entry = cached.toMemory(chapterId)
+                        ?: error("The read-along document could not be parsed safely")
+                    memory[chapterId] = entry
+                    disk?.write(chapterId, cached)
+                    entry.document
+                }
+
+                ReadAlongFetchResult.NotModified ->
+                    available?.document ?: error("The server returned 304 without a cached document")
+
+                ReadAlongFetchResult.NotFound -> {
+                    memory.remove(chapterId)
+                    disk?.delete(chapterId)
+                    null
+                }
+            }
+        } catch (failure: Throwable) {
+            // A refused credential immediately removes the authority to read account content.
+            if (failure is HttpException && failure.code() == 401) throw failure
+            available?.document ?: throw failure
+        }
+    }
+
+    private fun CachedReadAlong.toMemory(chapterId: Int): MemoryEntry? {
+        if (version != CachedReadAlong.CurrentVersion || response.chapter.id != chapterId) return null
+        return runCatching { MemoryEntry(this, ReadAlongDocument.from(response)) }.getOrNull()
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ReadAlongDiskCache.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ReadAlongDiskCache.kt
@@ -1,0 +1,120 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dk.perspektiva.ttsroad.desktop.security.SecureFiles
+import java.io.File
+import java.nio.file.Files
+
+/** Owner-only, bounded read-along documents for one stable server/account identity. */
+class ReadAlongDiskCache(
+    val root: File,
+    private val maxBytes: Long = DefaultMaxBytes,
+    private val maxEntries: Int = DefaultMaxEntries,
+    private val ownedDirectories: List<File> = listOf(root),
+    private val clock: () -> Long = System::currentTimeMillis,
+) {
+    private val adapter = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+        .adapter(CachedReadAlong::class.java)
+
+    fun read(chapterId: Int): CachedReadAlong? = runCatching {
+        val file = fileFor(chapterId)
+        if (!file.isFile) return null
+        prepare()
+        if (!SecureFiles.restrictToOwner(file.toPath())) return null
+        val cached = adapter.fromJson(file.readText()) ?: return null
+        if (cached.version != CachedReadAlong.CurrentVersion || cached.response.chapter.id != chapterId) {
+            file.delete()
+            return null
+        }
+        file.setLastModified(clock())
+        cached
+    }.onFailure { AppLog.warn("could not read cached read-along document", it) }.getOrNull()
+
+    fun write(chapterId: Int, value: CachedReadAlong) {
+        if (chapterId <= 0 || value.response.chapter.id != chapterId) return
+        runCatching {
+            prepare()
+            val file = fileFor(chapterId)
+            val restricted = SecureFiles.writeAtomically(
+                file,
+                adapter.toJson(value.copy(version = CachedReadAlong.CurrentVersion)),
+            )
+            if (!restricted) {
+                file.delete()
+                error("read-along cache file is not owner-only")
+            }
+            file.setLastModified(clock())
+            evictToBound()
+        }.onFailure { AppLog.warn("could not cache read-along document", it) }
+    }
+
+    fun delete(chapterId: Int) {
+        runCatching { fileFor(chapterId).delete() }
+    }
+
+    fun clear(): Long = runCatching {
+        safeFiles().sumOf { file -> file.length().also { file.delete() } }
+    }.getOrDefault(0L)
+
+    fun size(): Int = safeFiles().size
+    fun bytes(): Long = safeFiles().sumOf(File::length)
+
+    private fun evictToBound() {
+        val newestFirst = safeFiles().sortedByDescending(File::lastModified).toMutableList()
+        var bytes = newestFirst.sumOf(File::length)
+        while (newestFirst.size > maxEntries || bytes > maxBytes) {
+            val oldest = newestFirst.removeLastOrNull() ?: break
+            val length = oldest.length()
+            if (oldest.delete()) bytes -= length
+        }
+    }
+
+    private fun prepare() {
+        check(ownedDirectories.none { Files.isSymbolicLink(it.toPath()) }) {
+            "read-along cache directory is a symlink"
+        }
+        ownedDirectories.forEach { Files.createDirectories(it.toPath()) }
+        check(ownedDirectories.none { Files.isSymbolicLink(it.toPath()) }) {
+            "read-along cache directory is a symlink"
+        }
+        check(ownedDirectories.all { SecureFiles.restrictDirectoryToOwner(it.toPath()) }) {
+            "read-along cache directory is not owner-only"
+        }
+    }
+
+    private fun safeFiles(): List<File> {
+        if (ownedDirectories.any { Files.isSymbolicLink(it.toPath()) }) return emptyList()
+        return root.listFiles { file ->
+            file.isFile && !Files.isSymbolicLink(file.toPath()) && SafeFile.matches(file.name)
+        }?.toList().orEmpty()
+    }
+
+    private fun fileFor(chapterId: Int): File {
+        require(chapterId > 0) { "invalid chapter id" }
+        require(ownedDirectories.none { Files.isSymbolicLink(it.toPath()) }) {
+            "read-along cache directory is a symlink"
+        }
+        val base = root.toPath().toAbsolutePath().normalize()
+        val resolved = base.resolve("chapter-$chapterId.json").normalize()
+        require(resolved.startsWith(base)) { "read-along path escaped its root" }
+        require(!Files.isSymbolicLink(resolved)) { "read-along cache file is a symlink" }
+        return resolved.toFile()
+    }
+
+    companion object {
+        const val DefaultMaxBytes: Long = 64L * 1024L * 1024L
+        const val DefaultMaxEntries: Int = 80
+        private val SafeFile = Regex("chapter-[1-9][0-9]*\\.json")
+
+        fun forIdentity(
+            identity: StorageIdentity,
+            cacheDir: File = AppDirectories.cacheDir(),
+        ): ReadAlongDiskCache {
+            val readAlong = File(cacheDir, "readalong")
+            val server = File(readAlong, identity.serverKey)
+            val account = File(server, identity.accountKey)
+            return ReadAlongDiskCache(account, ownedDirectories = listOf(readAlong, server, account))
+        }
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ReadAlongDocument.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ReadAlongDocument.kt
@@ -1,0 +1,212 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import kotlin.math.abs
+
+/** A half-open `[start, end)` character range into a chapter's narration text. */
+data class TextSpan(val start: Int, val end: Int) {
+    val length: Int get() = end - start
+    fun contains(offset: Int): Boolean = offset in start until end
+    fun overlaps(other: TextSpan): Boolean = start < other.end && other.start < end
+}
+
+/** One timed word-like unit and the media position where it begins. */
+data class ReadAlongCue(val span: TextSpan, val startSeconds: Double)
+
+data class ReadAlongHighlight(
+    val cueIndex: Int = -1,
+    val word: TextSpan? = null,
+    val sentenceIndex: Int = -1,
+    val sentence: TextSpan? = null,
+) {
+    val isActive: Boolean get() = cueIndex >= 0
+
+    companion object {
+        val None: ReadAlongHighlight = ReadAlongHighlight()
+    }
+}
+
+/** Why a loaded document can or cannot follow playback confidently. */
+enum class ReadAlongTimingState {
+    Timed,
+    TextOnly,
+    Malformed,
+}
+
+/**
+ * Validated chapter text with binary cue, sentence, paragraph, and seek lookup.
+ *
+ * Every timing lookup consumes the media position reported by the player. Playback speed therefore
+ * needs no scaling and cannot accumulate wall-clock drift.
+ */
+data class ReadAlongDocument(
+    val chapterId: Int = 0,
+    val fictionId: Int = 0,
+    val title: String = "",
+    val chapterNumber: Double? = null,
+    val audioDurationSeconds: Double = 0.0,
+    val text: String = "",
+    val paragraphs: List<TextSpan> = emptyList(),
+    val cues: List<ReadAlongCue> = emptyList(),
+    val timingState: ReadAlongTimingState = ReadAlongTimingState.TextOnly,
+) {
+    val sentences: List<TextSpan> = segmentReadAlongSentences(text, paragraphs)
+    val hasReliableTimings: Boolean get() = timingState == ReadAlongTimingState.Timed && cues.isNotEmpty()
+
+    fun textIn(span: TextSpan): String =
+        text.substring(span.start.coerceIn(0, text.length), span.end.coerceIn(0, text.length))
+
+    fun cueIndexAt(positionSeconds: Double): Int {
+        if (!hasReliableTimings || !positionSeconds.isFinite()) return -1
+        var low = 0
+        var high = cues.lastIndex
+        var found = -1
+        while (low <= high) {
+            val middle = (low + high) ushr 1
+            if (cues[middle].startSeconds <= positionSeconds) {
+                found = middle
+                low = middle + 1
+            } else {
+                high = middle - 1
+            }
+        }
+        return found
+    }
+
+    fun highlightAtMillis(positionMs: Long): ReadAlongHighlight {
+        val cueIndex = cueIndexAt(positionMs / 1000.0)
+        if (cueIndex < 0) return ReadAlongHighlight.None
+        val word = cues[cueIndex].span
+        val sentenceIndex = spanIndexAt(sentences, word.start)
+        return ReadAlongHighlight(cueIndex, word, sentenceIndex, sentences.getOrNull(sentenceIndex))
+    }
+
+    fun paragraphIndexAt(offset: Int): Int = spanIndexAt(paragraphs, offset)
+
+    /** A click on untimed text deliberately returns null rather than borrowing a nearby cue. */
+    fun seekSecondsForOffset(offset: Int): Double? {
+        if (!hasReliableTimings) return null
+        var low = 0
+        var high = cues.lastIndex
+        var before = -1
+        while (low <= high) {
+            val middle = (low + high) ushr 1
+            if (cues[middle].span.start <= offset) {
+                before = middle
+                low = middle + 1
+            } else {
+                high = middle - 1
+            }
+        }
+        if (before < 0 || !cues[before].span.contains(offset)) return null
+        return cues[before].startSeconds
+    }
+
+    private fun spanIndexAt(spans: List<TextSpan>, offset: Int): Int {
+        var low = 0
+        var high = spans.lastIndex
+        var found = -1
+        while (low <= high) {
+            val middle = (low + high) ushr 1
+            if (spans[middle].start <= offset) {
+                found = middle
+                low = middle + 1
+            } else {
+                high = middle - 1
+            }
+        }
+        return found
+    }
+
+    companion object {
+        fun from(response: ReadAlongResponse): ReadAlongDocument {
+            val text = response.text
+            val paragraphs = response.paragraphs
+                .mapNotNull { it.toSpan(text.length) }
+                .sortedBy { it.start }
+                .withoutOverlaps()
+                .ifEmpty { paragraphsFromLineBreaks(text) }
+
+            val parsed = response.cues.mapNotNull { row ->
+                if (row.size < 3 || !row[2].isFinite() || row[2] < 0.0) return@mapNotNull null
+                row.toSpan(text.length)?.let { ReadAlongCue(it, row[2]) }
+            }.sortedBy { it.startSeconds }
+
+            // Time and character order must agree. Otherwise a binary time lookup can highlight a
+            // word behind the one just spoken, which is less honest than disabling highlights.
+            val monotonic = parsed.zipWithNext().all { (left, right) ->
+                right.startSeconds >= left.startSeconds && right.span.start >= left.span.end
+            }
+            val timingState = when {
+                !response.chapter.hasTimings && response.cues.isEmpty() -> ReadAlongTimingState.TextOnly
+                parsed.isEmpty() || !monotonic || parsed.size != response.cues.size -> ReadAlongTimingState.Malformed
+                else -> ReadAlongTimingState.Timed
+            }
+
+            return ReadAlongDocument(
+                chapterId = response.chapter.id,
+                fictionId = response.chapter.fictionId,
+                title = response.chapter.title,
+                chapterNumber = response.chapter.chapterNumber,
+                audioDurationSeconds = response.chapter.audioDuration
+                    ?.takeIf(Double::isFinite)
+                    ?.coerceAtLeast(0.0)
+                    ?: 0.0,
+                text = text,
+                paragraphs = paragraphs,
+                cues = if (timingState == ReadAlongTimingState.Timed) parsed else emptyList(),
+                timingState = timingState,
+            )
+        }
+
+        private fun List<Double>.toSpan(textLength: Int): TextSpan? {
+            if (size < 2 || !this[0].isFinite() || !this[1].isFinite()) return null
+            val start = this[0].toInt().coerceIn(0, textLength)
+            val end = this[1].toInt().coerceIn(0, textLength)
+            return if (end > start) TextSpan(start, end) else null
+        }
+
+        private fun List<TextSpan>.withoutOverlaps(): List<TextSpan> {
+            if (size < 2) return this
+            val result = ArrayList<TextSpan>(size)
+            forEach { span -> if (result.isEmpty() || span.start >= result.last().end) result += span }
+            return result
+        }
+
+        private fun paragraphsFromLineBreaks(text: String): List<TextSpan> {
+            val result = ArrayList<TextSpan>()
+            var cursor = 0
+            while (cursor < text.length) {
+                while (cursor < text.length && text[cursor] == '\n') cursor++
+                val start = cursor
+                while (cursor < text.length && text[cursor] != '\n') cursor++
+                var end = cursor
+                while (end > start && text[end - 1].isWhitespace()) end--
+                if (end > start) result += TextSpan(start, end)
+            }
+            return result
+        }
+    }
+}
+
+/** Duration mismatches disable confident highlighting against stale timing text/audio. */
+fun readAlongTimingsMatch(documentDurationSeconds: Double, playerDurationMs: Long): Boolean {
+    if (documentDurationSeconds <= 0.0 || playerDurationMs <= 0L) return true
+    val playerSeconds = playerDurationMs / 1000.0
+    val tolerance = maxOf(5.0, documentDurationSeconds * 0.02)
+    return abs(documentDurationSeconds - playerSeconds) <= tolerance
+}
+
+/** All case-insensitive, non-overlapping occurrences used by find-in-chapter. */
+fun readAlongMatches(text: String, query: String): List<TextSpan> {
+    val needle = query.trim()
+    if (needle.isEmpty()) return emptyList()
+    val result = ArrayList<TextSpan>()
+    var cursor = 0
+    while (cursor <= text.length - needle.length) {
+        val found = text.indexOf(needle, cursor, ignoreCase = true)
+        if (found < 0) break
+        result += TextSpan(found, found + needle.length)
+        cursor = found + needle.length.coerceAtLeast(1)
+    }
+    return result
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ReadAlongModels.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ReadAlongModels.kt
@@ -1,0 +1,63 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Json
+
+/** Raw `GET /api/mobile/chapters/{chapter_id}/readalong` response. */
+data class ReadAlongResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    val chapter: ReadAlongChapter = ReadAlongChapter(),
+    val text: String = "",
+    /** Half-open `[start, end]` character offsets into [text]. */
+    val paragraphs: List<List<Double>> = emptyList(),
+    /** `[start, end, media_time_seconds]`, compact because a chapter can contain many thousands. */
+    val cues: List<List<Double>> = emptyList(),
+)
+
+data class ReadAlongChapter(
+    val id: Int = 0,
+    @param:Json(name = "fiction_id") val fictionId: Int = 0,
+    val title: String = "",
+    @param:Json(name = "chapter_number") val chapterNumber: Double? = null,
+    @param:Json(name = "audio_duration") val audioDuration: Double? = null,
+    @param:Json(name = "has_timings") val hasTimings: Boolean = false,
+    @param:Json(name = "timing_version") val timingVersion: Int? = null,
+)
+
+/** Raw document plus the validator needed for a conditional re-open. */
+data class CachedReadAlong(
+    val version: Int = CurrentVersion,
+    val etag: String? = null,
+    val response: ReadAlongResponse = ReadAlongResponse(),
+) {
+    companion object {
+        const val CurrentVersion: Int = 1
+    }
+}
+
+/** Result of one authenticated conditional read-along request. */
+sealed interface ReadAlongFetchResult {
+    data class Modified(val response: ReadAlongResponse, val etag: String?) : ReadAlongFetchResult
+    data object NotModified : ReadAlongFetchResult
+    data object NotFound : ReadAlongFetchResult
+}
+
+/** The account preference envelope returned by both GET and PATCH. */
+data class ReaderPreferencesResponse(
+    val preferences: ReaderPreferencesWire = ReaderPreferencesWire(),
+)
+
+/** Nullable because an older account can have none of the reader keys yet. */
+data class ReaderPreferencesWire(
+    @param:Json(name = "reader_font_size") val fontSize: Double? = null,
+    @param:Json(name = "reader_line_height") val lineHeight: Double? = null,
+    @param:Json(name = "reader_theme") val theme: String? = null,
+    @param:Json(name = "reader_highlight") val highlight: String? = null,
+)
+
+/** Only the four reader keys are ever sent; unrelated account preferences cannot be overwritten. */
+data class ReaderPreferencesPatch(
+    @param:Json(name = "reader_font_size") val fontSize: Double,
+    @param:Json(name = "reader_line_height") val lineHeight: Double,
+    @param:Json(name = "reader_theme") val theme: String,
+    @param:Json(name = "reader_highlight") val highlight: String,
+)

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ReadAlongSentences.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ReadAlongSentences.kt
@@ -1,0 +1,73 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+/** Sentence spans for a stable highlight band; a sentence never crosses a paragraph. */
+fun segmentReadAlongSentences(text: String, paragraphs: List<TextSpan>): List<TextSpan> {
+    if (text.isEmpty()) return emptyList()
+    val result = ArrayList<TextSpan>()
+    paragraphs.forEach { paragraph ->
+        val start = paragraph.start.coerceIn(0, text.length)
+        val end = paragraph.end.coerceIn(0, text.length)
+        if (end > start) segmentParagraph(text, start, end, result)
+    }
+    return result
+}
+
+private fun segmentParagraph(text: String, start: Int, end: Int, output: MutableList<TextSpan>) {
+    var sentenceStart = start
+    var cursor = start
+    while (cursor < end) {
+        if (text[cursor] !in Terminators) {
+            cursor++
+            continue
+        }
+        val breakEnd = sentenceBreakEnd(text, cursor, end)
+        if (breakEnd < 0) {
+            cursor++
+            continue
+        }
+        output.addTrimmed(text, sentenceStart, breakEnd)
+        cursor = breakEnd
+        while (cursor < end && text[cursor].isWhitespace()) cursor++
+        sentenceStart = cursor
+    }
+    output.addTrimmed(text, sentenceStart, end)
+}
+
+private fun sentenceBreakEnd(text: String, at: Int, limit: Int): Int {
+    var end = at + 1
+    while (end < limit && text[end] in Terminators) end++
+    val runLength = end - at
+    while (end < limit && text[end] in Closers) end++
+    if (end >= limit) return end
+    if (!text[end].isWhitespace()) return -1
+    if (runLength == 1 && text[at] == '.' && endsWithAbbreviation(text, at)) return -1
+    var next = end
+    while (next < limit && text[next].isWhitespace()) next++
+    if (next < limit && !startsSentence(text[next])) return -1
+    return end
+}
+
+private fun endsWithAbbreviation(text: String, dot: Int): Boolean {
+    var start = dot
+    while (start > 0 && (text[start - 1].isLetterOrDigit() || text[start - 1] == '.')) start--
+    val token = text.substring(start, dot)
+    return (token.length == 1 && token.firstOrNull()?.isLetter() == true) || token.lowercase() in Abbreviations
+}
+
+private fun startsSentence(char: Char): Boolean = char.isUpperCase() || char.isDigit() || char in Openers
+
+private fun MutableList<TextSpan>.addTrimmed(text: String, from: Int, to: Int) {
+    var start = from
+    var end = to
+    while (start < end && text[start].isWhitespace()) start++
+    while (end > start && text[end - 1].isWhitespace()) end--
+    if (end > start) add(TextSpan(start, end))
+}
+
+private val Terminators = charArrayOf('.', '!', '?', '…')
+private val Closers = charArrayOf('"', '\'', '”', '’', ')', ']', '»')
+private val Openers = charArrayOf('"', '\'', '“', '‘', '(', '[', '«', '—', '–', '-', '*')
+private val Abbreviations = setOf(
+    "mr", "mrs", "ms", "mx", "dr", "prof", "st", "sr", "jr", "vs",
+    "capt", "lt", "sgt", "col", "gen", "rev", "hon", "e.g", "i.e",
+)

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ReaderPreferences.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ReaderPreferences.kt
@@ -1,0 +1,160 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dk.perspektiva.ttsroad.desktop.security.SecureFiles
+import java.io.File
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+enum class ReaderTheme(val wireName: String, val label: String) {
+    Dark("dark", "Dark"),
+    Sepia("sepia", "Sepia"),
+    Light("light", "Light"),
+}
+
+enum class ReaderHighlight(val wireName: String, val label: String) {
+    Sentence("sentence", "Sentence + word"),
+    Word("word", "Word"),
+    Off("off", "Off"),
+}
+
+data class ReaderPreferences(
+    val fontSize: Double = DefaultFontSize,
+    val lineHeight: Double = DefaultLineHeight,
+    val theme: ReaderTheme = ReaderTheme.Dark,
+    val highlight: ReaderHighlight = ReaderHighlight.Sentence,
+) {
+    companion object {
+        const val MinFontSize: Double = 14.0
+        const val MaxFontSize: Double = 30.0
+        const val DefaultFontSize: Double = 19.0
+        const val MinLineHeight: Double = 1.3
+        const val MaxLineHeight: Double = 2.4
+        const val DefaultLineHeight: Double = 1.75
+    }
+}
+
+fun ReaderPreferences.sanitised(): ReaderPreferences = copy(
+    fontSize = fontSize.takeIf(Double::isFinite)
+        ?.coerceIn(ReaderPreferences.MinFontSize, ReaderPreferences.MaxFontSize)
+        ?: ReaderPreferences.DefaultFontSize,
+    lineHeight = lineHeight.takeIf(Double::isFinite)
+        ?.coerceIn(ReaderPreferences.MinLineHeight, ReaderPreferences.MaxLineHeight)
+        ?: ReaderPreferences.DefaultLineHeight,
+)
+
+fun ReaderPreferencesWire.mergeInto(fallback: ReaderPreferences): ReaderPreferences = ReaderPreferences(
+    fontSize = fontSize ?: fallback.fontSize,
+    lineHeight = lineHeight ?: fallback.lineHeight,
+    theme = ReaderTheme.entries.firstOrNull { it.wireName == theme } ?: fallback.theme,
+    highlight = ReaderHighlight.entries.firstOrNull { it.wireName == highlight } ?: fallback.highlight,
+).sanitised()
+
+fun ReaderPreferences.toPatch(): ReaderPreferencesPatch = sanitised().let { value ->
+    ReaderPreferencesPatch(value.fontSize, value.lineHeight, value.theme.wireName, value.highlight.wireName)
+}
+
+interface ReaderPreferencesStore : AutoCloseable {
+    val preferences: StateFlow<ReaderPreferences>
+    fun update(transform: (ReaderPreferences) -> ReaderPreferences)
+    suspend fun refreshFromServer()
+    override fun close() = Unit
+}
+
+class InMemoryReaderPreferencesStore(
+    initial: ReaderPreferences = ReaderPreferences(),
+) : ReaderPreferencesStore {
+    private val state = MutableStateFlow(initial.sanitised())
+    override val preferences: StateFlow<ReaderPreferences> = state.asStateFlow()
+
+    override fun update(transform: (ReaderPreferences) -> ReaderPreferences) {
+        state.value = transform(state.value).sanitised()
+    }
+
+    override suspend fun refreshFromServer() = Unit
+}
+
+/** Local-first reader settings, opportunistically synchronized with the signed-in account. */
+class FileReaderPreferencesStore(
+    private val repository: TtsRoadRepository,
+    private val file: File = defaultFile(),
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : ReaderPreferencesStore {
+    private data class Stored(
+        val version: Int? = null,
+        val fontSize: Double? = null,
+        val lineHeight: Double? = null,
+        val theme: String? = null,
+        val highlight: String? = null,
+    )
+
+    private val adapter = Moshi.Builder().add(KotlinJsonAdapterFactory()).build().adapter(Stored::class.java)
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+    private val state = MutableStateFlow(read())
+    override val preferences: StateFlow<ReaderPreferences> = state.asStateFlow()
+    private var syncJob: Job? = null
+
+    @Synchronized
+    override fun update(transform: (ReaderPreferences) -> ReaderPreferences) {
+        val next = transform(state.value).sanitised()
+        if (next == state.value) return
+        state.value = next
+        write(next)
+        syncJob?.cancel()
+        syncJob = scope.launch {
+            // A small debounce collapses repeated +/- presses into one account PATCH.
+            delay(300)
+            runCatching { repository.updateReaderPreferences(state.value.toPatch()) }
+                .onSuccess { response ->
+                    response?.preferences?.mergeInto(state.value)?.let { accepted ->
+                        state.value = accepted
+                        write(accepted)
+                    }
+                }
+                .onFailure { AppLog.warn("could not sync reader preferences", it) }
+        }
+    }
+
+    override suspend fun refreshFromServer() {
+        runCatching { repository.readerPreferences() }
+            .onSuccess { response ->
+                response?.preferences?.mergeInto(state.value)?.let { loaded ->
+                    state.value = loaded
+                    write(loaded)
+                }
+            }
+            .onFailure { AppLog.warn("could not refresh reader preferences", it) }
+    }
+
+    private fun read(): ReaderPreferences = runCatching {
+        if (!file.isFile) return ReaderPreferences()
+        val stored = adapter.fromJson(file.readText()) ?: return ReaderPreferences()
+        ReaderPreferencesWire(stored.fontSize, stored.lineHeight, stored.theme, stored.highlight)
+            .mergeInto(ReaderPreferences())
+    }.onFailure { AppLog.warn("could not read reader preferences", it) }.getOrDefault(ReaderPreferences())
+
+    private fun write(value: ReaderPreferences) {
+        val stored = Stored(1, value.fontSize, value.lineHeight, value.theme.wireName, value.highlight.wireName)
+        runCatching { SecureFiles.writeAtomically(file, adapter.toJson(stored)) }
+            .onFailure { AppLog.warn("could not write reader preferences", it) }
+    }
+
+    override fun close() {
+        syncJob?.cancel()
+        scope.cancel()
+    }
+
+    companion object {
+        fun defaultFile(): File = FileSessionStore.configDir().resolve("reader.json")
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -117,6 +117,15 @@ interface TtsRoadRepository {
 
     suspend fun chapters(fictionId: Int, playableOnly: Boolean = false): ChaptersResponse
 
+    /** Conditional reader document request; 404 is a normal [ReadAlongFetchResult.NotFound]. */
+    suspend fun readAlong(chapterId: Int, ifNoneMatch: String? = null): ReadAlongFetchResult
+
+    /** Null means this older server has no account-preferences endpoint. */
+    suspend fun readerPreferences(): ReaderPreferencesResponse?
+
+    /** Null means this older server has no account-preferences endpoint. */
+    suspend fun updateReaderPreferences(request: ReaderPreferencesPatch): ReaderPreferencesResponse?
+
     suspend fun markPlayed(chapterIds: List<Int>, played: Boolean): PlaybackMarkResponse
 
     suspend fun saveProgress(
@@ -304,6 +313,26 @@ class RetrofitTtsRoadRepository(
 
     override suspend fun chapters(fictionId: Int, playableOnly: Boolean): ChaptersResponse =
         withAuthorizedApi { it.chapters(fictionId = fictionId, playableOnly = playableOnly) }
+
+    override suspend fun readAlong(chapterId: Int, ifNoneMatch: String?): ReadAlongFetchResult =
+        withAuthorizedApi { api ->
+            val response = api.readAlong(chapterId, ifNoneMatch)
+            when {
+                response.code() == 304 -> ReadAlongFetchResult.NotModified
+                response.code() == 404 -> ReadAlongFetchResult.NotFound
+                response.isSuccessful -> {
+                    val body = response.body() ?: error("The server returned an empty read-along document")
+                    ReadAlongFetchResult.Modified(body, response.headers()["ETag"])
+                }
+                else -> throw HttpException(response)
+            }
+        }
+
+    override suspend fun readerPreferences(): ReaderPreferencesResponse? =
+        ifEndpointExists { it.readerPreferences() }
+
+    override suspend fun updateReaderPreferences(request: ReaderPreferencesPatch): ReaderPreferencesResponse? =
+        ifEndpointExists { it.updateReaderPreferences(request) }
 
     override suspend fun markPlayed(chapterIds: List<Int>, played: Boolean): PlaybackMarkResponse =
         withAuthorizedApi { it.markPlayback(PlaybackMarkRequest(chapterIds, played)) }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -3,7 +3,9 @@ package dk.perspektiva.ttsroad.desktop.data
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.Headers
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -67,6 +69,19 @@ interface TtsRoadApi {
         @Query("playable_only") playableOnly: Boolean = false,
         @Query("include_excluded") includeExcluded: Boolean = false,
     ): ChaptersResponse
+
+    /** Raw response exposes both the ETag and the normal 304 revalidation path. */
+    @GET("api/mobile/chapters/{chapter_id}/readalong")
+    suspend fun readAlong(
+        @Path("chapter_id") chapterId: Int,
+        @Header("If-None-Match") ifNoneMatch: String? = null,
+    ): retrofit2.Response<ReadAlongResponse>
+
+    @GET("api/me/preferences")
+    suspend fun readerPreferences(): ReaderPreferencesResponse
+
+    @PATCH("api/me/preferences")
+    suspend fun updateReaderPreferences(@Body request: ReaderPreferencesPatch): ReaderPreferencesResponse
 
     @POST("api/mobile/playback/progress")
     suspend fun saveProgress(@Body request: PlaybackProgressRequest): PlaybackProgressResponse

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/di/AppContainer.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/di/AppContainer.kt
@@ -5,9 +5,12 @@ import dk.perspektiva.ttsroad.desktop.data.FilePlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.FileSessionStore
 import dk.perspektiva.ttsroad.desktop.data.FileWindowPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.LibraryCache
+import dk.perspektiva.ttsroad.desktop.data.FileReaderPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.PlaybackHistory
 import dk.perspektiva.ttsroad.desktop.data.PlaybackHistoryStore
 import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.ReadAlongCache
+import dk.perspektiva.ttsroad.desktop.data.ReaderPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.RetrofitTtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.download.DownloadCoordinator
 import dk.perspektiva.ttsroad.desktop.download.OfflineFirstMediaSourceFactory
@@ -98,6 +101,8 @@ class AppContainer(
         },
     libraryCacheFactory: (TtsRoadRepository, AppDispatchers, () -> Long) -> LibraryCache =
         { repo, d, now -> LibraryCache(repo, d.main, now) },
+    readerPreferencesFactory: (TtsRoadRepository, AppDispatchers) -> ReaderPreferencesStore =
+        { repo, d -> FileReaderPreferencesStore(repo, dispatcher = d.io) },
     /**
      * A factory rather than a value so a test can point downloads at a temp directory — the real
      * one writes into the user's data directory the moment somebody signs in.
@@ -190,6 +195,13 @@ class AppContainer(
     val libraryCache: LibraryCache = libraryCacheFactory(repository, dispatchers, clock)
         .attachDiskCache(downloads::libraryCacheOrNull)
 
+    /** Reader documents share the download identity but have their own bounded cache. */
+    val readAlongCache: ReadAlongCache = ReadAlongCache(repository)
+        .attachDiskCache(downloads::readAlongCacheOrNull)
+
+    /** Local fallback first, account GET/PATCH synchronization whenever the server supports it. */
+    val readerPreferences: ReaderPreferencesStore = readerPreferencesFactory(repository, dispatchers)
+
     /** Remembered window size/position/maximised state. Never holds anything transient or secret. */
     val windowPreferences: WindowPreferencesStore = windowPreferencesStore
 
@@ -203,6 +215,8 @@ class AppContainer(
         runCatching { downloads.close() }
         playback.release()
         libraryCache.close()
+        readAlongCache.clear()
+        readerPreferences.close()
         httpClient.dispatcher.executorService.shutdown()
         httpClient.connectionPool.evictAll()
         runCatching { httpClient.cache?.close() }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/download/ChapterDownloader.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/download/ChapterDownloader.kt
@@ -78,14 +78,25 @@ class ChapterDownloader(
             alreadyHave = 0L
         }
 
+        val completePart = expectedBytes > 0L && alreadyHave == expectedBytes
         val remaining = if (expectedBytes > 0) expectedBytes - alreadyHave else 0L
-        if (!storage.hasRoomFor(remaining)) {
+        if (!completePart && !storage.hasRoomFor(remaining)) {
             return DownloadResult.Failed(
                 DownloadFailure.OutOfSpace("Not enough free disk space for this chapter"),
             )
         }
 
-        return runCatching { transfer(audioUrl, part, target, alreadyHave, expectedBytes, onProgress) }
+        return runCatching {
+            if (completePart) {
+                // A previous process may have finished writing and crashed before the atomic move.
+                // Reissuing Range: bytes=<length>- would receive 416 forever; validate and promote
+                // the complete bytes locally instead.
+                RandomAccessFile(part, "rw").use { it.fd.sync() }
+                promote(part, target, alreadyHave)
+            } else {
+                transfer(audioUrl, part, target, alreadyHave, expectedBytes, onProgress)
+            }
+        }
             .getOrElse { error ->
                 when (error) {
                     is SessionExpiredDownloadException ->
@@ -190,25 +201,34 @@ class ChapterDownloader(
             if (total > 0 && written != total) {
                 throw IOException("The download ended early (${written} of $total bytes)")
             }
-            if (!validator.looksDecodable(part)) {
-                // The bytes are wrong rather than incomplete, so a resume would resume garbage.
-                runCatching { part.delete() }
-                return DownloadResult.Failed(
-                    DownloadFailure.Corrupt("The downloaded audio could not be read"),
-                )
-            }
-
-            // Atomic: a reader sees the old file or the new one, never a partial one. This is the
-            // single moment a chapter becomes playable offline.
-            runCatching {
-                Files.move(part.toPath(), target.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
-            }.recoverCatching {
-                Files.move(part.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
-            }.getOrElse { throw IOException("Could not finish the download", it) }
-
-            SecureFiles.restrictToOwner(target.toPath())
-            return DownloadResult.Success(written)
+            return promote(part, target, written)
         }
+    }
+
+    private fun promote(part: File, target: File, written: Long): DownloadResult {
+        if (!validator.looksDecodable(part)) {
+            // The bytes are wrong rather than incomplete, so a retry must start from zero.
+            runCatching { part.delete() }
+            return DownloadResult.Failed(
+                DownloadFailure.Corrupt("The downloaded audio could not be read"),
+            )
+        }
+
+        // Atomic: a reader sees the old file or the new one, never a partial one. This is the
+        // single moment a chapter becomes playable offline.
+        runCatching {
+            Files.move(
+                part.toPath(),
+                target.toPath(),
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING,
+            )
+        }.recoverCatching {
+            Files.move(part.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        }.getOrElse { throw IOException("Could not finish the download", it) }
+
+        SecureFiles.restrictToOwner(target.toPath())
+        return DownloadResult.Success(written)
     }
 
     private companion object {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/download/DownloadCoordinator.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/download/DownloadCoordinator.kt
@@ -3,6 +3,7 @@ package dk.perspektiva.ttsroad.desktop.download
 import dk.perspektiva.ttsroad.desktop.data.AppDirectories
 import dk.perspektiva.ttsroad.desktop.data.AppLog
 import dk.perspektiva.ttsroad.desktop.data.LibraryDiskCache
+import dk.perspektiva.ttsroad.desktop.data.ReadAlongDiskCache
 import dk.perspektiva.ttsroad.desktop.data.SessionState
 import dk.perspektiva.ttsroad.desktop.data.SessionStore
 import dk.perspektiva.ttsroad.desktop.data.StorageIdentity
@@ -57,6 +58,7 @@ class DownloadSession(
     val storage: DownloadStorage,
     val streamingCache: StreamingCache,
     val libraryCache: LibraryDiskCache,
+    val readAlongCache: ReadAlongDiskCache,
     val index: DownloadIndexStore,
     val manager: DownloadManager,
 ) : AutoCloseable {
@@ -129,6 +131,9 @@ class DownloadCoordinator(
 
     /** Rebuildable library/chapter metadata for the signed-in account only. */
     fun libraryCacheOrNull(): LibraryDiskCache? = refresh()?.libraryCache
+
+    /** Rebuildable, account-scoped narration text and cue documents. */
+    fun readAlongCacheOrNull(): ReadAlongDiskCache? = refresh()?.readAlongCache
 
     /**
      * Measures the current account only. A signed-out username/server hint is deliberately not
@@ -220,6 +225,7 @@ class DownloadCoordinator(
             .forEach { manager.remove(it.chapterId) }
         val streamingCache = StreamingCache.forIdentity(identity, cacheDir)
         val libraryCache = LibraryDiskCache.forIdentity(identity, cacheDir)
+        val readAlongCache = ReadAlongDiskCache.forIdentity(identity, cacheDir)
         // Interrupted rows are already Queued after index recovery. Cached chapter metadata gives
         // them their live URL again without waiting for the user to open every fiction manually.
         val pendingFictions = DownloadIndex.pending(index.entries.value).map { it.fictionId }.toSet()
@@ -229,7 +235,7 @@ class DownloadCoordinator(
                 .associateBy { it.resolvedChapterId },
             fictionTitles = cachedChapters.associate { it.value.fiction.id to it.value.fiction.title },
         )
-        return DownloadSession(identity, storage, streamingCache, libraryCache, index, manager)
+        return DownloadSession(identity, storage, streamingCache, libraryCache, readAlongCache, index, manager)
     }
 
     private fun closeCurrent() {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/download/DownloadManager.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/download/DownloadManager.kt
@@ -171,8 +171,35 @@ class DownloadManager(
         active.forEach { it.cancel() }
         active.joinAll()
         jobs.clear()
+        val before = index.entries.value
         val freed = runCatching { storage.deleteAll() }.getOrDefault(0L)
-        index.clear()
+        val remaining = storage.audioFileBytes()
+        if (remaining.isEmpty()) {
+            index.clear()
+        } else {
+            // A locked or permission-denied file is still a user-requested download. Preserve its
+            // title and state instead of clearing the row and orphaning opaque bytes on disk.
+            for (entry in before) {
+                val completedBytes = remaining[entry.fileName]
+                val partialBytes = remaining[entry.fileName + DownloadStorage.PartSuffix]
+                if (completedBytes == null && partialBytes == null) {
+                    index.remove(entry.chapterId)
+                } else {
+                    index.put(
+                        entry.copy(
+                            state = if (completedBytes != null) DownloadState.Downloaded else DownloadState.Failed,
+                            bytesDownloaded = completedBytes ?: partialBytes ?: 0L,
+                            failureMessage = if (completedBytes != null) {
+                                entry.failureMessage
+                            } else {
+                                "Could not remove the local file"
+                            },
+                            updatedAtMs = clock(),
+                        ),
+                    )
+                }
+            }
+        }
         return freed
     }
 
@@ -225,7 +252,8 @@ class DownloadManager(
                 // slow-transfer UI responsive. Success below always persists the exact final size.
                 val nowNanos = progressClockNanos()
                 val movedBackwards = soFar < lastPublishedBytes
-                val byteThresholdReached = soFar - lastPublishedBytes >= progressBytesThreshold
+                val byteThresholdReached = !movedBackwards &&
+                    soFar - lastPublishedBytes >= progressBytesThreshold
                 val timeThresholdReached = nowNanos - lastPublishedAtNanos >= progressIntervalNanos
                 if (!movedBackwards && !byteThresholdReached && !timeThresholdReached) return@download
                 val latest = DownloadIndex.find(index.entries.value, id) ?: return@download

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/download/DownloadStorage.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/download/DownloadStorage.kt
@@ -8,6 +8,7 @@ import java.io.File
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.LinkOption
+import java.nio.file.Path
 
 /**
  * The directory one account's downloads live in, and the only thing allowed to turn a name into a
@@ -25,6 +26,7 @@ import java.nio.file.LinkOption
 class DownloadStorage(
     val root: File,
     private val ownedDirectories: List<File> = listOf(root),
+    private val deletePath: (Path) -> Boolean = { Files.deleteIfExists(it) },
 ) {
 
     /** `downloads.json` for this account, kept beside the audio it describes. */
@@ -92,7 +94,7 @@ class DownloadStorage(
         for (candidate in listOf(name, "$name$PartSuffix")) {
             runCatching {
                 val path = resolve(candidate).toPath()
-                Files.deleteIfExists(path)
+                deletePath(path)
             }.onFailure {
                 deleted = false
                 AppLog.warn("could not delete $candidate", it)
@@ -122,7 +124,7 @@ class DownloadStorage(
             val path = file.toPath()
             if (Files.isSymbolicLink(path)) {
                 // Delete the link, never what it points at.
-                runCatching { Files.delete(path) }
+                runCatching { deletePath(path) }
                 continue
             }
             if (file.isDirectory) {
@@ -131,7 +133,7 @@ class DownloadStorage(
                 continue
             }
             val size = file.length()
-            if (runCatching { Files.deleteIfExists(path) }.getOrDefault(false)) freed += size
+            if (runCatching { deletePath(path) }.getOrDefault(false)) freed += size
         }
         runCatching { Files.deleteIfExists(root.toPath()) }
         return freed

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/download/StreamingCache.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/download/StreamingCache.kt
@@ -57,7 +57,7 @@ class StreamingCache(
     fun retaining(chapterId: Int, upstream: MediaSource): MediaSource = object : MediaSource {
         override fun open(): MediaStream {
             val network = upstream.open()
-            val part = runCatching { begin(chapterId) }
+            val part = runCatching { begin(chapterId, network.length) }
                 .onFailure { AppLog.warn("could not start the streaming cache", it) }
                 .getOrNull()
             return if (part == null) network else RetainingStream(network, part, chapterId)
@@ -92,7 +92,12 @@ class StreamingCache(
         return freed
     }
 
-    private fun begin(chapterId: Int): File {
+    @Synchronized
+    private fun begin(chapterId: Int, expectedBytes: Long): File? {
+        if (maxBytes >= 0L && (maxBytes == 0L || expectedBytes > maxBytes)) {
+            prune()
+            return null
+        }
         check(ownedDirectories.none { Files.isSymbolicLink(it.toPath()) }) {
             "cache directory is a symlink"
         }
@@ -103,6 +108,13 @@ class StreamingCache(
         val part = resolve(chapterFileName(chapterId) + DownloadStorage.PartSuffix)
         RandomAccessFile(part, "rw").use { it.setLength(0L) }
         SecureFiles.restrictToOwner(part.toPath())
+        if (maxBytes >= 0L && expectedBytes >= 0L) {
+            // Reserve the known chapter size by evicting completed LRU entries before any bytes
+            // arrive. The per-chunk check below remains authoritative under concurrent streams.
+            pruneTo((maxBytes - expectedBytes).coerceAtLeast(0L))
+        } else {
+            prune()
+        }
         return part
     }
 
@@ -123,9 +135,11 @@ class StreamingCache(
             if (read > 0) {
                 val sink = output
                 if (sink != null) {
-                    runCatching { sink.write(buffer, offset, read) }
-                        .onSuccess { written += read }
-                        .onFailure { abandon("could not retain streamed audio", it) }
+                    runCatching { retainChunk(sink, buffer, offset, read) }
+                        .fold(
+                            onSuccess = { retained -> if (retained) written += read else abandon() },
+                            onFailure = { abandon("could not retain streamed audio", it) },
+                        )
                 }
             } else if (read < 0) {
                 finish()
@@ -182,25 +196,51 @@ class StreamingCache(
         }
     }
 
+    /** Writes one chunk only while all completed and in-progress cache bytes remain within the cap. */
+    @Synchronized
+    private fun retainChunk(
+        sink: RandomAccessFile,
+        buffer: ByteArray,
+        offset: Int,
+        count: Int,
+    ): Boolean {
+        if (maxBytes >= 0L) {
+            val incoming = count.toLong()
+            if (incoming > maxBytes) return false
+            // Prefer evicting reusable LRU entries over abandoning the chapter currently playing.
+            pruneTo(maxBytes - incoming)
+            val retained = retainedFiles().sumOf(File::length)
+            if (retained > maxBytes - incoming) return false
+        }
+        sink.write(buffer, offset, count)
+        return true
+    }
+
     @Synchronized
     private fun prune() {
         if (maxBytes < 0L) return
+        pruneTo(maxBytes)
+    }
+
+    private fun pruneTo(targetBytes: Long) {
         val oldestFirst = completedFiles().sortedBy(File::lastModified).toMutableList()
-        var bytes = oldestFirst.sumOf(File::length)
-        while (bytes > maxBytes && oldestFirst.isNotEmpty()) {
+        var bytes = retainedFiles().sumOf(File::length)
+        while (bytes > targetBytes && oldestFirst.isNotEmpty()) {
             val victim = oldestFirst.removeFirst()
             val size = victim.length()
             if (runCatching { Files.deleteIfExists(victim.toPath()) }.getOrDefault(false)) bytes -= size
         }
     }
 
-    private fun completedFiles(): List<File> =
+    private fun retainedFiles(): List<File> =
         if (ownedDirectories.any { Files.isSymbolicLink(it.toPath()) }) emptyList() else root.listFiles().orEmpty().filter { file ->
             file.isFile &&
                 !Files.isSymbolicLink(file.toPath()) &&
-                file.name.endsWith(".mp3") &&
-                FileDownloadIndexStore.isSafeName(file.name)
+                FileDownloadIndexStore.isSafeName(file.name) &&
+                (file.name.endsWith(".mp3") || file.name.endsWith(".mp3${DownloadStorage.PartSuffix}"))
         }
+
+    private fun completedFiles(): List<File> = retainedFiles().filter { it.name.endsWith(".mp3") }
 
     private fun resolve(name: String): File {
         require(FileDownloadIndexStore.isSafeName(name)) { "unsafe cache file name: $name" }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/nav/AppNavigation.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/nav/AppNavigation.kt
@@ -29,9 +29,8 @@ sealed interface Destination {
      * Carries a chapter id and a display title rather than a `ChapterSummary` because it is also
      * reachable from the player, where only the currently loaded media is known.
      *
-     * There is no read-along UI in this build — the destination exists so the back stack, its keys
-     * and its retention rules are settled before the reader phase lands, and so a Reader entry can
-     * never be confused with the Fiction entry of the same numeric id.
+     * A Reader entry is deliberately distinct from the Fiction entry with the same numeric id, so
+     * its find query, follow state, and lazy-list position have their own retained lifetime.
      */
     data class Reader(val chapterId: Int, val title: String) : Destination
 

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterDownloadsBinding.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterDownloadsBinding.kt
@@ -35,6 +35,13 @@ fun chapterDownloadUi(entry: DownloadEntry?, available: Boolean): ChapterDownloa
     }
 }
 
+/** A queue cannot download a chapter whose metadata has no audio source yet. */
+fun chapterDownloadUi(
+    chapter: ChapterSummary,
+    entry: DownloadEntry?,
+    storageAvailable: Boolean,
+): ChapterDownloadUi = chapterDownloadUi(entry, storageAvailable && chapter.hasAudio)
+
 /**
  * Which chapters "Download next N" should queue.
  *
@@ -95,7 +102,9 @@ fun rememberChapterDownloads(
 
     return ChapterDownloadsUi(
         available = manager != null,
-        stateFor = { chapter -> chapterDownloadUi(byChapter[chapter.resolvedChapterId], manager != null) },
+        stateFor = { chapter ->
+            chapterDownloadUi(chapter, byChapter[chapter.resolvedChapterId], manager != null)
+        },
         onDownload = { chapter -> manager?.download(chapter, title) },
         onCancel = { chapter -> manager?.cancel(chapter.resolvedChapterId) },
         onDelete = { chapter -> manager?.remove(chapter.resolvedChapterId) },

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionDetailScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionDetailScreen.kt
@@ -321,7 +321,11 @@ fun FictionDetailScreen(
                         isCurrent = index == currentRow,
                         isPlaying = player.isPlaying,
                         canMarkPrevious = (canonicalIndex[chapter.resolvedChapterId] ?: 0) > 0,
-                        readAlongAvailable = capabilities.readAlong && chapter.hasTimings,
+                        // The capability gates the endpoint. `has_timings` only changes whether
+                        // the reader follows audio: chapters converted earlier still have useful
+                        // plain narration text and must remain openable.
+                        readAlongAvailable = capabilities.readAlong,
+                        readAlongTimed = chapter.hasTimings,
                         download = downloads.stateFor(chapter),
                         onPlay = { play(chapter) },
                         onMarkPlayed = { played -> mark(listOf(chapter.resolvedChapterId), played) },
@@ -583,6 +587,7 @@ private fun ChapterListRow(
     isPlaying: Boolean,
     canMarkPrevious: Boolean,
     readAlongAvailable: Boolean,
+    readAlongTimed: Boolean,
     download: ChapterDownloadUi,
     onPlay: () -> Unit,
     onMarkPlayed: (Boolean) -> Unit,
@@ -668,7 +673,7 @@ private fun ChapterListRow(
         if (readAlongAvailable) {
             RowIconAction(
                 icon = Icons.AutoMirrored.Filled.MenuBook,
-                contentDescription = "Read along",
+                contentDescription = if (readAlongTimed) "Read along" else "Read chapter text",
                 tint = if (active) AarisColor.Ink else AarisColor.Dim,
                 onClick = onOpenReader,
             )

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.FastForward
 import androidx.compose.material.icons.filled.FastRewind
 import androidx.compose.material.icons.filled.Forward10
@@ -42,6 +43,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
@@ -88,6 +90,8 @@ fun PlayerScreen(
      * to the real config directory.
      */
     preferences: PlaybackPreferencesStore = remember { InMemoryPlaybackPreferencesStore() },
+    readAlongAvailable: Boolean = false,
+    onOpenReader: (chapterId: Int, title: String) -> Unit = { _, _ -> },
     onBack: () -> Unit,
 ) {
     val s: PlayerUiState by playback.state.collectAsState()
@@ -104,7 +108,15 @@ fun PlayerScreen(
                 Modifier.fillMaxSize().padding(top = 28.dp).verticalScroll(rememberScrollState()),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                PlayerMain(s, playback, preferences, compact = true, modifier = Modifier.fillMaxWidth())
+                PlayerMain(
+                    s,
+                    playback,
+                    preferences,
+                    compact = true,
+                    readAlongAvailable = readAlongAvailable,
+                    onOpenReader = onOpenReader,
+                    modifier = Modifier.fillMaxWidth(),
+                )
                 if (hasQueue) {
                     Spacer(Modifier.height(20.dp))
                     QueuePanel(s, playback, Modifier.fillMaxWidth().height(260.dp))
@@ -118,6 +130,8 @@ fun PlayerScreen(
                         playback,
                         preferences,
                         compact = false,
+                        readAlongAvailable = readAlongAvailable,
+                        onOpenReader = onOpenReader,
                         modifier = Modifier.align(Alignment.TopCenter).widthIn(max = NarrowMaxWidth)
                             .fillMaxWidth().fillMaxHeight(),
                     )
@@ -138,6 +152,8 @@ private fun PlayerMain(
     playback: PlaybackController,
     preferences: PlaybackPreferencesStore,
     compact: Boolean,
+    readAlongAvailable: Boolean,
+    onOpenReader: (chapterId: Int, title: String) -> Unit,
     modifier: Modifier,
 ) {
     val prefs by preferences.preferences.collectAsState()
@@ -170,6 +186,19 @@ private fun PlayerMain(
         s.fictionTitle?.let {
             Spacer(Modifier.height(8.dp))
             MetaText(it)
+        }
+        val chapterId = s.queue.getOrNull(s.currentIndex)?.chapterId ?: 0
+        if (readAlongAvailable && chapterId > 0) {
+            Spacer(Modifier.height(12.dp))
+            OutlinedButton(
+                onClick = { onOpenReader(chapterId, s.title) },
+                shape = androidx.compose.ui.graphics.RectangleShape,
+                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+            ) {
+                Icon(Icons.AutoMirrored.Filled.MenuBook, contentDescription = null, Modifier.size(18.dp))
+                Spacer(Modifier.width(8.dp))
+                Text("READ ALONG")
+            }
         }
         Spacer(Modifier.height(20.dp))
         Slider(

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderScreen.kt
@@ -1,0 +1,694 @@
+@file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.foundation.VerticalScrollbar
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.interaction.DragInteraction
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.rememberScrollbarAdapter
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dk.perspektiva.ttsroad.desktop.data.ReadAlongCache
+import dk.perspektiva.ttsroad.desktop.data.ReadAlongDocument
+import dk.perspektiva.ttsroad.desktop.data.ReadAlongHighlight
+import dk.perspektiva.ttsroad.desktop.data.ReadAlongTimingState
+import dk.perspektiva.ttsroad.desktop.data.ReaderHighlight
+import dk.perspektiva.ttsroad.desktop.data.ReaderPreferences
+import dk.perspektiva.ttsroad.desktop.data.ReaderPreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.ReaderTheme
+import dk.perspektiva.ttsroad.desktop.data.TextSpan
+import dk.perspektiva.ttsroad.desktop.data.readAlongMatches
+import dk.perspektiva.ttsroad.desktop.data.readAlongTimingsMatch
+import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
+import dk.perspektiva.ttsroad.desktop.player.PlaybackController
+import dk.perspektiva.ttsroad.desktop.player.PlayerUiState
+import kotlin.math.roundToInt
+import kotlin.math.roundToLong
+import kotlinx.coroutines.launch
+
+const val ReaderListTestTag: String = "readerList"
+const val ReaderFindFieldTestTag: String = "readerFindField"
+const val ReaderSettingsButtonTestTag: String = "readerSettingsButton"
+const val ReaderParagraphTestTag: String = "readerParagraph"
+
+data class ReaderPalette(
+    val background: Color,
+    val ink: Color,
+    val muted: Color,
+    val line: Color,
+    val accent: Color,
+    val sentenceBand: Color,
+    val findBand: Color,
+)
+
+fun readerPalette(theme: ReaderTheme): ReaderPalette = when (theme) {
+    ReaderTheme.Dark -> ReaderPalette(
+        AarisColor.Bg, AarisColor.Ink, AarisColor.Muted, AarisColor.Line,
+        AarisColor.Accent, AarisColor.BgHover, Color(0x665B7CFF),
+    )
+    ReaderTheme.Sepia -> ReaderPalette(
+        Color(0xFFF2E7CF), Color(0xFF382F26), Color(0xFF776752), Color(0xFFCDBB99),
+        Color(0xFF9A431C), Color(0x33A86D32), Color(0x55638BA8),
+    )
+    ReaderTheme.Light -> ReaderPalette(
+        Color(0xFFF8F9FA), Color(0xFF16181C), Color(0xFF606873), Color(0xFFD4D9DF),
+        Color(0xFFC43D0E), Color(0x22FF5A1F), Color(0x445B7CFF),
+    )
+}
+
+enum class ReaderFollowEvent { ManualScroll, BackToCurrent, ChapterChanged, PassiveUpdate }
+
+/** Pure follow-state reducer: passive playback updates can never steal control back. */
+fun readerFollowAfter(current: Boolean, event: ReaderFollowEvent): Boolean = when (event) {
+    ReaderFollowEvent.ManualScroll -> false
+    ReaderFollowEvent.BackToCurrent, ReaderFollowEvent.ChapterChanged -> true
+    ReaderFollowEvent.PassiveUpdate -> current
+}
+
+fun readerAutoScrollOffsetPx(viewportHeightPx: Int): Int =
+    if (viewportHeightPx <= 0) 0 else -(viewportHeightPx / 3)
+
+fun readerShouldPrefetch(positionMs: Long, durationMs: Long): Boolean =
+    durationMs > 0L && positionMs.coerceAtLeast(0L).toDouble() / durationMs >= 0.8
+
+/** Audio-linked reader that remains useful as a plain, selectable document with no playback. */
+@Composable
+fun ReaderScreen(
+    chapterId: Int,
+    fallbackTitle: String,
+    cache: ReadAlongCache,
+    preferences: ReaderPreferencesStore,
+    playback: PlaybackController,
+    onBack: () -> Unit,
+    onChapterAdvanced: (chapterId: Int, title: String) -> Unit,
+) {
+    val player by playback.state.collectAsState()
+    val prefs by preferences.preferences.collectAsState()
+    val palette = remember(prefs.theme) { readerPalette(prefs.theme) }
+    val scope = rememberCoroutineScope()
+
+    var document by remember(chapterId) { mutableStateOf<ReadAlongDocument?>(null) }
+    var loading by remember(chapterId) { mutableStateOf(true) }
+    var error by remember(chapterId) { mutableStateOf<String?>(null) }
+    var reload by remember(chapterId) { mutableIntStateOf(0) }
+
+    LaunchedEffect(chapterId, reload) {
+        loading = true
+        error = null
+        runCatching { cache.load(chapterId) }
+            .onSuccess { document = it }
+            .onFailure { error = userFacingMessage(it, "Could not load chapter text") }
+        loading = false
+    }
+
+    val currentItem = player.queue.getOrNull(player.currentIndex)
+    val currentChapterId = currentItem?.chapterId ?: 0
+    val isPlayingThisChapter = currentChapterId == chapterId
+
+    // Opening a non-playing chapter must never jump to whatever happens to be playing. Once this
+    // reader has followed its own playing chapter, however, queue auto-advance carries it forward.
+    var followsQueue by remember(chapterId) { mutableStateOf(isPlayingThisChapter) }
+    LaunchedEffect(currentChapterId, chapterId) {
+        when {
+            currentChapterId == chapterId -> followsQueue = true
+            followsQueue && currentChapterId > 0 -> {
+                followsQueue = false
+                onChapterAdvanced(currentChapterId, currentItem?.title ?: "Chapter")
+            }
+        }
+    }
+
+    var prefetchedChapter by remember(chapterId) { mutableIntStateOf(0) }
+    LaunchedEffect(chapterId, player.positionMs, player.durationMs, currentChapterId) {
+        if (!isPlayingThisChapter || !readerShouldPrefetch(player.positionMs, player.durationMs)) {
+            return@LaunchedEffect
+        }
+        val next = player.queue.getOrNull(player.currentIndex + 1)?.chapterId ?: return@LaunchedEffect
+        if (next <= 0 || next == prefetchedChapter) return@LaunchedEffect
+        prefetchedChapter = next
+        cache.prefetch(next)
+    }
+
+    var showSettings by rememberSaveable { mutableStateOf(false) }
+
+    Box(Modifier.fillMaxSize().background(palette.background)) {
+        when {
+            loading && document == null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(color = palette.accent)
+            }
+
+            document == null && error != null -> ReaderFailure(error.orEmpty()) { reload++ }
+
+            document == null -> ReaderEmptyState(fallbackTitle, palette)
+
+            else -> ReaderDocumentPage(
+                document = requireNotNull(document),
+                player = player,
+                isPlayingThisChapter = isPlayingThisChapter,
+                playback = playback,
+                prefs = prefs,
+                palette = palette,
+                onBack = onBack,
+                onOpenSettings = { showSettings = true },
+            )
+        }
+    }
+
+    if (showSettings) {
+        ReaderSettingsDialog(
+            prefs = prefs,
+            onDismiss = { showSettings = false },
+            onChange = { transform -> preferences.update(transform) },
+        )
+    }
+}
+
+@Composable
+private fun ReaderDocumentPage(
+    document: ReadAlongDocument,
+    player: PlayerUiState,
+    isPlayingThisChapter: Boolean,
+    playback: PlaybackController,
+    prefs: ReaderPreferences,
+    palette: ReaderPalette,
+    onBack: () -> Unit,
+    onOpenSettings: () -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    val listState = androidx.compose.foundation.lazy.rememberLazyListState()
+    var followPlayback by rememberSaveable(document.chapterId) { mutableStateOf(true) }
+    val timingsMatch = !isPlayingThisChapter || readAlongTimingsMatch(
+        document.audioDurationSeconds,
+        player.durationMs,
+    )
+    val highlight = remember(document, player.positionMs, isPlayingThisChapter, timingsMatch) {
+        if (isPlayingThisChapter && timingsMatch) document.highlightAtMillis(player.positionMs)
+        else ReadAlongHighlight.None
+    }
+    val activeParagraph = highlight.word?.let { document.paragraphIndexAt(it.start) } ?: -1
+
+    LaunchedEffect(listState) {
+        listState.interactionSource.interactions.collect { interaction ->
+            if (interaction is DragInteraction.Start) {
+                followPlayback = readerFollowAfter(followPlayback, ReaderFollowEvent.ManualScroll)
+            }
+        }
+    }
+
+    suspend fun scrollToActive() {
+        if (activeParagraph < 0) return
+        val viewport = listState.layoutInfo.viewportEndOffset - listState.layoutInfo.viewportStartOffset
+        listState.animateScrollToItem(activeParagraph + 1, readerAutoScrollOffsetPx(viewport))
+    }
+
+    LaunchedEffect(activeParagraph, followPlayback) {
+        if (followPlayback) scrollToActive()
+    }
+
+    var findOpen by rememberSaveable(document.chapterId) { mutableStateOf(false) }
+    var query by rememberSaveable(document.chapterId) { mutableStateOf("") }
+    val matches = remember(document.text, query) { readAlongMatches(document.text, query) }
+    var activeMatch by remember(document.chapterId, query) { mutableIntStateOf(0) }
+    val shownMatch = activeMatch.coerceIn(0, matches.lastIndex.coerceAtLeast(0))
+    val activeMatchSpan = matches.getOrNull(shownMatch)
+
+    LaunchedEffect(activeMatchSpan) {
+        val match = activeMatchSpan ?: return@LaunchedEffect
+        val paragraph = document.paragraphIndexAt(match.start)
+        if (paragraph >= 0) {
+            followPlayback = readerFollowAfter(followPlayback, ReaderFollowEvent.ManualScroll)
+            listState.animateScrollToItem(paragraph + 1)
+        }
+    }
+
+    fun seekToOffset(offset: Int) {
+        if (!isPlayingThisChapter || !timingsMatch) return
+        val seconds = document.seekSecondsForOffset(offset) ?: return
+        playback.seekTo((seconds * 1000.0).roundToLong())
+        followPlayback = readerFollowAfter(followPlayback, ReaderFollowEvent.BackToCurrent)
+    }
+
+    fun handleKey(key: Key): Boolean = when (key) {
+        Key.PageUp -> {
+            scope.launch { listState.scrollBy(-listState.layoutInfo.viewportSize.height.toFloat()) }
+            followPlayback = readerFollowAfter(followPlayback, ReaderFollowEvent.ManualScroll)
+            true
+        }
+        Key.PageDown -> {
+            scope.launch { listState.scrollBy(listState.layoutInfo.viewportSize.height.toFloat()) }
+            followPlayback = readerFollowAfter(followPlayback, ReaderFollowEvent.ManualScroll)
+            true
+        }
+        Key.MoveHome -> {
+            scope.launch { listState.scrollToItem(0) }
+            followPlayback = readerFollowAfter(followPlayback, ReaderFollowEvent.ManualScroll)
+            true
+        }
+        Key.MoveEnd -> {
+            scope.launch { listState.scrollToItem(document.paragraphs.size) }
+            followPlayback = readerFollowAfter(followPlayback, ReaderFollowEvent.ManualScroll)
+            true
+        }
+        else -> false
+    }
+
+    val focusRequester = remember { FocusRequester() }
+    Box(
+        Modifier
+            .fillMaxSize()
+            .focusRequester(focusRequester)
+            .focusable()
+            .onPreviewKeyEvent { event ->
+                if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                if (event.isCtrlPressed && event.key == Key.F) {
+                    findOpen = true
+                    true
+                } else {
+                    handleKey(event.key)
+                }
+            },
+    ) {
+        Column(Modifier.align(Alignment.TopCenter).fillMaxSize().widthIn(max = 920.dp)) {
+            ReaderToolbar(
+                title = document.title.ifBlank { "Chapter" },
+                palette = palette,
+                onBack = onBack,
+                onFind = { findOpen = !findOpen },
+                onSettings = onOpenSettings,
+            )
+            if (findOpen) {
+                ReaderFindBar(
+                    query = query,
+                    onQuery = { query = it; activeMatch = 0 },
+                    result = if (matches.isEmpty()) "No matches" else "${shownMatch + 1} of ${matches.size}",
+                    onPrevious = {
+                        if (matches.isNotEmpty()) activeMatch = (shownMatch - 1 + matches.size) % matches.size
+                    },
+                    onNext = {
+                        if (matches.isNotEmpty()) activeMatch = (shownMatch + 1) % matches.size
+                    },
+                    onClose = { findOpen = false; query = "" },
+                    palette = palette,
+                )
+            }
+            Box(Modifier.weight(1f).fillMaxWidth()) {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(end = 14.dp)
+                        .testTag(ReaderListTestTag)
+                        .onPointerEvent(PointerEventType.Scroll) {
+                            followPlayback = readerFollowAfter(followPlayback, ReaderFollowEvent.ManualScroll)
+                        },
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                        start = PageGutter,
+                        end = PageGutter,
+                        top = 20.dp,
+                        bottom = 60.dp,
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(18.dp),
+                ) {
+                    item(key = "reader-heading") {
+                        ReaderHeading(document, isPlayingThisChapter, timingsMatch, palette)
+                    }
+                    itemsIndexed(
+                        document.paragraphs,
+                        key = { index, span -> "paragraph-$index-${span.start}" },
+                    ) { _, paragraph ->
+                        ReaderParagraph(
+                            document = document,
+                            paragraph = paragraph,
+                            highlight = highlight,
+                            matches = matches,
+                            activeMatch = activeMatchSpan,
+                            prefs = prefs,
+                            palette = palette,
+                            onSeek = ::seekToOffset,
+                        )
+                    }
+                }
+                VerticalScrollbar(
+                    adapter = rememberScrollbarAdapter(listState),
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .fillMaxHeight()
+                        .onPointerEvent(PointerEventType.Press) {
+                            followPlayback = readerFollowAfter(followPlayback, ReaderFollowEvent.ManualScroll)
+                        },
+                )
+            }
+        }
+
+        if (!followPlayback && activeParagraph >= 0) {
+            OutlinedButton(
+                onClick = {
+                    followPlayback = readerFollowAfter(followPlayback, ReaderFollowEvent.BackToCurrent)
+                    scope.launch { scrollToActive() }
+                },
+                shape = RectangleShape,
+                modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 14.dp)
+                    .background(palette.background).pointerHoverIcon(PointerIcon.Hand),
+            ) { Text("BACK TO CURRENT", color = palette.accent) }
+        }
+    }
+}
+
+@Composable
+private fun ReaderToolbar(
+    title: String,
+    palette: ReaderPalette,
+    onBack: () -> Unit,
+    onFind: () -> Unit,
+    onSettings: () -> Unit,
+) {
+    Row(
+        Modifier.fillMaxWidth().padding(horizontal = PageGutter, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back", tint = palette.ink)
+        }
+        Text(title, color = palette.ink, maxLines = 1, modifier = Modifier.weight(1f))
+        IconButton(onClick = onFind) { Icon(Icons.Default.Search, "Find in chapter", tint = palette.ink) }
+        IconButton(onClick = onSettings, modifier = Modifier.testTag(ReaderSettingsButtonTestTag)) {
+            Icon(Icons.Default.Settings, "Reading settings", tint = palette.ink)
+        }
+    }
+    HorizontalDivider(color = palette.line)
+}
+
+@Composable
+private fun ReaderFindBar(
+    query: String,
+    onQuery: (String) -> Unit,
+    result: String,
+    onPrevious: () -> Unit,
+    onNext: () -> Unit,
+    onClose: () -> Unit,
+    palette: ReaderPalette,
+) {
+    val requester = remember { FocusRequester() }
+    Row(
+        Modifier.fillMaxWidth().padding(horizontal = PageGutter, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        OutlinedTextField(
+            value = query,
+            onValueChange = onQuery,
+            singleLine = true,
+            label = { Text("Find in chapter") },
+            modifier = Modifier.weight(1f).focusRequester(requester).testTag(ReaderFindFieldTestTag),
+        )
+        MetaText(result, color = palette.muted)
+        TextButton(onClick = onPrevious) { Text("PREV") }
+        TextButton(onClick = onNext) { Text("NEXT") }
+        IconButton(onClick = onClose) { Icon(Icons.Default.Close, "Close find", tint = palette.ink) }
+    }
+    LaunchedEffect(Unit) { requester.requestFocus() }
+}
+
+@Composable
+private fun ReaderHeading(
+    document: ReadAlongDocument,
+    isPlayingThisChapter: Boolean,
+    timingsMatch: Boolean,
+    palette: ReaderPalette,
+) {
+    Column {
+        MetaText(
+            if (document.hasReliableTimings) "// Read along" else "// Text only",
+            color = palette.accent,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            document.title.ifBlank { "Chapter" },
+            color = palette.ink,
+            style = MaterialTheme.typography.headlineSmall,
+            modifier = Modifier.semantics { heading() },
+        )
+        val status = when {
+            document.timingState == ReadAlongTimingState.Malformed ->
+                "The timing data is malformed, so highlighting is disabled."
+            !timingsMatch -> "The timing data does not match this audio version, so highlighting is disabled."
+            !document.hasReliableTimings -> "This chapter has narration text but no word timings."
+            !isPlayingThisChapter -> "Play this chapter to follow the narration."
+            else -> null
+        }
+        status?.let {
+            Spacer(Modifier.height(8.dp))
+            Text(it, color = palette.muted, style = MaterialTheme.typography.bodyMedium)
+        }
+        Spacer(Modifier.height(12.dp))
+        HorizontalDivider(color = palette.line)
+    }
+}
+
+@Composable
+private fun ReaderParagraph(
+    document: ReadAlongDocument,
+    paragraph: TextSpan,
+    highlight: ReadAlongHighlight,
+    matches: List<TextSpan>,
+    activeMatch: TextSpan?,
+    prefs: ReaderPreferences,
+    palette: ReaderPalette,
+    onSeek: (Int) -> Unit,
+) {
+    val sentence = highlight.sentence?.takeIf { prefs.highlight == ReaderHighlight.Sentence && it.overlaps(paragraph) }
+    val word = highlight.word?.takeIf { prefs.highlight != ReaderHighlight.Off && it.overlaps(paragraph) }
+    val localMatches = matches.filter { it.overlaps(paragraph) }
+    val annotated = remember(paragraph, sentence, word, localMatches, activeMatch, palette) {
+        buildAnnotatedString {
+            append(document.textIn(paragraph))
+            sentence?.let { addReaderStyle(SpanStyle(background = palette.sentenceBand), paragraph, it) }
+            localMatches.forEach { match ->
+                addReaderStyle(
+                    SpanStyle(
+                        background = palette.findBand,
+                        fontWeight = if (match == activeMatch) FontWeight.Bold else FontWeight.Normal,
+                    ),
+                    paragraph,
+                    match,
+                )
+            }
+            word?.let {
+                addReaderStyle(SpanStyle(color = palette.accent, fontWeight = FontWeight.Bold), paragraph, it)
+            }
+        }
+    }
+    var layout by remember(paragraph) { mutableStateOf<TextLayoutResult?>(null) }
+    SelectionContainer {
+        Text(
+            text = annotated,
+            color = palette.ink,
+            style = TextStyle(
+                fontSize = prefs.fontSize.sp,
+                lineHeight = (prefs.fontSize * prefs.lineHeight).sp,
+            ),
+            onTextLayout = { layout = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(ReaderParagraphTestTag)
+                .semantics { contentDescription = document.textIn(paragraph) }
+                .pointerInput(paragraph) {
+                    detectTapGestures { position ->
+                        val local = layout?.getOffsetForPosition(position) ?: return@detectTapGestures
+                        onSeek(paragraph.start + local)
+                    }
+                },
+        )
+    }
+}
+
+private fun AnnotatedString.Builder.addReaderStyle(style: SpanStyle, paragraph: TextSpan, span: TextSpan) {
+    val start = (span.start - paragraph.start).coerceIn(0, paragraph.length)
+    val end = (span.end - paragraph.start).coerceIn(0, paragraph.length)
+    if (end > start) addStyle(style, start, end)
+}
+
+@Composable
+private fun ReaderFailure(message: String, onRetry: () -> Unit) {
+    Column(
+        Modifier.fillMaxSize().padding(PageGutter),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(message, color = MaterialTheme.colorScheme.error, textAlign = TextAlign.Center)
+        Spacer(Modifier.height(16.dp))
+        Button(onClick = onRetry, shape = RectangleShape) { Text("RETRY") }
+    }
+}
+
+@Composable
+private fun ReaderEmptyState(title: String, palette: ReaderPalette) {
+    Column(
+        Modifier.fillMaxSize().padding(PageGutter),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        MetaText("// No narration text", color = palette.accent)
+        Spacer(Modifier.height(8.dp))
+        Text(title, color = palette.ink, style = MaterialTheme.typography.titleLarge)
+        Spacer(Modifier.height(8.dp))
+        Text("This chapter has no narration text available.", color = palette.muted)
+    }
+}
+
+@Composable
+private fun ReaderSettingsDialog(
+    prefs: ReaderPreferences,
+    onDismiss: () -> Unit,
+    onChange: ((ReaderPreferences) -> ReaderPreferences) -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Reading settings") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(18.dp)) {
+                ReaderNumberControl(
+                    label = "Font size",
+                    value = "${prefs.fontSize.roundToInt()} pt",
+                    canDecrease = prefs.fontSize > ReaderPreferences.MinFontSize,
+                    canIncrease = prefs.fontSize < ReaderPreferences.MaxFontSize,
+                    onDecrease = { onChange { it.copy(fontSize = it.fontSize - 1.0) } },
+                    onIncrease = { onChange { it.copy(fontSize = it.fontSize + 1.0) } },
+                )
+                ReaderNumberControl(
+                    label = "Line height",
+                    value = String.format(java.util.Locale.ROOT, "%.1f", prefs.lineHeight),
+                    canDecrease = prefs.lineHeight > ReaderPreferences.MinLineHeight,
+                    canIncrease = prefs.lineHeight < ReaderPreferences.MaxLineHeight,
+                    onDecrease = { onChange { it.copy(lineHeight = it.lineHeight - 0.1) } },
+                    onIncrease = { onChange { it.copy(lineHeight = it.lineHeight + 0.1) } },
+                )
+                MetaText("// Theme", color = AarisColor.Accent)
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    ReaderTheme.entries.forEach { theme ->
+                        ReaderChoice(theme.label, theme == prefs.theme) { onChange { it.copy(theme = theme) } }
+                    }
+                }
+                MetaText("// Highlight", color = AarisColor.Accent)
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    ReaderHighlight.entries.forEach { mode ->
+                        ReaderChoice(mode.label, mode == prefs.highlight) { onChange { it.copy(highlight = mode) } }
+                    }
+                }
+            }
+        },
+        confirmButton = { TextButton(onClick = onDismiss) { Text("DONE") } },
+        shape = RectangleShape,
+    )
+}
+
+@Composable
+private fun ReaderNumberControl(
+    label: String,
+    value: String,
+    canDecrease: Boolean,
+    canIncrease: Boolean,
+    onDecrease: () -> Unit,
+    onIncrease: () -> Unit,
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Column(Modifier.weight(1f)) {
+            Text(label)
+            MetaText(value)
+        }
+        IconButton(onClick = onDecrease, enabled = canDecrease) { Icon(Icons.Default.Remove, "Decrease $label") }
+        IconButton(onClick = onIncrease, enabled = canIncrease) { Icon(Icons.Default.Add, "Increase $label") }
+    }
+}
+
+@Composable
+private fun ReaderChoice(label: String, selected: Boolean, onClick: () -> Unit) {
+    Text(
+        label.uppercase(),
+        color = if (selected) AarisColor.Accent else AarisColor.Muted,
+        modifier = Modifier
+            .border(1.dp, if (selected) AarisColor.Accent else AarisColor.Line)
+            .clickable(onClick = onClick)
+            .pointerHoverIcon(PointerIcon.Hand)
+            .padding(horizontal = 9.dp, vertical = 7.dp),
+        style = MaterialTheme.typography.labelLarge,
+    )
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -34,6 +34,11 @@ open class FakeRepository(
     var devicesResult: Result<List<DeviceSession>?> = Result.success(emptyList()),
     var revokeResult: Result<Boolean> = Result.success(true),
     var currentUserResult: Result<MobileUser?> = Result.success(null),
+    var readAlongResult: Result<dk.perspektiva.ttsroad.desktop.data.ReadAlongFetchResult> = Result.success(
+        dk.perspektiva.ttsroad.desktop.data.ReadAlongFetchResult.NotFound,
+    ),
+    var readerPreferencesResult: Result<dk.perspektiva.ttsroad.desktop.data.ReaderPreferencesResponse?> =
+        Result.success(null),
 ) : TtsRoadRepository {
     var loginCalls: Int = 0
         private set
@@ -49,6 +54,11 @@ open class FakeRepository(
         private set
     var revokeOtherDevicesCalls: Int = 0
         private set
+    var readAlongCalls: Int = 0
+        private set
+    val readAlongEtags: MutableList<String?> = mutableListOf()
+    val readerPreferencePatches: MutableList<dk.perspektiva.ttsroad.desktop.data.ReaderPreferencesPatch> =
+        mutableListOf()
 
     /** Token ids passed to [revokeDevice], in order — "the current session was never revoked". */
     val revokedDevices: MutableList<Int> = mutableListOf()
@@ -120,6 +130,25 @@ open class FakeRepository(
     override suspend fun chapters(fictionId: Int, playableOnly: Boolean): ChaptersResponse {
         chaptersCalls++
         return chaptersResult.getOrThrow()
+    }
+
+    override suspend fun readAlong(
+        chapterId: Int,
+        ifNoneMatch: String?,
+    ): dk.perspektiva.ttsroad.desktop.data.ReadAlongFetchResult {
+        readAlongCalls++
+        readAlongEtags += ifNoneMatch
+        return readAlongResult.getOrThrow()
+    }
+
+    override suspend fun readerPreferences(): dk.perspektiva.ttsroad.desktop.data.ReaderPreferencesResponse? =
+        readerPreferencesResult.getOrThrow()
+
+    override suspend fun updateReaderPreferences(
+        request: dk.perspektiva.ttsroad.desktop.data.ReaderPreferencesPatch,
+    ): dk.perspektiva.ttsroad.desktop.data.ReaderPreferencesResponse? {
+        readerPreferencePatches += request
+        return readerPreferencesResult.getOrThrow()
     }
 
     override suspend fun markPlayed(chapterIds: List<Int>, played: Boolean): PlaybackMarkResponse {

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ReadAlongCacheTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ReadAlongCacheTest.kt
@@ -1,0 +1,75 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import java.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import org.junit.jupiter.api.io.TempDir
+
+class ReadAlongCacheTest {
+    private val response = ReadAlongResponse(
+        chapter = ReadAlongChapter(10, 7, "Chapter 1", audioDuration = 60.0, hasTimings = true),
+        text = "One two.",
+        paragraphs = listOf(listOf(0.0, 8.0)),
+        cues = listOf(listOf(0.0, 3.0, 0.0), listOf(4.0, 7.0, 1.0)),
+    )
+
+    @Test
+    fun `first fetch persists and 304 returns the same parsed instance`(@TempDir root: java.io.File) =
+        kotlinx.coroutines.test.runTest {
+            val repository = FakeRepository(
+                readAlongResult = Result.success(ReadAlongFetchResult.Modified(response, "\"abc\"")),
+            )
+            val cache = ReadAlongCache(repository).attachDiskCache { ReadAlongDiskCache(root) }
+            val first = cache.load(10)
+            repository.readAlongResult = Result.success(ReadAlongFetchResult.NotModified)
+
+            val second = cache.load(10)
+
+            assertSame(first, second)
+            assertEquals(listOf(null, "\"abc\""), repository.readAlongEtags)
+        }
+
+    @Test
+    fun `a previous-launch document reads through a network outage`(@TempDir root: java.io.File) =
+        kotlinx.coroutines.test.runTest {
+            ReadAlongDiskCache(root).write(10, CachedReadAlong(etag = "\"abc\"", response = response))
+            val repository = FakeRepository(
+                readAlongResult = Result.failure(IOException("offline")),
+            )
+            val restarted = ReadAlongCache(repository).attachDiskCache { ReadAlongDiskCache(root) }
+
+            assertEquals("One two.", restarted.load(10)?.text)
+            assertEquals(listOf<String?>("\"abc\""), repository.readAlongEtags)
+        }
+
+    @Test
+    fun `404 is a normal empty state and removes stale disk content`(@TempDir root: java.io.File) =
+        kotlinx.coroutines.test.runTest {
+            ReadAlongDiskCache(root).write(10, CachedReadAlong(response = response))
+            val repository = FakeRepository(readAlongResult = Result.success(ReadAlongFetchResult.NotFound))
+            val cache = ReadAlongCache(repository).attachDiskCache { ReadAlongDiskCache(root) }
+
+            assertNull(cache.load(10))
+            assertNull(ReadAlongDiskCache(root).read(10))
+        }
+
+    @Test
+    fun `a mismatched chapter response is never cached or rendered`(@TempDir root: java.io.File) =
+        kotlinx.coroutines.test.runTest {
+            val repository = FakeRepository(
+                readAlongResult = Result.success(
+                    ReadAlongFetchResult.Modified(
+                        response.copy(chapter = response.chapter.copy(id = 99)),
+                        null,
+                    ),
+                ),
+            )
+            val cache = ReadAlongCache(repository).attachDiskCache { ReadAlongDiskCache(root) }
+
+            kotlin.test.assertFails { cache.load(10) }
+            assertNull(ReadAlongDiskCache(root).read(10))
+        }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ReadAlongDiskCacheTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ReadAlongDiskCacheTest.kt
@@ -1,0 +1,76 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import java.nio.file.Files
+import kotlin.io.path.createDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.io.TempDir
+
+class ReadAlongDiskCacheTest {
+    private fun cached(chapterId: Int, text: String = "Chapter $chapterId") = CachedReadAlong(
+        etag = "\"$chapterId\"",
+        response = ReadAlongResponse(
+            chapter = ReadAlongChapter(id = chapterId, fictionId = 7, title = text),
+            text = text,
+            paragraphs = listOf(listOf(0.0, text.length.toDouble())),
+        ),
+    )
+
+    @Test
+    fun `documents are isolated by stable server and account identity`(@TempDir root: java.io.File) {
+        val alice = ReadAlongDiskCache.forIdentity(StorageIdentity("server-a", "alice"), root)
+        val bob = ReadAlongDiskCache.forIdentity(StorageIdentity("server-a", "bob"), root)
+        val elsewhere = ReadAlongDiskCache.forIdentity(StorageIdentity("server-b", "alice"), root)
+
+        alice.write(10, cached(10, "Alice text"))
+
+        assertEquals("Alice text", alice.read(10)?.response?.text)
+        assertNull(bob.read(10))
+        assertNull(elsewhere.read(10))
+    }
+
+    @Test
+    fun `least recently used documents are evicted independently from audio`(@TempDir root: java.io.File) {
+        var now = 1L
+        val cache = ReadAlongDiskCache(root, maxBytes = Long.MAX_VALUE, maxEntries = 2, clock = { now++ })
+
+        cache.write(1, cached(1))
+        cache.write(2, cached(2))
+        cache.read(1) // Chapter 1 becomes newer than 2.
+        cache.write(3, cached(3))
+
+        assertEquals(2, cache.size())
+        assertTrue(cache.read(1) != null)
+        assertNull(cache.read(2))
+        assertTrue(cache.read(3) != null)
+    }
+
+    @Test
+    fun `copied wrong-chapter and corrupt files are rejected`(@TempDir root: java.io.File) {
+        val cache = ReadAlongDiskCache(root)
+        cache.write(10, cached(10))
+        Files.copy(root.resolve("chapter-10.json").toPath(), root.resolve("chapter-11.json").toPath())
+        root.resolve("chapter-12.json").writeText("not json")
+
+        assertNull(cache.read(11))
+        assertNull(cache.read(12))
+        assertFalse(root.resolve("chapter-11.json").exists())
+    }
+
+    @Test
+    fun `a symlink root is never followed`(@TempDir parent: java.io.File) {
+        val target = parent.toPath().resolve("target").createDirectory()
+        val link = parent.toPath().resolve("link")
+        Files.createSymbolicLink(link, target)
+        val cache = ReadAlongDiskCache(link.toFile())
+
+        cache.write(10, cached(10))
+
+        assertNull(cache.read(10))
+        assertEquals(0, cache.size())
+        assertTrue(target.toFile().listFiles().orEmpty().isEmpty())
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ReadAlongDocumentTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ReadAlongDocumentTest.kt
@@ -1,0 +1,139 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ReadAlongDocumentTest {
+    private fun response(
+        text: String = "The knight rode north. Snow fell.",
+        hasTimings: Boolean = true,
+        paragraphs: List<List<Double>> = listOf(listOf(0.0, text.length.toDouble())),
+        cues: List<List<Double>> = listOf(
+            listOf(0.0, 3.0, 0.0),
+            listOf(4.0, 10.0, 0.4),
+            listOf(11.0, 15.0, 0.9),
+            listOf(16.0, 21.0, 1.3),
+            listOf(23.0, 27.0, 2.0),
+        ),
+    ) = ReadAlongResponse(
+        chapter = ReadAlongChapter(10, 7, "Chapter 1", 1.0, 3.0, hasTimings, 1),
+        text = text,
+        paragraphs = paragraphs,
+        cues = cues,
+    )
+
+    @Test
+    fun `wire spans become a timed document with sentence and paragraph lookup`() {
+        val document = ReadAlongDocument.from(response())
+
+        assertEquals(ReadAlongTimingState.Timed, document.timingState)
+        assertTrue(document.hasReliableTimings)
+        assertEquals("knight", document.textIn(document.cues[1].span))
+        assertEquals(0, document.paragraphIndexAt(24))
+        assertEquals(TextSpan(0, 22), document.sentences[0])
+    }
+
+    @Test
+    fun `cue lookup uses exact media boundaries and works backwards after a seek`() {
+        val document = ReadAlongDocument.from(response())
+
+        assertEquals(0, document.highlightAtMillis(0).cueIndex)
+        assertEquals(1, document.highlightAtMillis(400).cueIndex)
+        assertEquals(4, document.highlightAtMillis(2_900).cueIndex)
+        assertEquals(1, document.highlightAtMillis(401).cueIndex)
+        assertEquals(ReadAlongHighlight.None, document.highlightAtMillis(-1))
+    }
+
+    @Test
+    fun `two-times playback still highlights from reported media position`() {
+        val document = ReadAlongDocument.from(response())
+
+        // At 2x these positions arrive in half the wall-clock time; lookup deliberately has no rate math.
+        assertEquals(listOf(0, 2, 4), listOf(0L, 900L, 2_000L).map { document.highlightAtMillis(it).cueIndex })
+    }
+
+    @Test
+    fun `only a click inside a timed word seeks`() {
+        val document = ReadAlongDocument.from(response())
+
+        assertEquals(0.4, document.seekSecondsForOffset(7))
+        assertNull(document.seekSecondsForOffset(21))
+        assertNull(document.seekSecondsForOffset(22))
+        assertNull(document.seekSecondsForOffset(-1))
+    }
+
+    @Test
+    fun `plain narration remains readable and never invents a seek`() {
+        val document = ReadAlongDocument.from(response(hasTimings = false, cues = emptyList()))
+
+        assertEquals(ReadAlongTimingState.TextOnly, document.timingState)
+        assertFalse(document.hasReliableTimings)
+        assertNull(document.seekSecondsForOffset(7))
+        assertEquals(ReadAlongHighlight.None, document.highlightAtMillis(1_000))
+    }
+
+    @Test
+    fun `malformed or non-monotonic cues disable all confident highlighting`() {
+        val document = ReadAlongDocument.from(
+            response(
+                cues = listOf(
+                    listOf(4.0, 10.0, 0.4),
+                    listOf(0.0, 3.0, 0.8),
+                    listOf(11.0, 15.0, Double.NaN),
+                ),
+            ),
+        )
+
+        assertEquals(ReadAlongTimingState.Malformed, document.timingState)
+        assertTrue(document.cues.isEmpty())
+        assertEquals(ReadAlongHighlight.None, document.highlightAtMillis(1_000))
+    }
+
+    @Test
+    fun `missing paragraph ranges fall back to blank-line separated paragraphs`() {
+        val document = ReadAlongDocument.from(
+            response(
+                text = "First paragraph.\n\nSecond paragraph.",
+                hasTimings = false,
+                paragraphs = emptyList(),
+                cues = emptyList(),
+            ),
+        )
+
+        assertEquals(2, document.paragraphs.size)
+        assertEquals("Second paragraph.", document.textIn(document.paragraphs[1]))
+    }
+
+    @Test
+    fun `duration mismatch rejects stale timings but tolerates normal encoder rounding`() {
+        assertTrue(readAlongTimingsMatch(100.0, 103_000))
+        assertFalse(readAlongTimingsMatch(100.0, 106_000))
+        assertTrue(readAlongTimingsMatch(0.0, 90_000))
+    }
+
+    @Test
+    fun `find returns every case-insensitive occurrence without overlap`() {
+        assertEquals(
+            listOf(TextSpan(0, 4), TextSpan(5, 9), TextSpan(10, 14)),
+            readAlongMatches("Snow snow SNOW", "snow"),
+        )
+        assertTrue(readAlongMatches("chapter", "  ").isEmpty())
+    }
+
+    @Test
+    fun `binary seek lookup remains correct with ten thousand cues`() {
+        val text = "x".repeat(50_000)
+        val cues = (0 until 10_000).map { index ->
+            listOf((index * 5).toDouble(), (index * 5 + 4).toDouble(), index / 4.0)
+        }
+        val document = ReadAlongDocument.from(
+            response(text = text, paragraphs = listOf(listOf(0.0, 50_000.0)), cues = cues),
+        )
+
+        assertEquals(1_250.0, document.seekSecondsForOffset(25_001))
+        assertEquals(9_999, document.highlightAtMillis(2_499_999).cueIndex)
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ReaderPreferencesTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ReaderPreferencesTest.kt
@@ -1,0 +1,82 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.io.TempDir
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReaderPreferencesTest {
+    @Test
+    fun `preference coercion honours the server vocabulary and ranges`() {
+        val merged = ReaderPreferencesWire(
+            fontSize = 99.0,
+            lineHeight = Double.NaN,
+            theme = "sepia",
+            highlight = "future-mode",
+        ).mergeInto(ReaderPreferences(theme = ReaderTheme.Light, highlight = ReaderHighlight.Word))
+
+        assertEquals(30.0, merged.fontSize)
+        assertEquals(ReaderPreferences.DefaultLineHeight, merged.lineHeight)
+        assertEquals(ReaderTheme.Sepia, merged.theme)
+        assertEquals(ReaderHighlight.Word, merged.highlight)
+    }
+
+    @Test
+    fun `server refresh merges supported keys over the local fallback`(@TempDir root: java.io.File) = runTest {
+        val repository = FakeRepository(
+            readerPreferencesResult = Result.success(
+                ReaderPreferencesResponse(ReaderPreferencesWire(fontSize = 24.0, theme = "light")),
+            ),
+        )
+        val store = FileReaderPreferencesStore(
+            repository,
+            root.resolve("reader.json"),
+            StandardTestDispatcher(testScheduler),
+        )
+
+        store.refreshFromServer()
+
+        assertEquals(24.0, store.preferences.value.fontSize)
+        assertEquals(ReaderTheme.Light, store.preferences.value.theme)
+        assertEquals(ReaderPreferences.DefaultLineHeight, store.preferences.value.lineHeight)
+        store.close()
+    }
+
+    @Test
+    fun `a local change persists immediately and patches only reader keys`(@TempDir root: java.io.File) = runTest {
+        val repository = FakeRepository(
+            readerPreferencesResult = Result.success(ReaderPreferencesResponse()),
+        )
+        val file = root.resolve("reader.json")
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val store = FileReaderPreferencesStore(repository, file, dispatcher)
+
+        store.update { it.copy(fontSize = 25.0, theme = ReaderTheme.Sepia) }
+        val reloaded = FileReaderPreferencesStore(repository, file, dispatcher)
+        assertEquals(25.0, reloaded.preferences.value.fontSize)
+        reloaded.close()
+        advanceTimeBy(301)
+        advanceUntilIdle()
+
+        val patch = repository.readerPreferencePatches.single()
+        assertEquals(25.0, patch.fontSize)
+        assertEquals("sepia", patch.theme)
+        store.close()
+    }
+
+    @Test
+    fun `offline or old-server refresh leaves the local fallback untouched`() = runTest {
+        val repository = FakeRepository(readerPreferencesResult = Result.success(null))
+        val store = InMemoryReaderPreferencesStore(ReaderPreferences(fontSize = 23.0))
+
+        store.refreshFromServer()
+
+        assertEquals(23.0, store.preferences.value.fontSize)
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/RepositoryTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/RepositoryTest.kt
@@ -86,6 +86,90 @@ class RepositoryTest {
     }
 
     @Test
+    fun `read-along sends its ETag and exposes a normal 304`() = runTest {
+        server.enqueue(MockResponse(code = 304))
+
+        val result = repository.readAlong(101, "\"chapter-etag\"")
+
+        assertEquals(ReadAlongFetchResult.NotModified, result)
+        val request = server.takeRequest()
+        assertEquals("/api/mobile/chapters/101/readalong", request.url.encodedPath)
+        assertEquals("\"chapter-etag\"", request.headers["If-None-Match"])
+        assertEquals("Bearer ttsr_token", request.headers["Authorization"])
+    }
+
+    @Test
+    fun `read-along returns a parsed document and response ETag`() = runTest {
+        val body = """
+            {"chapter":{"id":101,"fiction_id":7,"title":"Chapter 1","has_timings":false},
+             "text":"Narration text.","paragraphs":[[0,15]],"cues":[]}
+        """.trimIndent()
+        server.enqueue(
+            MockResponse(
+                code = 200,
+                headers = Headers.headersOf("Content-Type", "application/json", "ETag", "\"abc\""),
+                body = body,
+            ),
+        )
+
+        val result = repository.readAlong(101)
+
+        val modified = result as ReadAlongFetchResult.Modified
+        assertEquals("Narration text.", modified.response.text)
+        assertEquals("\"abc\"", modified.etag)
+    }
+
+    @Test
+    fun `read-along 404 is normal and does not end the session`() = runTest {
+        enqueue(404, """{"detail":"Chapter has no narration text"}""")
+
+        assertEquals(ReadAlongFetchResult.NotFound, repository.readAlong(101))
+
+        assertTrue(sessionStore.current().isLoggedIn)
+        assertNull(repository.sessionEnd.value)
+    }
+
+    @Test
+    fun `read-along 401 still ends the session`() = runTest {
+        enqueue(401, ServerFixtures.UNAUTHORIZED_TOKEN_EXPIRED)
+
+        assertThrows<HttpException> { repository.readAlong(101) }
+
+        assertFalse(sessionStore.current().isLoggedIn)
+        assertEquals(SessionEndReason.Expired, repository.sessionEnd.value?.reason)
+    }
+
+    @Test
+    fun `reader preferences GET and PATCH use only the supported account keys`() = runTest {
+        enqueue(
+            200,
+            """{"preferences":{"reader_font_size":22,"reader_line_height":1.8,"reader_theme":"sepia","reader_highlight":"word","hide_played":true}}""",
+        )
+        val loaded = repository.readerPreferences()
+        assertEquals(22.0, loaded?.preferences?.fontSize)
+        assertEquals("sepia", loaded?.preferences?.theme)
+
+        enqueue(
+            200,
+            """{"preferences":{"reader_font_size":24,"reader_line_height":1.9,"reader_theme":"light","reader_highlight":"off"}}""",
+        )
+        repository.updateReaderPreferences(ReaderPreferencesPatch(24.0, 1.9, "light", "off"))
+
+        val get = server.takeRequest()
+        assertEquals("GET", get.method)
+        assertEquals("/api/me/preferences", get.url.encodedPath)
+        val patch = server.takeRequest()
+        assertEquals("PATCH", patch.method)
+        assertEquals("/api/me/preferences", patch.url.encodedPath)
+        val json = patch.bodyText()
+        assertTrue(json.contains("\"reader_font_size\":24.0"), json)
+        assertTrue(json.contains("\"reader_line_height\":1.9"), json)
+        assertTrue(json.contains("\"reader_theme\":\"light\""), json)
+        assertTrue(json.contains("\"reader_highlight\":\"off\""), json)
+        assertFalse(json.contains("hide_played"), json)
+    }
+
+    @Test
     fun `markPlayed posts a chapter-id array even for a single chapter`() = runTest {
         enqueue(200, ServerFixtures.MARK_OK)
 

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/download/ChapterDownloaderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/download/ChapterDownloaderTest.kt
@@ -144,6 +144,19 @@ class ChapterDownloaderTest {
     }
 
     @Test
+    fun `an already complete part is promoted without an impossible range request`() = runBlocking {
+        val whole = mp3Bytes()
+        File(storage.root, "1.mp3.part").writeBytes(whole)
+
+        val result = downloader().download("/audio/s/1.mp3", "1.mp3", expectedBytes = whole.size.toLong())
+
+        assertIs<DownloadResult.Success>(result)
+        assertEquals(0, server.requestCount)
+        assertContentEquals(whole, storage.resolve("1.mp3").readBytes())
+        assertFalse(File(storage.root, "1.mp3.part").exists())
+    }
+
+    @Test
     fun `a server that ignores the range header restarts instead of corrupting the file`() = runBlocking {
         // The dangerous case: we asked to resume, the server sent the whole file with a 200.
         // Appending would produce a file of the right length made of the wrong bytes.

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/download/DownloadCoordinatorTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/download/DownloadCoordinatorTest.kt
@@ -1,8 +1,11 @@
 package dk.perspektiva.ttsroad.desktop.download
 
 import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.data.CachedReadAlong
 import dk.perspektiva.ttsroad.desktop.data.FileSessionStore
 import dk.perspektiva.ttsroad.desktop.data.InMemorySessionStore
+import dk.perspektiva.ttsroad.desktop.data.ReadAlongChapter
+import dk.perspektiva.ttsroad.desktop.data.ReadAlongResponse
 import dk.perspektiva.ttsroad.desktop.data.SessionState
 import dk.perspektiva.ttsroad.desktop.data.SessionStore
 import dk.perspektiva.ttsroad.desktop.security.InMemoryCredentialStore
@@ -94,17 +97,31 @@ class DownloadCoordinatorTest {
 
         val session = coordinator.refresh()!!
         session.storage.resolve("1.mp3").writeBytes(ByteArray(32))
+        session.readAlongCache.write(
+            1,
+            CachedReadAlong(
+                response = ReadAlongResponse(
+                    chapter = ReadAlongChapter(id = 1, fictionId = 7),
+                    text = "Private narration",
+                    paragraphs = listOf(listOf(0.0, 17.0)),
+                ),
+            ),
+        )
         val root = session.storage.root
+        val readAlongRoot = session.readAlongCache.root
 
         store.clearToken()
         // `clearToken` keeps login hints, but those are not authority to open account-protected
         // metadata. The live stack goes away while its bytes stay on disk.
         assertTrue(root.resolve("1.mp3").isFile, "signing out deleted a download")
         assertNull(coordinator.refresh(), "signed-out hints exposed the account's download index")
+        assertNull(coordinator.readAlongCacheOrNull(), "signed-out hints exposed narration text")
+        assertTrue(readAlongRoot.resolve("chapter-1.json").isFile, "signing out deleted rebuildable text")
 
         store.save(signedIn())
         assertEquals(root.path, coordinator.refresh()!!.storage.root.path)
         assertTrue(coordinator.refresh()!!.storage.resolve("1.mp3").isFile)
+        assertEquals("Private narration", coordinator.readAlongCacheOrNull()?.read(1)?.response?.text)
         coordinator.close()
     }
 

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/download/DownloadManagerTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/download/DownloadManagerTest.kt
@@ -7,6 +7,7 @@ import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
 import dk.perspektiva.ttsroad.desktop.data.InMemorySessionStore
 import dk.perspektiva.ttsroad.desktop.data.SessionState
 import java.io.File
+import java.nio.file.Files
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -96,16 +97,17 @@ class DownloadManagerTest {
         progressBytesThreshold: Long = DownloadManager.DefaultProgressBytesThreshold,
         progressIntervalNanos: Long = DownloadManager.DefaultProgressIntervalNanos,
         progressClockNanos: () -> Long = System::nanoTime,
+        downloadStorage: DownloadStorage = storage,
     ): DownloadManager {
         val repository = object : FakeRepository(serverUrl = server.url("/").toString()) {
             override fun authHeaderValue(): String? = sessionStore.current().authorizationHeader
             override fun resolveUrl(url: String): String =
                 if (url.startsWith("http")) url else server.url("/").toString().trimEnd('/') + url
         }
-        val downloader = ChapterDownloader(authedClient(sessionStore), repository, storage)
+        val downloader = ChapterDownloader(authedClient(sessionStore), repository, downloadStorage)
         return DownloadManager(
             downloader,
-            storage,
+            downloadStorage,
             indexStore,
             retryDelaysMs = retryDelaysMs,
             progressBytesThreshold = progressBytesThreshold,
@@ -308,6 +310,33 @@ class DownloadManagerTest {
         assertEquals(3 * 4096L, freed)
         assertTrue(index.entries.value.isEmpty())
         assertFalse(storage.root.exists())
+    }
+
+    @Test
+    fun `delete all preserves metadata for a file the filesystem refused to remove`() = runBlocking {
+        val stubborn = DownloadStorage(
+            root = File(tempDir, "stubborn"),
+            deletePath = { path ->
+                if (path.fileName.toString() == "2.mp3") false else Files.deleteIfExists(path)
+            },
+        ).also { it.prepare() }
+        val localIndex = InMemoryDownloadIndexStore(
+            listOf(
+                DownloadEntry(1, 7, "A Serial", "One", DownloadState.Downloaded, 100, 100, "1.mp3"),
+                DownloadEntry(2, 7, "A Serial", "Two", DownloadState.Downloaded, 200, 200, "2.mp3"),
+            ),
+        )
+        stubborn.resolve("1.mp3").writeBytes(ByteArray(100))
+        stubborn.resolve("2.mp3").writeBytes(ByteArray(200))
+
+        val freed = manager(indexStore = localIndex, downloadStorage = stubborn).deleteAll()
+
+        assertEquals(100L, freed)
+        assertNull(DownloadIndex.find(localIndex.entries.value, 1))
+        val retained = DownloadIndex.find(localIndex.entries.value, 2)!!
+        assertEquals("Two", retained.chapterTitle)
+        assertEquals(DownloadState.Downloaded, retained.state)
+        assertTrue(stubborn.resolve("2.mp3").isFile)
     }
 
     // --- Restart ------------------------------------------------------------------------------------

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/download/StreamingCacheTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/download/StreamingCacheTest.kt
@@ -18,10 +18,13 @@ class StreamingCacheTest {
     @TempDir
     lateinit var tempDir: File
 
-    private class BytesSource(private val bytes: ByteArray) : MediaSource {
+    private class BytesSource(
+        private val bytes: ByteArray,
+        private val reportedLength: Long = bytes.size.toLong(),
+    ) : MediaSource {
         override fun open(): MediaStream = object : MediaStream {
             private var position = 0
-            override val length: Long = bytes.size.toLong()
+            override val length: Long = reportedLength
             override val isSeekable: Boolean = true
 
             override fun read(buffer: ByteArray, offset: Int, count: Int): Int {
@@ -107,6 +110,35 @@ class StreamingCacheTest {
 
         assertTrue(cache.stats().bytes <= 80L)
         assertEquals(1, cache.stats().files)
+    }
+
+    @Test
+    fun `a known stream larger than the cache cap is played without retaining bytes`() {
+        val cache = cache(maxBytes = 10)
+        val bytes = ByteArray(64) { it.toByte() }
+
+        assertEquals(bytes.toList(), consume(cache.retaining(7, BytesSource(bytes))).toList())
+
+        assertEquals(0L, cache.root.listFiles().orEmpty().sumOf(File::length))
+        assertNull(cache.sourceFor(7))
+    }
+
+    @Test
+    fun `an unknown-length stream never writes beyond the hard cache cap`() {
+        val cache = cache(maxBytes = 10)
+        val bytes = ByteArray(64) { it.toByte() }
+        val retained = cache.retaining(7, BytesSource(bytes, reportedLength = -1L))
+
+        retained.open().use { stream ->
+            val buffer = ByteArray(7)
+            while (stream.read(buffer, 0, buffer.size) >= 0) {
+                val bytesOnDisk = cache.root.listFiles().orEmpty().sumOf(File::length)
+                assertTrue(bytesOnDisk <= 10L, "streaming cache grew to $bytesOnDisk bytes")
+            }
+        }
+
+        assertNull(cache.sourceFor(7))
+        assertFalse(File(cache.root, "7.mp3.part").exists())
     }
 
     @Test

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterBrowsingUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterBrowsingUiTest.kt
@@ -309,7 +309,7 @@ class ChapterBrowsingUiTest {
     }
 
     @Test
-    fun `read-along is offered only when the server and the chapter both support it`() {
+    fun `read-along is hidden when the server does not support the endpoint`() {
         val repository = FakeRepository(
             chaptersResult = Result.success(response(listOf(chapter(1, hasTimings = true)))),
         )
@@ -317,6 +317,20 @@ class ChapterBrowsingUiTest {
         screen(repository)
 
         compose.onAllNodesWithContentDescription("Read along").assertCountEquals(0)
+        compose.onAllNodesWithContentDescription("Read chapter text").assertCountEquals(0)
+    }
+
+    @Test
+    fun `an untimed chapter still offers its plain narration text on a capable server`() {
+        val repository = FakeRepository(
+            capabilitiesResult = ServerCapabilities(readAlong = true),
+            chaptersResult = Result.success(response(listOf(chapter(1, hasTimings = false)))),
+        )
+        runBlocking { repository.refreshCurrentCapabilities() }
+
+        screen(repository)
+
+        compose.onNodeWithContentDescription("Read chapter text").assertHasClickAction()
     }
 
     @Test

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterDownloadsBindingTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterDownloadsBindingTest.kt
@@ -67,6 +67,13 @@ class ChapterDownloadsBindingTest {
     }
 
     @Test
+    fun `a chapter without audio has no dead download action`() {
+        val ui = chapterDownloadUi(chapter(1, hasAudio = false), entry = null, storageAvailable = true)
+
+        assertEquals(ChapterDownloadState.Unavailable, ui.state)
+    }
+
+    @Test
     fun `each index state maps to the control that state affords`() {
         fun stateOf(s: DownloadState) = chapterDownloadUi(entry(1, s), available = true).state
 

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/NavigationUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/NavigationUiTest.kt
@@ -32,9 +32,14 @@ import dk.perspektiva.ttsroad.desktop.data.ChaptersResponse
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
 import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackHistoryStore
 import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.InMemoryReaderPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.InMemorySessionStore
 import dk.perspektiva.ttsroad.desktop.data.LibraryCache
 import dk.perspektiva.ttsroad.desktop.data.LibraryResponse
+import dk.perspektiva.ttsroad.desktop.data.ReadAlongChapter
+import dk.perspektiva.ttsroad.desktop.data.ReadAlongFetchResult
+import dk.perspektiva.ttsroad.desktop.data.ReadAlongResponse
+import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
 import dk.perspektiva.ttsroad.desktop.data.SessionState
 import dk.perspektiva.ttsroad.desktop.di.AppContainer
 import dk.perspektiva.ttsroad.desktop.download.DownloadCoordinator
@@ -92,6 +97,7 @@ class NavigationUiTest {
         // ~/.config/TTSRoad files the production stores default to.
         playbackPreferences = InMemoryPlaybackPreferencesStore(),
         playbackHistory = InMemoryPlaybackHistoryStore(),
+        readerPreferencesFactory = { _, _ -> InMemoryReaderPreferencesStore() },
         // See `testLibraryCache`: immediate main dispatch is what makes `waitForIdle` sufficient.
         libraryCacheFactory = { repo, _, now -> LibraryCache(repo, Dispatchers.Main.immediate, now) },
         downloadCoordinatorFactory = { store, client, repo, dispatchers ->
@@ -381,6 +387,36 @@ class NavigationUiTest {
     }
 
     // --- Chapters --------------------------------------------------------------------------------
+
+    @Test
+    fun `a capability-gated chapter row opens the real reader destination`() {
+        val repository = FakeRepository(
+            libraryResult = Result.success(bigLibrary(60)),
+            chaptersResult = Result.success(chapters),
+            capabilitiesResult = ServerCapabilities(serverVersion = "1.4.0", readAlong = true),
+            readAlongResult = Result.success(
+                ReadAlongFetchResult.Modified(
+                    ReadAlongResponse(
+                        chapter = ReadAlongChapter(5001, 50, "Chapter One", hasTimings = false),
+                        text = "The real reader is here.",
+                        paragraphs = listOf(listOf(0.0, 24.0)),
+                    ),
+                    "\"reader\"",
+                ),
+            ),
+        )
+        compose.setContent { TtsRoadTheme { App(container(repository)) } }
+        compose.waitForIdle()
+
+        compose.onNodeWithTag(LibraryGridTestTag).performScrollToNode(hasText("Serial 50"))
+        compose.onNodeWithText("Serial 50").performClick()
+        compose.waitForIdle()
+        compose.onNodeWithContentDescription("Read chapter text").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("The real reader is here.").assertIsDisplayed()
+        compose.onNodeWithText("// TEXT ONLY").assertIsDisplayed()
+    }
 
     @Test
     fun `a fiction with many chapters composes only the rows on screen`() {

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreenUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreenUiTest.kt
@@ -96,6 +96,26 @@ class PlayerScreenUiTest {
     }
 
     @Test
+    fun `the capable player opens the current chapter in the reader`() {
+        val playback = FakePlaybackController(playingState())
+        var opened: Pair<Int, String>? = null
+        compose.setContent {
+            TtsRoadTheme {
+                PlayerScreen(
+                    playback,
+                    readAlongAvailable = true,
+                    onOpenReader = { id, title -> opened = id to title },
+                    onBack = {},
+                )
+            }
+        }
+
+        compose.onNodeWithText("READ ALONG").assertHasClickAction().performClick()
+
+        assertEquals(101 to "Chapter 3 — The Descent", opened)
+    }
+
+    @Test
     fun `a playback error is shown instead of the buffering hint`() {
         val playback = FakePlaybackController(
             PlayerUiState(

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderBehaviourTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderBehaviourTest.kt
@@ -1,0 +1,31 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ReaderBehaviourTest {
+    @Test
+    fun `active content is placed one third down the viewport`() {
+        assertEquals(-300, readerAutoScrollOffsetPx(900))
+        assertEquals(0, readerAutoScrollOffsetPx(0))
+    }
+
+    @Test
+    fun `manual scrolling yields permanently until Back to current`() {
+        var follow = true
+        follow = readerFollowAfter(follow, ReaderFollowEvent.ManualScroll)
+        follow = readerFollowAfter(follow, ReaderFollowEvent.PassiveUpdate)
+        assertFalse(follow)
+        assertTrue(readerFollowAfter(follow, ReaderFollowEvent.BackToCurrent))
+        assertTrue(readerFollowAfter(false, ReaderFollowEvent.ChapterChanged))
+    }
+
+    @Test
+    fun `next chapter prefetch starts at eighty percent`() {
+        assertFalse(readerShouldPrefetch(79_999, 100_000))
+        assertTrue(readerShouldPrefetch(80_000, 100_000))
+        assertFalse(readerShouldPrefetch(1, 0))
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderScreenUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderScreenUiTest.kt
@@ -1,0 +1,180 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import dk.perspektiva.ttsroad.desktop.FakePlaybackController
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.data.InMemoryReaderPreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.ReadAlongCache
+import dk.perspektiva.ttsroad.desktop.data.ReadAlongChapter
+import dk.perspektiva.ttsroad.desktop.data.ReadAlongFetchResult
+import dk.perspektiva.ttsroad.desktop.data.ReadAlongResponse
+import dk.perspektiva.ttsroad.desktop.player.PlayerUiState
+import dk.perspektiva.ttsroad.desktop.player.QueueItem
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class ReaderScreenUiTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    private fun response(
+        chapterId: Int = 10,
+        text: String = "Snow fell softly. Then snow stopped.",
+        hasTimings: Boolean = true,
+        paragraphs: List<List<Double>> = listOf(listOf(0.0, text.length.toDouble())),
+    ) = ReadAlongResponse(
+        chapter = ReadAlongChapter(
+            id = chapterId,
+            fictionId = 7,
+            title = "Chapter One",
+            audioDuration = 60.0,
+            hasTimings = hasTimings,
+        ),
+        text = text,
+        paragraphs = paragraphs,
+        cues = if (hasTimings) {
+            listOf(
+                listOf(0.0, 4.0, 0.0),
+                listOf(5.0, 9.0, 1.0),
+                listOf(10.0, 16.0, 2.0),
+            )
+        } else {
+            emptyList()
+        },
+    )
+
+    private fun screen(
+        response: ReadAlongResponse = response(),
+        player: FakePlaybackController = FakePlaybackController(),
+        preferences: InMemoryReaderPreferencesStore = InMemoryReaderPreferencesStore(),
+        onAdvanced: (Int, String) -> Unit = { _, _ -> },
+    ) {
+        val repository = FakeRepository(
+            readAlongResult = Result.success(ReadAlongFetchResult.Modified(response, "\"etag\"")),
+        )
+        compose.setContent {
+            TtsRoadTheme {
+                ReaderScreen(
+                    chapterId = response.chapter.id,
+                    fallbackTitle = response.chapter.title,
+                    cache = ReadAlongCache(repository),
+                    preferences = preferences,
+                    playback = player,
+                    onBack = {},
+                    onChapterAdvanced = onAdvanced,
+                )
+            }
+        }
+        compose.waitForIdle()
+    }
+
+    @Test
+    fun `a timed chapter renders its selectable narration`() {
+        screen()
+        compose.onNodeWithText("// READ ALONG").assertIsDisplayed()
+        compose.onNodeWithText("Snow fell softly. Then snow stopped.").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a text-only chapter explains why it cannot follow audio`() {
+        screen(response(hasTimings = false))
+        compose.onNodeWithText("// TEXT ONLY").assertIsDisplayed()
+        compose.onNodeWithText("This chapter has narration text but no word timings.").assertIsDisplayed()
+    }
+
+    @Test
+    fun `find in chapter reports and cycles through matches`() {
+        screen()
+
+        compose.onNodeWithContentDescription("Find in chapter").performClick()
+        compose.onNodeWithTag(ReaderFindFieldTestTag).performTextInput("snow")
+        compose.waitForIdle()
+
+        compose.onNodeWithText("1 OF 2").assertIsDisplayed()
+        compose.onNodeWithText("NEXT").performClick()
+        compose.onNodeWithText("2 OF 2").assertIsDisplayed()
+    }
+
+    @Test
+    fun `reader settings are keyboard-visible and update the local store`() {
+        val preferences = InMemoryReaderPreferencesStore()
+        screen(preferences = preferences)
+
+        compose.onNodeWithContentDescription("Reading settings").assertHasClickAction().performClick()
+        compose.onNodeWithText("Reading settings").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Increase Font size").performClick()
+
+        assertEquals(20.0, preferences.preferences.value.fontSize)
+    }
+
+    @Test
+    fun `queue auto-advance moves a reader that was following the playing chapter`() {
+        val initial = PlayerUiState(
+            title = "Chapter One",
+            hasMedia = true,
+            positionMs = 10_000,
+            durationMs = 60_000,
+            queue = listOf(QueueItem(10, "Chapter One"), QueueItem(11, "Chapter Two")),
+            currentIndex = 0,
+            hasNext = true,
+        )
+        val player = FakePlaybackController(initial)
+        var advanced: Pair<Int, String>? = null
+        screen(player = player, onAdvanced = { id, title -> advanced = id to title })
+
+        player.emit(initial.copy(title = "Chapter Two", currentIndex = 1, hasNext = false))
+        compose.waitForIdle()
+
+        assertEquals(11 to "Chapter Two", advanced)
+    }
+
+    @Test
+    fun `opening a different chapter never follows unrelated playback`() {
+        val player = FakePlaybackController(
+            PlayerUiState(
+                title = "Somewhere else",
+                hasMedia = true,
+                queue = listOf(QueueItem(99, "Somewhere else"), QueueItem(100, "Later")),
+                currentIndex = 0,
+            ),
+        )
+        var advances = 0
+        screen(player = player, onAdvanced = { _, _ -> advances++ })
+
+        player.emit(player.state.value.copy(currentIndex = 1))
+        compose.waitForIdle()
+
+        assertEquals(0, advances)
+        compose.onNodeWithText("Play this chapter to follow the narration.").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a ten-thousand-word fixture composes only visible paragraph nodes`() {
+        val paragraph = "word ".repeat(20).trim()
+        val paragraphs = ArrayList<List<Double>>()
+        val text = buildString {
+            repeat(500) {
+                val start = length
+                append(paragraph)
+                val end = length
+                paragraphs += listOf(start.toDouble(), end.toDouble())
+                append("\n\n")
+            }
+        }
+        screen(response(text = text, hasTimings = false, paragraphs = paragraphs))
+
+        val composed = compose.onAllNodesWithTag(ReaderParagraphTestTag).fetchSemanticsNodes().size
+        assertTrue(composed in 1..80, "the lazy reader composed $composed of 500 paragraphs")
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ScreensUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ScreensUiTest.kt
@@ -17,6 +17,7 @@ import dk.perspektiva.ttsroad.desktop.ParsedFixtures
 import dk.perspektiva.ttsroad.desktop.testLibraryCache
 import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackHistoryStore
 import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.InMemoryReaderPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.InMemorySessionStore
 import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
 import dk.perspektiva.ttsroad.desktop.data.SessionEnd
@@ -70,6 +71,7 @@ class ScreensUiTest {
         // ~/.config/TTSRoad files the production stores default to.
         playbackPreferences = InMemoryPlaybackPreferencesStore(),
         playbackHistory = InMemoryPlaybackHistoryStore(),
+        readerPreferencesFactory = { _, _ -> InMemoryReaderPreferencesStore() },
         downloadCoordinatorFactory = ::testDownloads,
     )
 
@@ -170,6 +172,7 @@ class ScreensUiTest {
             // ~/.config/TTSRoad files the production stores default to.
             playbackPreferences = InMemoryPlaybackPreferencesStore(),
             playbackHistory = InMemoryPlaybackHistoryStore(),
+            readerPreferencesFactory = { _, _ -> InMemoryReaderPreferencesStore() },
             downloadCoordinatorFactory = ::testDownloads,
         )
         compose.setContent { TtsRoadTheme { App(app) } }
@@ -248,6 +251,7 @@ class ScreensUiTest {
             // ~/.config/TTSRoad files the production stores default to.
             playbackPreferences = InMemoryPlaybackPreferencesStore(),
             playbackHistory = InMemoryPlaybackHistoryStore(),
+            readerPreferencesFactory = { _, _ -> InMemoryReaderPreferencesStore() },
             downloadCoordinatorFactory = ::testDownloads,
         )
         compose.setContent { TtsRoadTheme { App(app) } }


### PR DESCRIPTION
## Summary

- add the audio-synchronized reader with active-sentence focus, navigation, themes, typography, and scrolling preferences
- fetch, parse, and cache read-along documents with in-memory and disk-backed caching
- integrate reader entry points with chapter browsing and playback
- include regression coverage for the remaining Phase 7 automated-review findings
- document the Phase 8 architecture and update project guidance

## Verification

- `./gradlew clean check --warning-mode fail -Pttsroad.warningsAsErrors=true` under Xvfb
- `./gradlew createDistributable --warning-mode fail -Pttsroad.warningsAsErrors=true`
- packaged desktop `--smoke-test` (`TTSRoad 1.0.1 smoke test OK`)

All verification commands completed successfully.