### PR TITLE
Phase 10: automate releases and add a verifying update check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,23 @@ env:
     -Pttsroad.warningsAsErrors=true
 
 jobs:
+  # Blocks a pull request that introduces a dependency with a known vulnerability or a licence the
+  # project does not accept. The action needs the dependency graph, which GitHub only provides for
+  # public repositories (or private ones with Advanced Security), so the job skips itself while the
+  # repository is private rather than failing every PR.
+  dependency-review:
+    name: Dependency review
+    if: ${{ github.event_name == 'pull_request' && !github.event.repository.private }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out
+        uses: actions/checkout@v7
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+
   build:
     name: Build, test and package (Ubuntu)
     # Linux Mint 22.x is based on Ubuntu 24.04. Build the .deb on that exact ABI generation rather

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,336 @@
+name: Release
+
+# Tag pushes publish; workflow_dispatch performs the identical build and verification but stops
+# before the release is created, which is the documented dry run.
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+# Least privilege by default. Only the publishing job widens this, and only to what it needs.
+permissions:
+  contents: read
+
+env:
+  GRADLE_FLAGS: >-
+    --no-daemon
+    --stacktrace
+    --warning-mode fail
+    -Pttsroad.warningsAsErrors=true
+
+jobs:
+  # Everything downstream builds from the version this job resolves, so a tag that disagrees with
+  # gradle.properties, or a version with no changelog entry, stops the release before a single
+  # artifact exists.
+  verify:
+    name: Verify version, tag and release notes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      tag: ${{ steps.resolve.outputs.tag }}
+      publish: ${{ steps.resolve.outputs.publish }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v7
+
+      - name: Resolve and cross-check the version
+        id: resolve
+        run: |
+          version=$(sed -n 's/^ttsroad\.version=//p' gradle.properties)
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            tag=${{ github.ref_name }}
+            if [ "$tag" != "v$version" ]; then
+              echo "tag $tag does not match ttsroad.version $version (expected v$version)" >&2
+              exit 1
+            fi
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            tag="v$version"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Extract the release notes for this version
+        run: ./packaging/release/changelog-section.sh "${{ steps.resolve.outputs.version }}" > release-notes.md
+
+      - name: Upload the release notes
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-notes
+          path: release-notes.md
+          if-no-files-found: error
+
+  # Linux is the supported release target, so it is the only one whose package is installed and
+  # upgraded before publishing. Windows and macOS build and smoke-test their installers only.
+  linux:
+    name: Linux .deb
+    needs: verify
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Check out
+        uses: actions/checkout@v7
+
+      - name: Validate the Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v6
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Install packaging, Xvfb, Secret Service and GStreamer tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            desktop-file-utils \
+            fakeroot \
+            xvfb \
+            xauth \
+            gstreamer1.0-tools \
+            gstreamer1.0-plugins-base \
+            gstreamer1.0-plugins-good \
+            gstreamer1.0-pulseaudio \
+            libsecret-tools \
+            lintian
+
+      - name: Compile, unit tests and Compose UI tests
+        run: xvfb-run -a ./gradlew ${{ env.GRADLE_FLAGS }} clean check
+
+      # runReleaseDistributable is the gate that catches a missing jlink module or, if release
+      # minification is ever enabled, a missing reflection keep rule — before anything is published.
+      - name: Run the release distributable
+        run: TTSROAD_SMOKE_TEST=1 xvfb-run -a ./gradlew ${{ env.GRADLE_FLAGS }} runReleaseDistributable
+
+      - name: Build the release .deb
+        run: ./gradlew ${{ env.GRADLE_FLAGS }} packageReleaseDeb
+
+      - name: Inspect the release .deb
+        run: ./packaging/linux/inspect-deb.sh build/compose/binaries/main-release/deb/ttsroad_*_amd64.deb
+
+      - name: Stage the release artifact
+        run: |
+          mkdir -p build/release-artifacts
+          cp build/compose/binaries/main-release/deb/ttsroad_*_amd64.deb build/release-artifacts/
+
+      - name: Upload the Linux artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-linux
+          path: build/release-artifacts/*.deb
+          if-no-files-found: error
+
+      # The application image, not the .deb, because syft reads the bundled jars and runtime
+      # directly. One SBOM covers every platform: the same jars ship in all three installers.
+      - name: Generate the SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: build/compose/binaries/main-release/app/TTSRoad
+          artifact-name: ttsroad-${{ needs.verify.outputs.version }}-sbom.spdx.json
+          output-file: ttsroad-${{ needs.verify.outputs.version }}-sbom.spdx.json
+          upload-release-assets: false
+
+      - name: Upload the SBOM
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-sbom
+          path: ttsroad-${{ needs.verify.outputs.version }}-sbom.spdx.json
+          if-no-files-found: error
+
+  # A published .deb that has never been installed is an untested .deb. This is the same clean
+  # container check CI runs, against the artifact that is about to be released.
+  linux-lifecycle:
+    name: Install, upgrade and uninstall the release .deb
+    needs: [verify, linux]
+    runs-on: ubuntu-24.04
+    container: ubuntu:24.04
+    timeout-minutes: 20
+    steps:
+      - name: Check out verification scripts
+        uses: actions/checkout@v7
+
+      - name: Download the Linux artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: release-linux
+          path: build/release-artifacts
+
+      - name: Install clean-container test tools
+        run: |
+          apt-get update
+          apt-get install -y ca-certificates python3 xvfb xauth
+
+      # The release package is installed over itself: same version, same revision. That still
+      # exercises install, the packaged login window, dpkg's upgrade path and removal.
+      - name: Verify install, packaged login, upgrade and uninstall
+        run: |
+          package=$(find build/release-artifacts -name 'ttsroad_*_amd64.deb' -print -quit)
+          test -n "$package"
+          ./packaging/linux/verify-install-lifecycle.sh "$package" "$package"
+
+  windows:
+    name: Windows .msi
+    needs: verify
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out
+        uses: actions/checkout@v7
+
+      - name: Validate the Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v6
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      # jpackage shells out to WiX for an MSI and fails with a bare "candle.exe not found" when it
+      # is absent. Runner images have dropped it before, so install it rather than assume it.
+      - name: Ensure WiX 3 is present
+        shell: pwsh
+        run: |
+          if (-not (Get-Command candle.exe -ErrorAction SilentlyContinue)) {
+            choco install wixtoolset --no-progress --yes
+            $wix = Join-Path ${env:ProgramFiles(x86)} 'WiX Toolset v3.14\bin'
+            if (Test-Path $wix) { Add-Content $env:GITHUB_PATH $wix }
+          }
+
+      # bash rather than pwsh so the Gradle invocation is character-for-character the one the other
+      # two platforms run, including GRADLE_FLAGS word splitting.
+      - name: Compile and unit tests
+        shell: bash
+        run: ./gradlew ${{ env.GRADLE_FLAGS }} clean check
+
+      - name: Build the release .msi
+        shell: bash
+        run: ./gradlew ${{ env.GRADLE_FLAGS }} packageReleaseMsi
+
+      - name: Smoke test the release image
+        shell: bash
+        run: TTSROAD_SMOKE_TEST=1 ./gradlew ${{ env.GRADLE_FLAGS }} runReleaseDistributable
+
+      - name: Upload the Windows artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-windows
+          path: build/compose/binaries/main-release/msi/*.msi
+          if-no-files-found: error
+
+  macos:
+    name: macOS .dmg
+    needs: verify
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out
+        uses: actions/checkout@v7
+
+      - name: Validate the Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v6
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Compile and unit tests
+        run: ./gradlew ${{ env.GRADLE_FLAGS }} clean check
+
+      - name: Build the release .dmg
+        run: ./gradlew ${{ env.GRADLE_FLAGS }} packageReleaseDmg
+
+      - name: Smoke test the release image
+        run: TTSROAD_SMOKE_TEST=1 ./gradlew ${{ env.GRADLE_FLAGS }} runReleaseDistributable
+
+      - name: Upload the macOS artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-macos
+          path: build/compose/binaries/main-release/dmg/*.dmg
+          if-no-files-found: error
+
+  publish:
+    name: Publish the draft release
+    needs: [verify, linux, linux-lifecycle, windows, macos]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      # contents: write creates the release. The two id-token/attestations scopes are what
+      # actions/attest-build-provenance needs; nothing here holds a signing key of its own.
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Check out
+        uses: actions/checkout@v7
+
+      - name: Download every built artifact
+        uses: actions/download-artifact@v7
+        with:
+          path: downloads
+
+      - name: Collect the release assets
+        id: collect
+        run: |
+          mkdir -p release
+          find downloads -type f \( -name '*.deb' -o -name '*.msi' -o -name '*.dmg' -o -name '*sbom*.json' \) \
+            -exec cp {} release/ \;
+          cp downloads/release-notes/release-notes.md release-notes.md
+          cp packaging/linux/LICENSE.txt release/LICENSE.txt
+          # Each format is built on its own OS, so a missing one means that job produced nothing.
+          for extension in deb msi dmg; do
+            count=$(find release -name "*.$extension" | wc -l)
+            if [ "$count" -ne 1 ]; then
+              echo "expected exactly one .$extension asset, found $count" >&2
+              exit 1
+            fi
+          done
+          ( cd release && sha256sum ./* > SHA256SUMS )
+          cat release/SHA256SUMS
+
+      # Signed provenance for the installers themselves. The SBOM, checksums and licence file are
+      # descriptions of those artifacts, not the artifacts a user executes.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            release/*.deb
+            release/*.msi
+            release/*.dmg
+
+      # A dry run reaches this point having built, tested and checksummed everything, and stops
+      # without creating a release. A failed gate above never gets here at all.
+      - name: Create the draft release
+        if: needs.verify.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ needs.verify.outputs.tag }}" \
+            --draft \
+            --title "TTSRoad Desktop ${{ needs.verify.outputs.version }}" \
+            --notes-file release-notes.md \
+            --target "${{ github.sha }}" \
+            release/*
+
+      - name: Report a dry run
+        if: needs.verify.outputs.publish != 'true'
+        run: |
+          echo "Dry run for ${{ needs.verify.outputs.tag }}: artifacts built, verified and checksummed."
+          echo "Nothing was published. Push the tag to publish a draft release."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to TTSRoad Desktop are recorded here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Versioning and tag policy
+
+- `ttsroad.version` in `gradle.properties` is the one application version. A release tag is that
+  version prefixed with `v`, so `1.0.1` is released as `v1.0.1`. The release workflow refuses to
+  publish when the two disagree.
+- MAJOR must stay at or above `1`, because jpackage rejects a `0` major in installer metadata.
+- `ttsroad.debRevision` is Debian packaging metadata, never a second application version. A
+  packaging-only rebuild moves `1.0.1-1` to `1.0.1-2` and does **not** get its own tag or entry
+  here — the application did not change.
+- Every released version needs a section below whose heading matches the tag. The workflow reads
+  its body as the release notes and fails the release when the section is missing.
+
+## [Unreleased]
+
+## [1.0.1] - 2026-08-10
+
+First packaged release: a feature-complete, Linux-native desktop client for a private TTSRoad
+server.
+
+### Added
+
+- Sign-in with two-factor authentication, with the bearer token held in the OS credential store
+  (Windows Credential Manager, macOS Keychain, freedesktop Secret Service) and never on disk.
+- Library browsing, search, fiction details and chapter lists with filtering, sorting, bulk
+  selection and optimistic mark-played.
+- Queue playback through GStreamer, falling back to Java Sound where GStreamer is absent, with
+  auto-advance, progress saving, a typed retry ladder and explicit session-expiry handling.
+- Listening preferences, a sleep timer with fade, local playback history, MPRIS/media keys and a
+  keyboard shortcut table.
+- Offline downloads under the XDG data directory and a bounded streaming cache under the XDG cache
+  directory, both namespaced by server and account identity.
+- An audio-synchronized read-along reader with ETag-cached documents, media-time highlighting,
+  word-click seeking and synchronized reader appearance.
+- Server capability discovery, so an older server keeps baseline login, library and playback
+  behaviour and unavailable features are never advertised.
+- A Debian package with a bundled JDK 25 runtime, desktop entry, upgrade-safe revisioning and XDG
+  rotating logs, plus credential-safe `--version` and `--diagnostics` commands.
+
+[Unreleased]: https://github.com/jonarihen/TTSRoad-Desktop/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/jonarihen/TTSRoad-Desktop/releases/tag/v1.0.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,10 @@ Single test class or method — the `test` task uses the JUnit Platform:
 **Tests need a display.** `tasks.test` sets `java.awt.headless=false` because Skiko renders through
 AWT even off-screen. Locally they use your desktop; headless, prefix with `xvfb-run -a`.
 
+**Tests need an unencrypted filesystem.** eCryptfs caps filenames at 143 bytes and a few generated
+test class files exceed it, so `check` fails with `error while writing … (Permission denied)` under
+an encrypted home. Build from a path on ext4 instead.
+
 Reproduce a CI failure locally — CI adds two gates that local builds do not have:
 
 ```bash
@@ -206,6 +210,21 @@ There is deliberately no file-based fallback — encrypting with a key stored be
 plaintext with extra steps. `session.json` holds non-secret hints plus the keyring entry id, written
 atomically and owner-only.
 
+### Releases and update checking
+
+A release tag is `v` plus `ttsroad.version`; `release.yml` refuses to publish when the tag,
+`gradle.properties` and the `CHANGELOG.md` section disagree, and
+`packaging/release/changelog-section.sh` is both the notes extractor and that gate. Each installer
+builds on its own OS; only the `.deb` gets the clean-container install/upgrade/uninstall run. The
+release is created as a **draft**, and `workflow_dispatch` is the dry run that publishes nothing.
+
+The update check reads the *public* GitHub release feed **over the shared `OkHttpClient`** — that is
+what keeps the bearer token off api.github.com, via the same origin rule. It never installs: a
+download is verified against the release's `SHA256SUMS`, a mismatch is deleted and never opened, and
+the verified file goes to the desktop's own handler. No `sudo`, no package manager call. Throttling
+is once per launch and once per day, dismissal is per version, and a manual check bypasses both. A
+release with no asset for this platform/architecture is announced *without* a download button.
+
 ### Server capability discovery
 
 `GET /api/mobile/capabilities` is unauthenticated and additive. Only a literal JSON `true` enables a
@@ -292,7 +311,8 @@ credential storage and capability discovery (0002), the playback engine (0002-pl
 device sessions and Settings (0003), navigation (0004), chapter browsing (0005), and listening
 preferences / sleep timer / MPRIS / shortcuts (0006). Read the relevant one before changing any of
 the invariants above; offline storage and caching are in 0007, read-along is in 0008, and Debian
-packaging/operations are in 0009. They exist because the alternative was tried or measured.
+packaging/operations are in 0009, and releases/update checking are in 0010. They exist because
+the alternative was tried or measured.
 
 ## CI
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Built with Compose for Desktop — real Skia-rendered UI, real OS installers, no
 ![Kotlin](https://img.shields.io/badge/Kotlin-2.4.10-7F52FF?logo=kotlin&logoColor=white)
 ![Compose Multiplatform](https://img.shields.io/badge/Compose%20Multiplatform-1.11.1-4285F4?logo=jetpackcompose&logoColor=white)
 ![JDK](https://img.shields.io/badge/JDK-25-ED8B00?logo=openjdk&logoColor=white)
-![Gradle](https://img.shields.io/badge/Gradle-9.6.1-02303A?logo=gradle&logoColor=white)
+![Gradle](https://img.shields.io/badge/Gradle-9.7.0-02303A?logo=gradle&logoColor=white)
 ![Platforms](https://img.shields.io/badge/platforms-Windows%20%7C%20macOS%20%7C%20Linux-informational)
 ![Status](https://img.shields.io/badge/status-alpha-orange)
 
@@ -22,7 +22,7 @@ Built with Compose for Desktop — real Skia-rendered UI, real OS installers, no
 ## ✨ Highlights
 
 - 🖥️ **Truly native UI** — rendered with Skia via JetBrains Compose Multiplatform (Material 3), *not* a web view.
-- 📦 **Real installers** — ships as `.msi` (Windows), `.dmg` (macOS), and `.deb` (Linux) with a **bundled Java runtime**, so end users never install Java.
+- 📦 **Real installers** — ships as `.deb` (Linux), `.msi` (Windows) and `.dmg` (macOS) with a **bundled Java runtime**, so end users never install Java. Linux is the platform with a clean-machine install/upgrade/uninstall test; see [Releases](#-releases).
 - 🔗 **Shares the mobile API** — talks to the same `/api/mobile/*` endpoints as the Android app, and wears the same **AARIS** design language.
 - 🔊 **Real audio playback** — bearer-protected chapter MP3s are decoded in pure JVM and streamed to the system audio device.
 
@@ -144,7 +144,7 @@ launches of the packaged app, and an inspected/installed `packageReleaseDeb` on 
 | Component | Version | Where it is declared |
 | --- | --- | --- |
 | JDK (build **and** bundled runtime) | **25** | `gradle/libs.versions.toml` → `jdk`, applied as `kotlin { jvmToolchain(25) }` |
-| Gradle | **9.6.1** | `gradle/wrapper/gradle-wrapper.properties` (SHA-256 pinned) |
+| Gradle | **9.7.0** | `gradle/wrapper/gradle-wrapper.properties` (SHA-256 pinned) |
 | Kotlin | **2.4.10** | `libs.versions.toml` → `kotlin` (also the Compose *compiler* plugin version) |
 | Compose Multiplatform | **1.11.1** | `libs.versions.toml` → `composeMultiplatform` |
 | Compose Material 3 | 1.9.0 | independently versioned; 1.9.0 is the newest **stable** |
@@ -239,8 +239,42 @@ reset it to `1` when `ttsroad.version` changes. APT compares the combined `VERSI
    native linkage, desktop entry and safe diagnostics, then exercise clean install, login-window
    probe, in-place upgrade and uninstall in an Ubuntu 24.04 container.
 
+7. Dependency review on pull requests, failing on a high-severity advisory. It needs GitHub's
+   dependency graph, so it skips itself while the repository is private.
+
 Dependency updates arrive as weekly grouped Dependabot PRs
-([`.github/dependabot.yml`](.github/dependabot.yml)).
+([`.github/dependabot.yml`](.github/dependabot.yml)). Response times for a security report are in
+[`docs/SECURITY.md`](docs/SECURITY.md).
+
+> **Running the tests on an encrypted home directory.** eCryptfs (Linux Mint's "encrypt my home
+> folder" option) caps a filename at 143 bytes, and a few generated test class files are longer
+> than that. `./gradlew check` then fails with `error while writing … (Permission denied)`. Build
+> from a path on an unencrypted filesystem instead — CI is unaffected.
+
+## 🚢 Releases
+
+A release is a tag: `ttsroad.version` prefixed with `v`, so `1.0.1` ships as `v1.0.1`.
+[`.github/workflows/release.yml`](.github/workflows/release.yml) refuses to publish when the tag and
+`gradle.properties` disagree, or when [`CHANGELOG.md`](CHANGELOG.md) has no entry for that version.
+
+Each installer is built on its own operating system. The Linux `.deb` is additionally inspected and
+then installed, upgraded and removed in a clean Ubuntu 24.04 container before anything is published;
+the `.msi` and `.dmg` are built and smoke-tested but have no clean-machine install test. The publish
+job attaches SHA-256 checksums, an SBOM and signed build provenance, and creates the release as a
+**draft** — publishing stays a human action.
+
+Run the workflow manually (`workflow_dispatch`) for a dry run: identical build and verification,
+nothing published.
+
+### Update checking
+
+Settings → **Updates & About** checks the public GitHub release feed at most once per launch and
+once per day, and can be turned off. A version you dismiss is not announced again until a newer one
+appears; pressing **CHECK NOW** ignores all of that.
+
+A download is verified against the release's published `SHA256SUMS` and only then handed to your
+desktop's installer. A file that fails verification is deleted and never opened. The application
+never runs `sudo` and never installs anything itself.
 
 ## 🗂️ Project layout
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,57 @@
+# Security policy
+
+## Supported versions
+
+The most recent released version is supported. There is no long-term-support branch: fixes ship in
+a new release rather than as patches to an older one.
+
+## Reporting a vulnerability
+
+Report privately through GitHub's **Security → Report a vulnerability** form on this repository, or
+by email to the address in the package `Maintainer` field. Please do not open a public issue for
+anything that affects credential handling, the update path or the packaged runtime.
+
+Include the application version (`TTSRoad --version`), the operating system, and what an attacker
+would gain. A `--diagnostics` export is useful and is redacted by design — but read it before
+attaching it.
+
+## Response times
+
+These are the commitments, measured from a report being acknowledged:
+
+| Severity | Acknowledge | Fix released |
+| --- | --- | --- |
+| Critical — credential disclosure, remote code execution, update-path compromise | 2 working days | 7 days |
+| High — privilege or origin boundary crossed, local data disclosure | 5 working days | 30 days |
+| Moderate and low | 10 working days | next scheduled release |
+
+A dependency advisory follows the same table, judged by its severity *in this application* rather
+than by its headline score: a vulnerability in a code path the desktop client never executes is not
+critical here.
+
+## Dependency updates
+
+- Dependabot opens grouped Gradle and GitHub Actions pull requests weekly. Kotlin and the Compose
+  compiler plugin are grouped because their versions must match.
+- `dependency-review-action` runs on every pull request and fails on a high-severity advisory. It
+  requires GitHub's dependency graph, so it is inactive while the repository is private.
+- A security update that is not blocked by a failing test is merged as soon as CI is green, ahead of
+  feature work.
+
+## What the application protects
+
+- **The bearer token** lives only in the OS credential store — Windows Credential Manager, macOS
+  Keychain, freedesktop Secret Service. There is deliberately no encrypted-file fallback; where no
+  keyring exists the session is memory-only and the UI says so.
+- **The token's origin** is enforced in one place. `AuthInterceptor` attaches it only when scheme,
+  host and port match the signed-in server, which is what keeps it off audio URLs, cover images and
+  the GitHub update feed.
+- **Logs and diagnostics** pass through one redaction boundary before they are written or shown.
+- **Downloaded updates** are verified against the release's published SHA-256 before being handed to
+  the desktop, and the application never installs anything itself.
+
+## What it does not do
+
+There is no telemetry and no crash reporting. The application makes no network request that is not
+either to the server the user signed in to or to the public release feed described in
+[`docs/adr/0010-releases-and-update-checking.md`](adr/0010-releases-and-update-checking.md).

--- a/docs/adr/0010-releases-and-update-checking.md
+++ b/docs/adr/0010-releases-and-update-checking.md
@@ -1,0 +1,108 @@
+# 10. Releases, update checking and the security update process
+
+Date: 2026-08-10
+
+## Status
+
+Accepted.
+
+## Context
+
+Phase 9 produced an installable `.deb`, but nothing published it. A release had to become an
+operation that is repeatable, verifiable after the fact, and safe to hand to a user — including the
+part where the application tells that user a newer build exists.
+
+The application version already has exactly one source (`ttsroad.version`). Everything below exists
+to keep the release from introducing a second one, and to make sure a published artifact is one
+that was actually tested.
+
+## Decision
+
+### One version, one tag, one changelog section
+
+A release tag is the application version prefixed with `v`. The release workflow resolves the
+version from `gradle.properties`, refuses to continue when the tag disagrees, and refuses again when
+`CHANGELOG.md` has no non-empty section for it. `packaging/release/changelog-section.sh` is both the
+extractor and that second gate, so the notes GitHub publishes are the notes a human wrote.
+
+`ttsroad.debRevision` is deliberately outside this. A packaging-only rebuild moves the Debian
+revision without a tag, because the application did not change.
+
+### Publish only what was tested, and prove it afterwards
+
+Each installer is built on its own operating system, because jpackage does not cross-compile. The
+Linux job additionally inspects the package and a separate clean-container job installs, upgrades
+and removes it before anything is published — a `.deb` that has never been installed is an untested
+`.deb`. The publish job then computes SHA-256 checksums over the collected assets, attaches an SBOM
+generated from the release application image, and requests signed build provenance for the three
+installers.
+
+Permissions are read-only at the top of the workflow; only the publishing job widens them, and only
+to `contents: write` plus the two scopes the attestation action requires. No signing secret exists,
+so no job can leak one. The release is created as a **draft**: publishing stays a human action after
+a human has looked at the assets.
+
+`workflow_dispatch` runs the identical build and verification and stops before creating anything,
+which is the documented dry run.
+
+### The update check reads a public release feed and installs nothing
+
+The application asks `api.github.com` for the latest release. This is the reason the repository is
+public: an authenticated feed would require shipping a credential inside a desktop application,
+which is not a secret at all.
+
+Three properties are load-bearing:
+
+- **It uses the shared `OkHttpClient`.** `AuthInterceptor` attaches the TTSRoad bearer token only
+  when scheme, host and port match the signed-in server, so the GitHub request carries no
+  credential. A second client would put this call outside the rule that makes that true.
+- **It never installs.** A downloaded file is verified against the release's published
+  `SHA256SUMS` and, only then, handed to the desktop's own handler. A mismatch deletes the file and
+  never opens it. The application does not run `sudo`, `dpkg` or any package manager: installing a
+  system package is an authorisation the desktop's installer asks for, not one an audiobook player
+  should take.
+- **It is quiet.** At most one automatic check per launch and per day; a version the user dismissed
+  is not announced again until a newer one exists; automatic checking can be turned off entirely,
+  and a manual check ignores all of it because the user just asked.
+
+A release with no asset for this platform and architecture is still announced, with no download
+button. An aarch64 Linux desktop is told a version exists rather than handed an `amd64` package
+`dpkg` would refuse.
+
+Failures are deliberately vague in the UI ("Could not reach the update server") because a response
+body can contain anything; the detail goes to the redacted log instead.
+
+### Dependency and security updates
+
+Dependabot already opens weekly grouped pull requests for Gradle dependencies and actions. CI adds
+`dependency-review-action` on pull requests, failing on a high-severity advisory. That action needs
+GitHub's dependency graph, so the job skips itself while the repository is private rather than
+failing every pull request.
+
+The response times the project commits to are in `docs/SECURITY.md`.
+
+## Consequences
+
+- The repository must be public for the update check to work. A private repository degrades to
+  "could not reach the update server" rather than misbehaving, but the feature is off in practice.
+- Windows and macOS release jobs exist because the README claims those platforms. Neither installer
+  has a clean-machine install test the way the `.deb` does; they build and smoke-test the release
+  image only. That difference is stated in the README rather than papered over.
+- The SBOM is generated from the Linux application image. The same jars ship in all three
+  installers, so one SBOM describes the application; it does not describe the Windows or macOS
+  bundled runtimes.
+
+## Rejected alternatives
+
+- **Checking a version endpoint on the TTSRoad server.** It would work for a private repository and
+  reuse existing auth, but it makes the desktop client's update path depend on a server change and
+  on every deployment being current. The client would also have to trust the server to describe an
+  artifact it does not host.
+- **Silent or automatic installation.** It requires either running as root or holding a privileged
+  helper. Neither is proportionate for this application, and both turn a checksum bug into a
+  privileged-execution bug.
+- **Publishing directly rather than as a draft.** A draft costs one click and makes "the gate
+  passed but the notes are wrong" recoverable without deleting a published release.
+- **A separate HTTP client for GitHub.** Simpler to reason about in isolation, but it would create a
+  second outbound path not covered by the interceptor's origin rule — the exact thing that rule
+  exists to prevent.

--- a/packaging/linux/finalize-deb.sh
+++ b/packaging/linux/finalize-deb.sh
@@ -58,6 +58,9 @@ fi
 if ! grep -q '^StartupWMClass=' "$desktop"; then
     sed -i '/^Categories=/a StartupWMClass=dk-perspektiva-ttsroad-desktop-MainKt' "$desktop"
 fi
+# jpackage always emits MimeType, empty when no association was requested. An empty key is a
+# declaration that this application handles nothing, which is not the same as saying nothing.
+sed -i '/^MimeType=[[:space:]]*$/d' "$desktop"
 
 # jpackage keeps the desktop entry inside its own /opt tree and registers it from postinst with
 # `xdg-desktop-menu install`, under `set -e`. That call exits non-zero wherever no writable system

--- a/packaging/release/changelog-section.sh
+++ b/packaging/release/changelog-section.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Print the CHANGELOG body for one version, for use as generated release notes.
+#
+# The release workflow uses this as a gate as much as a formatter: a version with no section, or
+# with an empty one, exits non-zero and stops the release before anything is published.
+set -euo pipefail
+
+fail() {
+    echo "Changelog extraction failed: $*" >&2
+    exit 1
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    echo "usage: $0 <version> [changelog-path]" >&2
+    exit 2
+fi
+
+version=$1
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+changelog=${2:-$(cd -- "$script_dir/../.." && pwd)/CHANGELOG.md}
+
+[[ -f $changelog ]] || fail "no changelog at $changelog"
+
+# Match "## [1.0.1]" with or without a trailing date, and stop at the next second-level heading.
+# The link-reference block at the bottom of the file starts with "[", never "#", so it is only
+# reached when the requested section is the last one; awk drops those lines explicitly.
+section=$(
+    awk -v version="$version" '
+        $0 ~ "^## \\[" version "\\]" { collecting = 1; next }
+        collecting && /^## / { exit }
+        collecting && /^\[[^]]+\]:/ { next }
+        collecting { print }
+    ' "$changelog"
+)
+
+# A section that is only blank lines is a section nobody wrote.
+[[ -n ${section//[[:space:]]/} ]] || fail "CHANGELOG.md has no entry for $version"
+
+# Trim leading and trailing blank lines without touching the interior spacing.
+printf '%s\n' "$section" | awk '
+    { line[NR] = $0; if ($0 ~ /[^[:space:]]/) { if (!first) first = NR; last = NR } }
+    END { for (i = first; i <= last; i++) print line[i] }
+'

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -85,6 +85,7 @@ import dk.perspektiva.ttsroad.desktop.ui.ShortcutsDialog
 import dk.perspektiva.ttsroad.desktop.ui.WindowSizeClass
 import dk.perspektiva.ttsroad.desktop.ui.hasSession
 import dk.perspektiva.ttsroad.desktop.ui.rememberChapterDownloads
+import dk.perspektiva.ttsroad.desktop.ui.UpdateStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.rememberStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.windowSizeClassFor
 
@@ -105,6 +106,11 @@ fun App(container: AppContainer = remember { AppContainer() }) {
     // Hoisted above navigation on purpose: `when (destination)` disposes the screen it leaves, so a
     // holder created inside SettingsScreen would drop the selected pane and the loaded device list
     // every time the user glanced at the library.
+    // Hoisted above navigation like the settings holder, so leaving the About pane and coming
+    // back shows the answer the last check produced instead of checking again.
+    val updates = rememberStateHolder(container) {
+        UpdateStateHolder(container.updateChecker, container.updateDownloader, container.updateSettings)
+    }
     val settings = rememberStateHolder(repository, sessionStore) {
         SettingsStateHolder(repository, sessionStore, offlineStorage = container.downloads)
     }
@@ -346,6 +352,7 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                     // can do by construction.
                                     canChangeSpeed = playerState.canChangeSpeed,
                                     canSkipSilence = playerState.canSkipSilence,
+                                    updates = updates,
                                     // Keeps the destination and the open pane in step, so the
                                     // Devices deep link and the in-screen pane list are the same
                                     // thing rather than two competing notions of "where am I".

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/di/AppContainer.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/di/AppContainer.kt
@@ -1,5 +1,6 @@
 package dk.perspektiva.ttsroad.desktop.di
 
+import dk.perspektiva.ttsroad.desktop.data.AppDirectories
 import dk.perspektiva.ttsroad.desktop.data.FilePlaybackHistoryStore
 import dk.perspektiva.ttsroad.desktop.data.FilePlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.FileSessionStore
@@ -28,6 +29,13 @@ import dk.perspektiva.ttsroad.desktop.player.PlaybackEngine
 import dk.perspektiva.ttsroad.desktop.player.QueuePlaybackController
 import dk.perspektiva.ttsroad.desktop.security.CredentialStore
 import dk.perspektiva.ttsroad.desktop.security.CredentialStores
+import dk.perspektiva.ttsroad.desktop.update.FileUpdateSettingsStore
+import dk.perspektiva.ttsroad.desktop.update.GitHubReleaseSource
+import dk.perspektiva.ttsroad.desktop.update.ReleaseSource
+import dk.perspektiva.ttsroad.desktop.update.UpdateChecker
+import dk.perspektiva.ttsroad.desktop.update.UpdateDownloader
+import dk.perspektiva.ttsroad.desktop.update.UpdateSettingsStore
+import java.io.File
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -111,6 +119,13 @@ class AppContainer(
         { session, client, repo, d -> DownloadCoordinator(session, client, repo, dispatcher = d.io) },
     // A store rather than a file path, so a test never writes into the user's config directory.
     windowPreferencesStore: WindowPreferencesStore = FileWindowPreferencesStore(),
+    /**
+     * When this build last looked for a newer one, and which version was dismissed. Machine-local
+     * like the listening preferences: which build is installed is a property of this desktop.
+     */
+    val updateSettings: UpdateSettingsStore = FileUpdateSettingsStore(),
+    // A factory so a test substitutes the release feed instead of reaching api.github.com.
+    releaseSourceFactory: (OkHttpClient) -> ReleaseSource = { GitHubReleaseSource(it) },
 ) : AutoCloseable {
     val httpClient: OkHttpClient = httpClientFactory(sessionStore)
     val repository: TtsRoadRepository = repositoryFactory(sessionStore, httpClient, dispatchers)
@@ -204,6 +219,26 @@ class AppContainer(
 
     /** Remembered window size/position/maximised state. Never holds anything transient or secret. */
     val windowPreferences: WindowPreferencesStore = windowPreferencesStore
+
+    /**
+     * Looks for a newer published build. On the shared HTTP client on purpose: the auth
+     * interceptor's same-origin rule is what keeps the TTSRoad bearer token off api.github.com,
+     * and a second client would put this call outside that rule.
+     */
+    val updateChecker: UpdateChecker = UpdateChecker(
+        source = releaseSourceFactory(httpClient),
+        settingsStore = updateSettings,
+        clock = clock,
+    )
+
+    /**
+     * Downloads go to the cache root: a rebuildable installer is not user data, and one left behind
+     * by an update the user never ran should be evictable.
+     */
+    val updateDownloader: UpdateDownloader = UpdateDownloader(
+        client = httpClient,
+        targetDirectory = File(AppDirectories.cacheDir(), "updates"),
+    )
 
     /** Called when the main window closes; without it the playback job and temp file outlive it. */
     override fun close() {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
@@ -40,6 +40,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -65,6 +67,8 @@ import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferences
 import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
+import dk.perspektiva.ttsroad.desktop.data.AppDirectories
+import dk.perspektiva.ttsroad.desktop.update.UpdateStatus
 import dk.perspektiva.ttsroad.desktop.data.SessionState
 import dk.perspektiva.ttsroad.desktop.data.SessionStore
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
@@ -114,6 +118,11 @@ fun SettingsScreen(
     canSkipSilence: Boolean = false,
     // Injected so "expires in 42 days" can be asserted without the test depending on wall time.
     nowMs: () -> Long = System::currentTimeMillis,
+    /**
+     * The update check, or null where there is none — a preview or a screen test. Null keeps
+     * the About pane from claiming an update state nothing checked.
+     */
+    updates: UpdateStateHolder? = null,
 ) {
     val ui by holder.state.collectAsState()
     val session by sessionStore.session.collectAsState()
@@ -152,7 +161,7 @@ fun SettingsScreen(
                         SettingsSection.Devices -> DevicesPane(ui, session, holder, nowMs)
                         SettingsSection.Playback -> PlaybackPane(preferences, canChangeSpeed, canSkipSilence)
                         SettingsSection.Offline -> OfflinePane(ui.offline, holder)
-                        SettingsSection.About -> AboutPane(session, capabilities, sessionStore)
+                        SettingsSection.About -> AboutPane(session, capabilities, sessionStore, updates)
                     }
                 }
             }
@@ -809,6 +818,7 @@ private fun AboutPane(
     session: SessionState,
     capabilities: ServerCapabilities,
     sessionStore: SessionStore,
+    updates: UpdateStateHolder? = null,
 ) {
     PaneTitle("Updates & About", "Build, licences and diagnostics")
 
@@ -819,12 +829,12 @@ private fun AboutPane(
         RowDivider()
         SettingRow("Release channel", "Installed build")
         RowDivider()
-        // Honest rather than aspirational: there is no updater in this build, so claiming to be
-        // "up to date" would be a claim nothing checked.
-        SettingRow("Update check", "Not available — install a newer build to update")
-        RowDivider()
         SettingRow("Java runtime", "${System.getProperty("java.vm.name")} ${System.getProperty("java.version")}")
     }
+
+    // Absent only where the caller supplied no updater — a preview or a screen test. Claiming to
+    // be "up to date" without an updater would be a claim nothing checked.
+    if (updates != null) UpdateCard(updates)
 
     MetaText(text = "// Open source", color = AarisColor.Accent)
     SettingsCard {
@@ -847,12 +857,135 @@ private fun AboutPane(
             color = AarisColor.Muted,
         )
     }
-    OutlinedButton(
-        onClick = { copyToClipboard(diagnostics) },
-        shape = RectangleShape,
-        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-    ) { Text("COPY DIAGNOSTICS") }
+    var exported by remember { mutableStateOf<String?>(null) }
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        OutlinedButton(
+            onClick = { copyToClipboard(diagnostics) },
+            shape = RectangleShape,
+            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+        ) { Text("COPY DIAGNOSTICS") }
+        OutlinedButton(
+            onClick = { exported = exportDiagnostics(diagnostics)?.toString() },
+            shape = RectangleShape,
+            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+        ) { Text("EXPORT DIAGNOSTICS") }
+    }
+    exported?.let { path ->
+        Text(
+            "Saved to $path",
+            style = MaterialTheme.typography.bodySmall,
+            color = AarisColor.Muted,
+        )
+    }
 }
+
+/**
+ * The update card: what the last check found, and the two actions that follow from it.
+ *
+ * Download is offered only when the release actually carries a package for this machine. A release
+ * that does not is still announced — with a link rather than a button, because a download that
+ * cannot be installed here is worse than no button at all.
+ */
+@Composable
+private fun UpdateCard(updates: UpdateStateHolder) {
+    val state by updates.state.collectAsState()
+
+    // Once per entry to the pane. The checker owns the throttle, so this is not a request per view.
+    LaunchedEffect(Unit) { updates.checkAutomatically() }
+
+    MetaText(text = "// Updates", color = AarisColor.Accent)
+    SettingsCard {
+        val status = state.status
+        SettingRow(
+            "Update check",
+            when (status) {
+                is UpdateStatus.Checking -> "Checking…"
+                is UpdateStatus.UpToDate -> "${BuildInfo.VERSION} is the newest release"
+                is UpdateStatus.Available -> "Version ${status.release.version} is available"
+                is UpdateStatus.Failed -> status.reason
+                is UpdateStatus.Unknown -> "Not checked yet"
+            },
+        )
+        RowDivider()
+        ToggleRow(
+            label = "Check automatically",
+            description = "At most once a day, and once per launch.",
+            checked = state.automatic,
+            onCheckedChange = updates::setAutomatic,
+        )
+    }
+
+    state.available?.let { release ->
+        if (release.notes.isNotBlank()) {
+            SettingsCard {
+                Text(
+                    release.notes,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = AarisColor.Muted,
+                )
+            }
+        }
+    }
+
+    state.downloadError?.let { error ->
+        Text(error, style = MaterialTheme.typography.bodyMedium, color = AarisColor.Danger)
+    }
+    state.downloadedName?.let { name ->
+        Text(
+            "Downloaded and verified $name. Your desktop's installer takes it from here.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = AarisColor.Muted,
+        )
+    }
+
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        OutlinedButton(
+            onClick = updates::checkNow,
+            enabled = state.status !is UpdateStatus.Checking,
+            shape = RectangleShape,
+            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+        ) { Text("CHECK NOW") }
+
+        if (state.available != null) {
+            if (state.downloadable != null) {
+                Button(
+                    onClick = updates::download,
+                    enabled = !state.isDownloading,
+                    shape = RectangleShape,
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                ) { Text(if (state.isDownloading) "DOWNLOADING…" else "DOWNLOAD") }
+            }
+            TextButton(
+                onClick = updates::dismiss,
+                shape = RectangleShape,
+                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+            ) { Text("DISMISS") }
+        }
+    }
+    if (state.available != null && state.downloadable == null) {
+        Text(
+            "This release publishes nothing for this platform and architecture.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = AarisColor.Muted,
+        )
+    }
+}
+
+/**
+ * Writes the redacted diagnostics block to a file the user can attach to a report.
+ *
+ * The same text the Copy button produces, so there is one redaction boundary rather than two. A
+ * failure returns null instead of throwing: not being able to write a support file is not a reason
+ * to take Settings down.
+ */
+private fun exportDiagnostics(diagnostics: String): java.io.File? = runCatching {
+    val directory = java.io.File(AppDirectories.cacheDir(), "diagnostics")
+    directory.mkdirs()
+    val stamp = java.time.Instant.now().toString().replace(':', '-').substringBefore('.')
+    val file = java.io.File(directory, "ttsroad-diagnostics-$stamp.txt")
+    file.writeText(diagnostics)
+    file
+}.getOrNull()
 
 /**
  * The block a user can paste into a bug report.

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/UpdateStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/UpdateStateHolder.kt
@@ -1,0 +1,109 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.update.DownloadOutcome
+import dk.perspektiva.ttsroad.desktop.update.LatestRelease
+import dk.perspektiva.ttsroad.desktop.update.ReleaseAsset
+import dk.perspektiva.ttsroad.desktop.update.UpdateChecker
+import dk.perspektiva.ttsroad.desktop.update.UpdateDownloader
+import dk.perspektiva.ttsroad.desktop.update.UpdateSettingsStore
+import dk.perspektiva.ttsroad.desktop.update.UpdateStatus
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/** What the About pane draws. Downloading is separate from checking; both can be in flight once. */
+data class UpdateUiState(
+    val status: UpdateStatus = UpdateStatus.Unknown,
+    val automatic: Boolean = true,
+    val isDownloading: Boolean = false,
+    /** Set once a verified installer is on disk and has been handed to the desktop. */
+    val downloadedName: String? = null,
+    val downloadError: String? = null,
+) {
+    val available: LatestRelease?
+        get() = (status as? UpdateStatus.Available)?.release
+
+    val downloadable: ReleaseAsset?
+        get() = (status as? UpdateStatus.Available)?.asset
+}
+
+/**
+ * Drives the update check for the About pane.
+ *
+ * The screen never calls the checker or the downloader directly, so the pane stays a rendering of
+ * one state value and every decision — throttled, dismissed, verified, rejected — is exercised in
+ * the holder's own tests rather than only through the Compose runtime.
+ */
+class UpdateStateHolder(
+    private val checker: UpdateChecker,
+    private val downloader: UpdateDownloader,
+    settingsStore: UpdateSettingsStore,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : StateHolder(dispatcher) {
+
+    private val _state = MutableStateFlow(UpdateUiState(automatic = settingsStore.settings.value.automatic))
+    val state: StateFlow<UpdateUiState> = _state.asStateFlow()
+
+    /**
+     * The once-per-launch check. Safe to call on every entry to the pane: the checker itself owns
+     * the throttle, and a throttled call answers [UpdateStatus.Unknown] without a request.
+     */
+    fun checkAutomatically() {
+        check(manual = false)
+    }
+
+    fun checkNow() {
+        check(manual = true)
+    }
+
+    private fun check(manual: Boolean) {
+        if (_state.value.status is UpdateStatus.Checking) return
+        scope.launch {
+            // A throttled automatic check must not blank a result the pane is already showing.
+            if (manual) _state.value = _state.value.copy(status = UpdateStatus.Checking)
+            val status = checker.check(manual)
+            if (status is UpdateStatus.Unknown && !manual) {
+                _state.value = _state.value.copy(status = _state.value.status)
+            } else {
+                _state.value = _state.value.copy(status = status, downloadError = null)
+            }
+        }
+    }
+
+    /** Downloads and verifies. Installing the result stays an explicit action by the user. */
+    fun download() {
+        val state = _state.value
+        val release = state.available ?: return
+        val asset = state.downloadable ?: return
+        if (state.isDownloading) return
+        _state.value = state.copy(isDownloading = true, downloadError = null, downloadedName = null)
+        scope.launch {
+            when (val outcome = downloader.download(release, asset)) {
+                is DownloadOutcome.Verified -> _state.value = _state.value.copy(
+                    isDownloading = false,
+                    downloadedName = outcome.file.name,
+                )
+
+                is DownloadOutcome.Failed -> _state.value = _state.value.copy(
+                    isDownloading = false,
+                    downloadError = outcome.reason,
+                )
+            }
+        }
+    }
+
+    /** Stops this version being announced again, and clears it from the pane. */
+    fun dismiss() {
+        val version = _state.value.available?.version ?: return
+        checker.dismiss(version)
+        _state.value = _state.value.copy(status = UpdateStatus.UpToDate(0L))
+    }
+
+    fun setAutomatic(enabled: Boolean) {
+        checker.setAutomatic(enabled)
+        _state.value = _state.value.copy(automatic = enabled)
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/update/UpdateChecker.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/update/UpdateChecker.kt
@@ -1,0 +1,273 @@
+package dk.perspektiva.ttsroad.desktop.update
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dk.perspektiva.ttsroad.desktop.BuildInfo
+import dk.perspektiva.ttsroad.desktop.data.AppLog
+import java.awt.Desktop
+import java.io.File
+import java.io.IOException
+import java.security.MessageDigest
+import okhttp3.CacheControl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/** Where the update check looks. Public releases only; the endpoint needs no credential. */
+const val ReleaseRepositorySlug: String = "jonarihen/TTSRoad-Desktop"
+
+/**
+ * The published release, however it is obtained.
+ *
+ * A seam rather than a direct call so the whole update flow — throttling, comparison, asset
+ * selection, dismissal — is testable without a network or a GitHub account.
+ */
+fun interface ReleaseSource {
+    /** Returns the latest published release, or null when the project has never published one. */
+    suspend fun latestRelease(): LatestRelease?
+}
+
+private data class GitHubAsset(
+    val name: String? = null,
+    val browser_download_url: String? = null,
+    val size: Long? = null,
+)
+
+private data class GitHubRelease(
+    val tag_name: String? = null,
+    val name: String? = null,
+    val body: String? = null,
+    val html_url: String? = null,
+    val draft: Boolean? = null,
+    val prerelease: Boolean? = null,
+    val assets: List<GitHubAsset>? = null,
+)
+
+/**
+ * Reads `releases/latest` from GitHub over the application's shared HTTP client.
+ *
+ * Sharing the client is deliberate: `AuthInterceptor` attaches the TTSRoad bearer token only when
+ * scheme, host and port match the signed-in server, so an api.github.com request carries no
+ * credential. A separate client would duplicate the pool and, more importantly, would put a second
+ * outbound path outside the rule that makes that true.
+ */
+class GitHubReleaseSource(
+    private val client: OkHttpClient,
+    private val repositorySlug: String = ReleaseRepositorySlug,
+) : ReleaseSource {
+    private val adapter = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+        .adapter(GitHubRelease::class.java)
+
+    override suspend fun latestRelease(): LatestRelease? {
+        val request = Request.Builder()
+            .url("https://api.github.com/repos/$repositorySlug/releases/latest")
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("User-Agent", "${BuildInfo.APP_NAME}/${BuildInfo.VERSION}")
+            // The 24-hour throttle is the caching policy; a stale cached body would defeat a
+            // manual "check now" the user pressed precisely because they expect a fresh answer.
+            .cacheControl(CacheControl.FORCE_NETWORK)
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            // A project with no releases answers 404. That is "nothing published", not a failure.
+            if (response.code == 404) return null
+            if (!response.isSuccessful) throw IOException("GitHub answered ${response.code}")
+            val payload = response.body.string()
+            val release = adapter.fromJson(payload) ?: return null
+            if (release.draft == true || release.prerelease == true) return null
+            val tag = release.tag_name?.takeIf { it.isNotBlank() } ?: return null
+            return LatestRelease(
+                tag = tag,
+                version = tag.removePrefix("v"),
+                notes = release.body.orEmpty().trim(),
+                htmlUrl = release.html_url.orEmpty(),
+                assets = release.assets.orEmpty().mapNotNull { asset ->
+                    val name = asset.name?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                    val url = asset.browser_download_url?.takeIf { it.isNotBlank() }
+                        ?: return@mapNotNull null
+                    ReleaseAsset(name = name, browserDownloadUrl = url, sizeBytes = asset.size ?: 0L)
+                },
+            )
+        }
+    }
+}
+
+/**
+ * Decides whether to check, performs the check, and records the outcome.
+ *
+ * Deliberately free of Compose and of any I/O it does not own: the source is injected, the clock is
+ * injected, and the persisted state is a store. That is what lets the acceptance cases — throttled,
+ * dismissed, no asset for this platform, network failure — be ordinary unit tests.
+ */
+class UpdateChecker(
+    private val source: ReleaseSource,
+    private val settingsStore: UpdateSettingsStore,
+    private val installedVersion: String = BuildInfo.VERSION,
+    private val osName: String = System.getProperty("os.name").orEmpty(),
+    private val architecture: String = System.getProperty("os.arch").orEmpty(),
+    private val clock: () -> Long = System::currentTimeMillis,
+) {
+    private var checkedThisLaunch = false
+
+    /**
+     * Runs a check unless an automatic one is not due yet.
+     *
+     * [manual] bypasses the throttle and the "already checked" flag, because a user who presses
+     * the button is asking for a network round trip, not for the cached verdict.
+     */
+    suspend fun check(manual: Boolean): UpdateStatus {
+        val settings = settingsStore.settings.value
+        if (!manual && !shouldCheckAutomatically(settings, clock(), checkedThisLaunch)) {
+            return UpdateStatus.Unknown
+        }
+        checkedThisLaunch = true
+
+        val release = try {
+            source.latestRelease()
+        } catch (failure: IOException) {
+            // The reason is a short human sentence. A response body could carry anything, so it
+            // never becomes UI text.
+            AppLog.warn("the update check could not reach GitHub", failure)
+            return UpdateStatus.Failed("Could not reach the update server")
+        } catch (failure: RuntimeException) {
+            AppLog.warn("the update check returned something unreadable", failure)
+            return UpdateStatus.Failed("The update information could not be read")
+        }
+
+        val now = clock()
+        settingsStore.update { it.copy(lastCheckMillis = now) }
+
+        if (release == null || !isNewerVersion(release.version, installedVersion)) {
+            return UpdateStatus.UpToDate(now)
+        }
+        // A dismissal covers exactly the version it was made against. A newer one asks again.
+        if (!manual && settings.dismissedVersion == release.version) return UpdateStatus.UpToDate(now)
+
+        return UpdateStatus.Available(
+            release = release,
+            asset = selectAssetFor(release.assets, osName, architecture),
+        )
+    }
+
+    /** Stops this one version from being announced again; a later release still is. */
+    fun dismiss(version: String) {
+        settingsStore.update { it.copy(dismissedVersion = version) }
+    }
+
+    fun setAutomatic(enabled: Boolean) {
+        settingsStore.update { it.copy(automatic = enabled) }
+    }
+}
+
+/** Why a download did not end in a file the user can install. */
+sealed interface DownloadOutcome {
+    /** The file is verified and on disk. Installing it is the user's next, explicit action. */
+    data class Verified(val file: File) : DownloadOutcome
+
+    data class Failed(val reason: String) : DownloadOutcome
+}
+
+/**
+ * Downloads a release asset and refuses to hand over anything it could not verify.
+ *
+ * The rule that matters: a file whose SHA-256 does not match the published `SHA256SUMS` entry is
+ * deleted and never opened. Nothing here installs anything — no `sudo`, no package manager call.
+ * The verified file is handed to the desktop, which is what asks the user for authorisation.
+ */
+class UpdateDownloader(
+    private val client: OkHttpClient,
+    private val targetDirectory: File,
+    private val open: (File) -> Unit = ::openWithDesktop,
+) {
+    suspend fun download(release: LatestRelease, asset: ReleaseAsset): DownloadOutcome {
+        val checksumAsset = release.assets.firstOrNull { it.name == ChecksumAssetName }
+            ?: return DownloadOutcome.Failed("The release publishes no checksums")
+
+        val expected = try {
+            parseChecksums(fetchText(checksumAsset.browserDownloadUrl))[asset.name]
+        } catch (failure: IOException) {
+            AppLog.warn("could not download the release checksums", failure)
+            return DownloadOutcome.Failed("Could not download the checksums")
+        } ?: return DownloadOutcome.Failed("The checksums do not cover ${asset.name}")
+
+        targetDirectory.mkdirs()
+        // A partial file never carries the final name, so an interrupted download cannot be
+        // mistaken for a verified one by this or any later run.
+        val partial = File(targetDirectory, "${asset.name}.part")
+        val target = File(targetDirectory, asset.name)
+        val actual = try {
+            downloadTo(asset.browserDownloadUrl, partial)
+        } catch (failure: IOException) {
+            partial.delete()
+            AppLog.warn("could not download the release asset", failure)
+            return DownloadOutcome.Failed("The download did not complete")
+        }
+
+        if (!actual.equals(expected, ignoreCase = true)) {
+            partial.delete()
+            AppLog.warn("rejected a release asset whose checksum did not match")
+            return DownloadOutcome.Failed("The download failed its checksum check and was deleted")
+        }
+
+        target.delete()
+        if (!partial.renameTo(target)) {
+            partial.delete()
+            return DownloadOutcome.Failed("The verified download could not be saved")
+        }
+        runCatching { open(target) }
+            .onFailure { AppLog.warn("could not hand the installer to the desktop", it) }
+        return DownloadOutcome.Verified(target)
+    }
+
+    private fun fetchText(url: String): String {
+        val request = Request.Builder().url(url).build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw IOException("download answered ${response.code}")
+            return response.body.string()
+        }
+    }
+
+    /** Streams to disk and returns the hex SHA-256 of what was actually written. */
+    private fun downloadTo(url: String, destination: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val request = Request.Builder().url(url).build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw IOException("download answered ${response.code}")
+            val body = response.body
+            destination.outputStream().use { output ->
+                body.byteStream().use { input ->
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    while (true) {
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        digest.update(buffer, 0, read)
+                        output.write(buffer, 0, read)
+                    }
+                }
+                output.flush()
+            }
+        }
+        return digest.digest().joinToString("") { byte -> "%02x".format(byte) }
+    }
+}
+
+/**
+ * Hands a verified file to the desktop's own handler.
+ *
+ * Never a package-manager invocation: installing a system package is an authorised action that
+ * belongs to the desktop's installer, which prompts. An application that ran `sudo dpkg -i` itself
+ * would be asking the user to trust it with far more than an update.
+ */
+private fun openWithDesktop(file: File) {
+    if (Desktop.isDesktopSupported()) {
+        val desktop = Desktop.getDesktop()
+        if (desktop.isSupported(Desktop.Action.OPEN)) {
+            desktop.open(file)
+            return
+        }
+    }
+    // Headless or a desktop without OPEN support: showing the folder is the honest fallback.
+    AppLog.info("no desktop handler for ${file.name}; it is in ${file.parent}")
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/update/UpdateModels.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/update/UpdateModels.kt
@@ -1,0 +1,132 @@
+package dk.perspektiva.ttsroad.desktop.update
+
+/**
+ * One downloadable file attached to a GitHub release.
+ *
+ * [browserDownloadUrl] is an absolute URL on a GitHub host, which is exactly why the update code
+ * uses the shared [okhttp3.OkHttpClient]: the auth interceptor's same-origin rule means the
+ * TTSRoad bearer token is not attached to it.
+ */
+data class ReleaseAsset(
+    val name: String,
+    val browserDownloadUrl: String,
+    val sizeBytes: Long,
+)
+
+/** The published release the update check compares against, with its notes and assets. */
+data class LatestRelease(
+    val tag: String,
+    val version: String,
+    val notes: String,
+    val htmlUrl: String,
+    val assets: List<ReleaseAsset>,
+)
+
+/** What the UI renders. A check that failed is not the same as a check that found nothing. */
+sealed interface UpdateStatus {
+    /** No check has run yet in this session. */
+    data object Unknown : UpdateStatus
+
+    data object Checking : UpdateStatus
+
+    /** The check succeeded and this build is current. */
+    data class UpToDate(val checkedAtMillis: Long) : UpdateStatus
+
+    /**
+     * A newer release exists. [asset] is null when the release carries nothing for this
+     * platform/architecture, which is a real outcome rather than an error: the user is told a
+     * version exists and pointed at the release page instead of a download button that lies.
+     */
+    data class Available(
+        val release: LatestRelease,
+        val asset: ReleaseAsset?,
+    ) : UpdateStatus
+
+    /** The check itself failed. The message is for a human; it never carries a response body. */
+    data class Failed(val reason: String) : UpdateStatus
+}
+
+/**
+ * Compares two dotted numeric versions.
+ *
+ * Only the numeric core is ordered. A pre-release suffix (`1.2.0-rc1`) sorts *below* the same core
+ * release, per SemVer, so an installed release build is never asked to "update" to its own
+ * candidate. Anything unparseable compares as 0, which makes an unknown version look older than a
+ * known one rather than newer — the safe direction for something that offers downloads.
+ */
+fun compareVersions(left: String, right: String): Int {
+    val (leftCore, leftPre) = splitVersion(left)
+    val (rightCore, rightPre) = splitVersion(right)
+    val width = maxOf(leftCore.size, rightCore.size)
+    for (index in 0 until width) {
+        val comparison = leftCore.getOrElse(index) { 0 }.compareTo(rightCore.getOrElse(index) { 0 })
+        if (comparison != 0) return comparison
+    }
+    return when {
+        leftPre == rightPre -> 0
+        leftPre == null -> 1
+        rightPre == null -> -1
+        else -> leftPre.compareTo(rightPre)
+    }
+}
+
+private fun splitVersion(version: String): Pair<List<Int>, String?> {
+    val trimmed = version.trim().removePrefix("v")
+    val core = trimmed.substringBefore('-').substringBefore('+')
+    val preRelease = trimmed.substringAfter('-', "").takeIf { it.isNotEmpty() }
+    val numbers = core.split('.').map { part -> part.trim().toIntOrNull() ?: 0 }
+    return numbers to preRelease
+}
+
+/** True when [candidate] is a strictly newer release than [installed]. */
+fun isNewerVersion(candidate: String, installed: String): Boolean =
+    compareVersions(candidate, installed) > 0
+
+/** The three formats a release publishes, one per operating system. */
+private val LinuxArchitectures = setOf("amd64", "x86_64", "x64")
+
+/**
+ * Picks the asset this machine can actually install, or null when the release has none.
+ *
+ * Architecture is only enforced where more than one is conceivable. Linux publishes an `amd64`
+ * package and nothing else, so an aarch64 desktop gets null rather than a package `dpkg` would
+ * refuse — offering it would be a download that cannot succeed.
+ */
+fun selectAssetFor(
+    assets: List<ReleaseAsset>,
+    osName: String,
+    architecture: String,
+): ReleaseAsset? {
+    val os = osName.lowercase()
+    val arch = architecture.lowercase()
+    return when {
+        os.contains("win") -> assets.firstOrNull { it.name.endsWith(".msi", ignoreCase = true) }
+        os.contains("mac") || os.contains("darwin") ->
+            assets.firstOrNull { it.name.endsWith(".dmg", ignoreCase = true) }
+        arch in LinuxArchitectures ->
+            assets.firstOrNull { it.name.endsWith("_amd64.deb", ignoreCase = true) }
+        else -> null
+    }
+}
+
+/**
+ * Reads a `sha256sum` output file into name → digest.
+ *
+ * Both `sha256sum` spellings appear in the wild — `<digest>  name` and `<digest> *name` — and the
+ * release workflow writes names as `./name`, so the leading `./` is stripped. A malformed line is
+ * skipped rather than failing the whole file, but a name that is therefore absent later fails the
+ * verification, which is the outcome that matters.
+ */
+fun parseChecksums(text: String): Map<String, String> = buildMap {
+    for (line in text.lineSequence()) {
+        val trimmed = line.trim()
+        if (trimmed.isEmpty()) continue
+        val digest = trimmed.substringBefore(' ').lowercase()
+        if (digest.length != 64 || !digest.all { it in '0'..'9' || it in 'a'..'f' }) continue
+        val name = trimmed.substringAfter(' ').trim().removePrefix("*").removePrefix("./")
+        if (name.isNotEmpty()) put(name, digest)
+    }
+}
+
+/** The name of the checksum asset the release workflow publishes. */
+const val ChecksumAssetName: String = "SHA256SUMS"

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/update/UpdateSettings.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/update/UpdateSettings.kt
@@ -1,0 +1,121 @@
+package dk.perspektiva.ttsroad.desktop.update
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dk.perspektiva.ttsroad.desktop.data.AppLog
+import dk.perspektiva.ttsroad.desktop.data.FileSessionStore
+import dk.perspektiva.ttsroad.desktop.security.SecureFiles
+import java.io.File
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * What the machine remembers between launches about update checking.
+ *
+ * Machine-local like the listening preferences and for the same reason: which build is installed
+ * here is a property of this desktop, not of whoever is signed in. Nothing here is secret, and
+ * there is nowhere in the type to put something that is.
+ */
+data class UpdateSettings(
+    /** Automatic checks can be turned off; a manual check always ignores this. */
+    val automatic: Boolean = true,
+    val lastCheckMillis: Long = 0L,
+    /** The version the user chose to stop being told about. Cleared when a newer one appears. */
+    val dismissedVersion: String? = null,
+)
+
+/** Fully nullable on-disk form, so a file from another build loads degraded instead of throwing. */
+internal data class StoredUpdateSettings(
+    val automatic: Boolean? = null,
+    val lastCheckMillis: Long? = null,
+    val dismissedVersion: String? = null,
+) {
+    fun toSettings(): UpdateSettings = UpdateSettings(
+        automatic = automatic ?: true,
+        // A timestamp from the future would suppress checks indefinitely; treat it as never checked.
+        lastCheckMillis = lastCheckMillis?.takeIf { it >= 0L } ?: 0L,
+        dismissedVersion = dismissedVersion?.takeIf { it.isNotBlank() },
+    )
+
+    companion object {
+        fun from(settings: UpdateSettings): StoredUpdateSettings = StoredUpdateSettings(
+            automatic = settings.automatic,
+            lastCheckMillis = settings.lastCheckMillis,
+            dismissedVersion = settings.dismissedVersion,
+        )
+    }
+}
+
+interface UpdateSettingsStore {
+    val settings: StateFlow<UpdateSettings>
+
+    fun update(transform: (UpdateSettings) -> UpdateSettings)
+}
+
+/** In-memory store for tests and for the smoke test, which must not write to a real home. */
+class InMemoryUpdateSettingsStore(
+    initial: UpdateSettings = UpdateSettings(),
+) : UpdateSettingsStore {
+    private val _settings = MutableStateFlow(initial)
+    override val settings: StateFlow<UpdateSettings> = _settings.asStateFlow()
+
+    @Synchronized
+    override fun update(transform: (UpdateSettings) -> UpdateSettings) {
+        _settings.value = transform(_settings.value)
+    }
+}
+
+/** `update.json` beside the session and playback settings, written owner-only. */
+class FileUpdateSettingsStore(
+    private val file: File = defaultFile(),
+) : UpdateSettingsStore {
+    private val adapter = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+        .adapter(StoredUpdateSettings::class.java)
+
+    private val _settings = MutableStateFlow(read())
+    override val settings: StateFlow<UpdateSettings> = _settings.asStateFlow()
+
+    @Synchronized
+    override fun update(transform: (UpdateSettings) -> UpdateSettings) {
+        val next = transform(_settings.value)
+        if (next == _settings.value) return
+        _settings.value = next
+        runCatching { SecureFiles.writeAtomically(file, adapter.toJson(StoredUpdateSettings.from(next))) }
+            .onFailure { AppLog.warn("could not write the update settings file", it) }
+    }
+
+    private fun read(): UpdateSettings =
+        runCatching { if (file.isFile) adapter.fromJson(file.readText()) else null }
+            .onFailure { AppLog.warn("could not read the update settings file", it) }
+            .getOrNull()
+            ?.toSettings()
+            ?: UpdateSettings()
+
+    companion object {
+        fun defaultFile(): File = FileSessionStore.configDir().resolve("update.json")
+    }
+}
+
+/** At most one automatic check per day, on top of at most one per launch. */
+const val UpdateCheckIntervalMillis: Long = 24L * 60 * 60 * 1000
+
+/**
+ * Whether an automatic check may run now.
+ *
+ * A clock that has moved backwards (a corrected system time, a restored VM) would otherwise park
+ * the next check up to a day in the future, so a [lastCheckMillis] later than [nowMillis] is
+ * treated as due rather than as recent.
+ */
+fun shouldCheckAutomatically(
+    settings: UpdateSettings,
+    nowMillis: Long,
+    alreadyCheckedThisLaunch: Boolean,
+): Boolean {
+    if (!settings.automatic) return false
+    if (alreadyCheckedThisLaunch) return false
+    if (settings.lastCheckMillis > nowMillis) return true
+    return nowMillis - settings.lastCheckMillis >= UpdateCheckIntervalMillis
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreenUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreenUiTest.kt
@@ -387,9 +387,11 @@ class SettingsScreenUiTest {
         compose.waitForIdle()
 
         compose.onNodeWithText("Installed build").assertIsDisplayed()
-        compose.onNodeWithText("Not available — install a newer build to update").assertIsDisplayed()
         compose.onNodeWithText("Kotlin, Compose Multiplatform, OkHttp, Retrofit, Moshi, Coil").assertIsDisplayed()
         compose.onNodeWithText("COPY DIAGNOSTICS").assertHasClickAction()
+        compose.onNodeWithText("EXPORT DIAGNOSTICS").assertHasClickAction()
+        // No updater was supplied, so the pane must not claim an update state nothing checked.
+        compose.onNodeWithText("CHECK NOW").assertDoesNotExist()
     }
 
     // --- Devices: supported ------------------------------------------------------------------

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/update/UpdateCheckerTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/update/UpdateCheckerTest.kt
@@ -1,0 +1,223 @@
+package dk.perspektiva.ttsroad.desktop.update
+
+import java.io.IOException
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Throttling, dismissal and failure handling around the update check.
+ *
+ * Everything here runs without a network: the release feed is a lambda and the clock is a variable,
+ * which is the point of the [ReleaseSource] seam.
+ */
+class UpdateCheckerTest {
+
+    private val installed = "1.0.1"
+
+    /** A realistic wall-clock value: an install that has never checked is due immediately. */
+    private val now = 1_700_000_000_000L
+
+    private fun release(
+        version: String,
+        assets: List<ReleaseAsset> = listOf(
+            ReleaseAsset("ttsroad_$version-1_amd64.deb", "https://example.invalid/deb", 100),
+        ),
+    ) = LatestRelease(
+        tag = "v$version",
+        version = version,
+        notes = "Notes for $version",
+        htmlUrl = "https://example.invalid/releases/v$version",
+        assets = assets,
+    )
+
+    private fun checker(
+        store: UpdateSettingsStore,
+        now: () -> Long,
+        source: ReleaseSource,
+        osName: String = "Linux",
+        architecture: String = "amd64",
+    ) = UpdateChecker(
+        source = source,
+        settingsStore = store,
+        installedVersion = installed,
+        osName = osName,
+        architecture = architecture,
+        clock = now,
+    )
+
+    // --- Finding an update ----------------------------------------------------------------------
+
+    @Test
+    fun `a newer release is reported with the asset for this machine`() = runTest {
+        val store = InMemoryUpdateSettingsStore()
+        val status = checker(store, { now }, { release("1.0.2") }).check(manual = true)
+
+        val available = assertIs<UpdateStatus.Available>(status)
+        assertEquals("1.0.2", available.release.version)
+        assertEquals("ttsroad_1.0.2-1_amd64.deb", available.asset?.name)
+    }
+
+    @Test
+    fun `a release with nothing for this architecture is still announced, without a download`() =
+        runTest {
+            val store = InMemoryUpdateSettingsStore()
+            val status = checker(store, { now }, { release("1.0.2") }, architecture = "aarch64")
+                .check(manual = true)
+
+            val available = assertIs<UpdateStatus.Available>(status)
+            // Told that a version exists, but not handed a package dpkg would refuse.
+            assertNull(available.asset)
+        }
+
+    @Test
+    fun `the same version is up to date, not an update`() = runTest {
+        val store = InMemoryUpdateSettingsStore()
+        val status = checker(store, { now }, { release(installed) }).check(manual = true)
+        assertIs<UpdateStatus.UpToDate>(status)
+    }
+
+    @Test
+    fun `a project with no published release is up to date, not a failure`() = runTest {
+        val store = InMemoryUpdateSettingsStore()
+        val status = checker(store, { now }, { null }).check(manual = true)
+        assertIs<UpdateStatus.UpToDate>(status)
+    }
+
+    // --- Throttling -----------------------------------------------------------------------------
+
+    @Test
+    fun `an automatic check runs once per launch and no more`() = runTest {
+        val store = InMemoryUpdateSettingsStore()
+        var calls = 0
+        val subject = checker(store, { now }, { calls++; release("1.0.2") })
+
+        assertIs<UpdateStatus.Available>(subject.check(manual = false))
+        assertIs<UpdateStatus.Unknown>(subject.check(manual = false))
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun `an automatic check waits a day after the last one`() = runTest {
+        val store = InMemoryUpdateSettingsStore(UpdateSettings(lastCheckMillis = 1_000L))
+        var calls = 0
+        val justUnderADay = 1_000L + UpdateCheckIntervalMillis - 1
+
+        assertIs<UpdateStatus.Unknown>(
+            checker(store, { justUnderADay }, { calls++; release("1.0.2") }).check(manual = false),
+        )
+        assertEquals(0, calls)
+
+        assertIs<UpdateStatus.Available>(
+            checker(store, { justUnderADay + 1 }, { calls++; release("1.0.2") })
+                .check(manual = false),
+        )
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun `a manual check ignores both the daily interval and the once-per-launch flag`() = runTest {
+        val store = InMemoryUpdateSettingsStore(UpdateSettings(lastCheckMillis = 1_000L))
+        var calls = 0
+        val subject = checker(store, { 1_001L }, { calls++; release("1.0.2") })
+
+        assertIs<UpdateStatus.Available>(subject.check(manual = true))
+        assertIs<UpdateStatus.Available>(subject.check(manual = true))
+        assertEquals(2, calls)
+    }
+
+    @Test
+    fun `a clock that moved backwards does not park the next check in the future`() = runTest {
+        val store = InMemoryUpdateSettingsStore(UpdateSettings(lastCheckMillis = 10_000L))
+        var calls = 0
+
+        assertIs<UpdateStatus.Available>(
+            checker(store, { 5_000L }, { calls++; release("1.0.2") }).check(manual = false),
+        )
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun `turning automatic checks off stops them, and a manual check still works`() = runTest {
+        val store = InMemoryUpdateSettingsStore()
+        var calls = 0
+        val subject = checker(store, { now }, { calls++; release("1.0.2") })
+        subject.setAutomatic(false)
+
+        assertIs<UpdateStatus.Unknown>(subject.check(manual = false))
+        assertEquals(0, calls)
+        assertIs<UpdateStatus.Available>(subject.check(manual = true))
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun `a successful check records when it happened`() = runTest {
+        val store = InMemoryUpdateSettingsStore()
+        checker(store, { 4_242L }, { release(installed) }).check(manual = true)
+        assertEquals(4_242L, store.settings.value.lastCheckMillis)
+    }
+
+    // --- Dismissal ------------------------------------------------------------------------------
+
+    @Test
+    fun `a dismissed version stops being announced automatically`() = runTest {
+        val store = InMemoryUpdateSettingsStore()
+        checker(store, { now }, { release("1.0.2") }).dismiss("1.0.2")
+
+        val status = checker(store, { now }, { release("1.0.2") }).check(manual = false)
+        assertIs<UpdateStatus.UpToDate>(status)
+    }
+
+    @Test
+    fun `a version newer than the dismissed one is announced again`() = runTest {
+        val store = InMemoryUpdateSettingsStore(UpdateSettings(dismissedVersion = "1.0.2"))
+        val status = checker(store, { now }, { release("1.0.3") }).check(manual = false)
+        assertIs<UpdateStatus.Available>(status)
+    }
+
+    @Test
+    fun `a manual check shows a dismissed version, because the user just asked`() = runTest {
+        val store = InMemoryUpdateSettingsStore(UpdateSettings(dismissedVersion = "1.0.2"))
+        val status = checker(store, { now }, { release("1.0.2") }).check(manual = true)
+        assertIs<UpdateStatus.Available>(status)
+    }
+
+    // --- Failure --------------------------------------------------------------------------------
+
+    @Test
+    fun `a network failure is reported without leaking the response`() = runTest {
+        val store = InMemoryUpdateSettingsStore()
+        val status = checker(store, { now }, { throw IOException("connect timed out to 10.0.0.1") })
+            .check(manual = true)
+
+        val failed = assertIs<UpdateStatus.Failed>(status)
+        assertFalse(failed.reason.contains("10.0.0.1"))
+    }
+
+    @Test
+    fun `a failed check does not count as a check`() = runTest {
+        // Otherwise one outage would silence update checking for a whole day.
+        val store = InMemoryUpdateSettingsStore()
+        checker(store, { 9_000L }, { throw IOException("offline") }).check(manual = true)
+        assertEquals(0L, store.settings.value.lastCheckMillis)
+    }
+
+    // --- Persisted settings ---------------------------------------------------------------------
+
+    @Test
+    fun `a stored file from another build loads degraded rather than throwing`() {
+        val settings = StoredUpdateSettings(automatic = null, lastCheckMillis = null).toSettings()
+        assertTrue(settings.automatic)
+        assertEquals(0L, settings.lastCheckMillis)
+        assertNull(settings.dismissedVersion)
+    }
+
+    @Test
+    fun `a negative stored timestamp is treated as never checked`() {
+        assertEquals(0L, StoredUpdateSettings(lastCheckMillis = -1L).toSettings().lastCheckMillis)
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/update/UpdateDownloaderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/update/UpdateDownloaderTest.kt
@@ -1,0 +1,147 @@
+package dk.perspektiva.ttsroad.desktop.update
+
+import java.io.File
+import java.security.MessageDigest
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.OkHttpClient
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * The download half of the updater, against a real HTTP server.
+ *
+ * The load-bearing case is the mismatch: a file whose digest does not match the published one must
+ * be deleted and must never be handed to the desktop, because handing it over is what would get it
+ * executed.
+ */
+class UpdateDownloaderTest {
+
+    private lateinit var server: MockWebServer
+    private val client = OkHttpClient()
+
+    @TempDir
+    lateinit var directory: File
+
+    private val payload = "a packaged installer"
+    private val payloadDigest: String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(payload.toByteArray())
+            .joinToString("") { "%02x".format(it) }
+
+    @BeforeEach
+    fun start() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @AfterEach
+    fun stop() {
+        server.close()
+    }
+
+    private fun releaseWith(checksums: String): Pair<LatestRelease, ReleaseAsset> {
+        // Enqueued in the order the downloader asks for them: checksums first, then the asset.
+        server.enqueue(MockResponse(code = 200, body = checksums))
+        server.enqueue(MockResponse(code = 200, body = payload))
+        val asset = ReleaseAsset(
+            name = "ttsroad_1.0.2-1_amd64.deb",
+            browserDownloadUrl = server.url("/asset").toString(),
+            sizeBytes = payload.length.toLong(),
+        )
+        val sums = ReleaseAsset(
+            name = ChecksumAssetName,
+            browserDownloadUrl = server.url("/SHA256SUMS").toString(),
+            sizeBytes = checksums.length.toLong(),
+        )
+        val release = LatestRelease(
+            tag = "v1.0.2",
+            version = "1.0.2",
+            notes = "",
+            htmlUrl = server.url("/release").toString(),
+            assets = listOf(asset, sums),
+        )
+        return release to asset
+    }
+
+    @Test
+    fun `a matching checksum yields a saved file that is handed to the desktop`() = runTest {
+        val (release, asset) = releaseWith("$payloadDigest  ./${"ttsroad_1.0.2-1_amd64.deb"}")
+        val opened = mutableListOf<File>()
+        val downloader = UpdateDownloader(client, directory) { opened += it }
+
+        val outcome = downloader.download(release, asset)
+
+        val verified = assertIs<DownloadOutcome.Verified>(outcome)
+        assertEquals(payload, verified.file.readText())
+        assertEquals(listOf(verified.file), opened)
+    }
+
+    @Test
+    fun `a mismatched checksum deletes the download and never opens it`() = runTest {
+        val (release, asset) = releaseWith("${"b".repeat(64)}  ttsroad_1.0.2-1_amd64.deb")
+        val opened = mutableListOf<File>()
+        val downloader = UpdateDownloader(client, directory) { opened += it }
+
+        val outcome = downloader.download(release, asset)
+
+        assertIs<DownloadOutcome.Failed>(outcome)
+        assertTrue(opened.isEmpty(), "a file that failed verification must not be opened")
+        assertTrue(
+            directory.listFiles().orEmpty().isEmpty(),
+            "the rejected download must not be left on disk",
+        )
+    }
+
+    @Test
+    fun `a release that publishes no checksums downloads nothing at all`() = runTest {
+        val asset = ReleaseAsset("ttsroad_1.0.2-1_amd64.deb", server.url("/asset").toString(), 1)
+        val release = LatestRelease("v1.0.2", "1.0.2", "", "", listOf(asset))
+        val opened = mutableListOf<File>()
+
+        val outcome = UpdateDownloader(client, directory) { opened += it }.download(release, asset)
+
+        val failed = assertIs<DownloadOutcome.Failed>(outcome)
+        assertContains(failed.reason, "checksums")
+        assertEquals(0, server.requestCount, "nothing should be fetched without checksums")
+        assertTrue(opened.isEmpty())
+    }
+
+    @Test
+    fun `checksums that do not cover this asset stop the download`() = runTest {
+        val (release, asset) = releaseWith("$payloadDigest  some-other-file.deb")
+        val opened = mutableListOf<File>()
+
+        val outcome = UpdateDownloader(client, directory) { opened += it }.download(release, asset)
+
+        assertIs<DownloadOutcome.Failed>(outcome)
+        assertTrue(opened.isEmpty())
+    }
+
+    @Test
+    fun `a failed transfer leaves no partial file behind`() = runTest {
+        server.enqueue(MockResponse(code = 200, body = "$payloadDigest  ttsroad_1.0.2-1_amd64.deb"))
+        server.enqueue(MockResponse(code = 503))
+        val asset = ReleaseAsset(
+            "ttsroad_1.0.2-1_amd64.deb",
+            server.url("/asset").toString(),
+            payload.length.toLong(),
+        )
+        val sums = ReleaseAsset(ChecksumAssetName, server.url("/SHA256SUMS").toString(), 1)
+        val release = LatestRelease("v1.0.2", "1.0.2", "", "", listOf(asset, sums))
+
+        val outcome = UpdateDownloader(client, directory) { }.download(release, asset)
+
+        assertIs<DownloadOutcome.Failed>(outcome)
+        assertFalse(File(directory, "${asset.name}.part").exists())
+        assertFalse(File(directory, asset.name).exists())
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/update/UpdateModelsTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/update/UpdateModelsTest.kt
@@ -1,0 +1,122 @@
+package dk.perspektiva.ttsroad.desktop.update
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Version ordering, platform/architecture asset selection and checksum parsing — the three pure
+ * decisions that stand between a release feed and a file the user is invited to install.
+ */
+class UpdateModelsTest {
+
+    // --- Version comparison ---------------------------------------------------------------------
+
+    @Test
+    fun `a higher patch, minor or major is newer`() {
+        assertTrue(isNewerVersion("1.0.2", "1.0.1"))
+        assertTrue(isNewerVersion("1.1.0", "1.0.9"))
+        assertTrue(isNewerVersion("2.0.0", "1.9.9"))
+    }
+
+    @Test
+    fun `the installed version is not newer than itself`() {
+        assertFalse(isNewerVersion("1.0.1", "1.0.1"))
+        assertFalse(isNewerVersion("1.0.0", "1.0.1"))
+    }
+
+    @Test
+    fun `a v prefix on the tag does not make it a different version`() {
+        assertFalse(isNewerVersion("v1.0.1", "1.0.1"))
+        assertTrue(isNewerVersion("v1.0.2", "1.0.1"))
+    }
+
+    @Test
+    fun `versions of different lengths compare on the parts they share`() {
+        assertFalse(isNewerVersion("1.0", "1.0.0"))
+        assertTrue(isNewerVersion("1.0.1", "1.0"))
+    }
+
+    @Test
+    fun `a pre-release sorts below the release with the same core`() {
+        // Otherwise an installed 1.1.0 would be offered "1.1.0-rc1" as an upgrade.
+        assertFalse(isNewerVersion("1.1.0-rc1", "1.1.0"))
+        assertTrue(isNewerVersion("1.1.0", "1.1.0-rc1"))
+    }
+
+    @Test
+    fun `an unparseable version is treated as older, never as newer`() {
+        // The safe direction: garbage in the feed must not trigger a download offer.
+        assertFalse(isNewerVersion("not-a-version", "1.0.1"))
+    }
+
+    // --- Asset selection ------------------------------------------------------------------------
+
+    private val assets = listOf(
+        ReleaseAsset("ttsroad_1.0.2-1_amd64.deb", "https://example.invalid/deb", 100),
+        ReleaseAsset("TTSRoad-1.0.2.msi", "https://example.invalid/msi", 200),
+        ReleaseAsset("TTSRoad-1.0.2.dmg", "https://example.invalid/dmg", 300),
+        ReleaseAsset("SHA256SUMS", "https://example.invalid/sums", 10),
+    )
+
+    @Test
+    fun `each platform selects its own installer format`() {
+        assertEquals("ttsroad_1.0.2-1_amd64.deb", selectAssetFor(assets, "Linux", "amd64")?.name)
+        assertEquals("TTSRoad-1.0.2.msi", selectAssetFor(assets, "Windows 11", "amd64")?.name)
+        assertEquals("TTSRoad-1.0.2.dmg", selectAssetFor(assets, "Mac OS X", "aarch64")?.name)
+    }
+
+    @Test
+    fun `x86_64 and x64 name the same Linux architecture as amd64`() {
+        assertEquals("ttsroad_1.0.2-1_amd64.deb", selectAssetFor(assets, "Linux", "x86_64")?.name)
+        assertEquals("ttsroad_1.0.2-1_amd64.deb", selectAssetFor(assets, "Linux", "x64")?.name)
+    }
+
+    @Test
+    fun `an architecture the release does not publish for selects nothing`() {
+        // dpkg would refuse an amd64 package here, so offering it would be a download that cannot
+        // succeed. Nothing is the correct answer.
+        assertNull(selectAssetFor(assets, "Linux", "aarch64"))
+    }
+
+    @Test
+    fun `a release without this platform's format selects nothing`() {
+        val linuxOnly = assets.filter { it.name.endsWith(".deb") }
+        assertNull(selectAssetFor(linuxOnly, "Windows 11", "amd64"))
+    }
+
+    // --- Checksums ------------------------------------------------------------------------------
+
+    private val digest = "a".repeat(64)
+
+    @Test
+    fun `both sha256sum spellings and the leading dot-slash are understood`() {
+        val parsed = parseChecksums(
+            """
+            $digest  ./ttsroad_1.0.2-1_amd64.deb
+            ${"b".repeat(64)} *TTSRoad-1.0.2.msi
+            """.trimIndent(),
+        )
+        assertEquals(digest, parsed["ttsroad_1.0.2-1_amd64.deb"])
+        assertEquals("b".repeat(64), parsed["TTSRoad-1.0.2.msi"])
+    }
+
+    @Test
+    fun `a malformed line is skipped rather than failing the whole file`() {
+        val parsed = parseChecksums(
+            """
+            this is not a checksum line
+            deadbeef  short-digest.deb
+            $digest  good.deb
+            """.trimIndent(),
+        )
+        assertEquals(mapOf("good.deb" to digest), parsed)
+    }
+
+    @Test
+    fun `an uppercase digest matches the lowercase one computed locally`() {
+        assertEquals(digest, parseChecksums("${digest.uppercase()}  good.deb")["good.deb"])
+    }
+}


### PR DESCRIPTION
## Summary
- add a tag-driven release workflow that builds the `.deb`, `.msi` and `.dmg` on their own runners, gates on tag/version/changelog agreement, and publishes a draft with SHA-256 checksums, an SBOM and signed build provenance
- add an in-app update check against the public GitHub release feed that throttles, honours dismissal, verifies every download against `SHA256SUMS`, and installs nothing itself
- add the dependency-review gate, `docs/SECURITY.md` with response times, an Export diagnostics action, and ADR 0010

Part of #1. Addresses the release-automation, observability and documentation parts of #10; crash reporting is deliberately left out of this phase.

## Verification
- `clean check --warning-mode fail -Pttsroad.warningsAsErrors=true` — 802 tests, 5 failures, all pre-existing `SettingsScreenUiTest` cases that need a display and pass under CI's Xvfb (identical set on `master` without this branch)
- 32 new tests covering version ordering, platform/architecture asset selection, checksum parsing, throttling, dismissal, failure handling, and the download path against a `MockWebServer` — including that a checksum mismatch deletes the file and never opens it
- `changelog-section.sh` exercised for a present section, a missing version and an empty section
- YAML and shell syntax validated

## Notes
- **The release workflow itself has not run.** GitHub Actions is currently blocked on this account (`The job was not started because recent account payments have failed or your spending limit needs to be increased`), so neither this workflow nor CI can execute.
- The update check requires the repository to be **public**; while private it degrades to "Could not reach the update server".
- The Windows and macOS release jobs are unverified — neither installer has ever been built on its own runner here, and neither has a clean-machine install test the way the `.deb` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)