### PR TITLE
Release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ All notable changes to TTSRoad Desktop are recorded here. The format follows
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-08-10
+
+### Fixed
+
+- Starting a chapter from the library queued only that one chapter, so the Next control was
+  disabled and playback stopped at the end of the chapter instead of advancing. A queue is now
+  always the whole fiction in reading order, wherever playback was started from.
+- Chapter audio was resampled at GStreamer's default quality. Speech crossing the common
+  44.1 kHz to 48 kHz boundary is now resampled at full quality.
+
 ## [1.0.1] - 2026-08-10
 
 First packaged release: a feature-complete, Linux-native desktop client for a private TTSRoad
@@ -42,5 +52,6 @@ server.
 - A Debian package with a bundled JDK 25 runtime, desktop entry, upgrade-safe revisioning and XDG
   rotating logs, plus credential-safe `--version` and `--diagnostics` commands.
 
-[Unreleased]: https://github.com/jonarihen/TTSRoad-Desktop/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/jonarihen/TTSRoad-Desktop/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/jonarihen/TTSRoad-Desktop/releases/tag/v1.0.2
 [1.0.1]: https://github.com/jonarihen/TTSRoad-Desktop/releases/tag/v1.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.configuration-cache=true
 #   - BuildInfo.VERSION, which the runtime About text renders
 #   - release automation / CI artifact names
 # jpackage rejects MAJOR 0, so this must stay >= 1.0.0.
-ttsroad.version=1.0.1
+ttsroad.version=1.0.2
 
 # Debian revision, deliberately separate from the application version. A packaging-only fix can
 # move 1.0.1-1 to 1.0.1-2 without making the About screen claim the application itself changed.


### PR DESCRIPTION
## Summary
- bump `ttsroad.version` to 1.0.2 and add the CHANGELOG entry the release workflow gates on

1.0.1 was tagged before #33, so its draft ships the single-chapter-queue bug and the low-quality resampler. That draft is being discarded in favour of this version rather than published.

## Contents
Everything on master, plus #33:
- library playback queues the whole fiction, so auto-advance and Next work wherever playback started
- `audioresample quality=10` instead of GStreamer's default 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)