### PR TITLE
Stop offline progress from overwriting newer positions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,12 @@ dependencies {
     // past what our Kotlin 2.1.0 compiler's metadata reader accepts.
     implementation("io.coil-kt.coil3:coil-compose:3.2.0")
     implementation("io.coil-kt.coil3:coil-network-okhttp:3.2.0")
+
+    testImplementation(kotlin("test"))
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 java {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -83,7 +83,12 @@ fun App() {
     // A session restored from disk never goes through login, so this is where a relaunch learns
     // what the server can do. Failure is silent: all-false is the pre-capability feature set.
     LaunchedEffect(session.isLoggedIn) {
-        if (session.isLoggedIn) runCatching { repository.refreshCapabilities() }
+        if (session.isLoggedIn) {
+            runCatching { repository.refreshCapabilities() }
+            // Relaunching is the reconnect that matters: anything recorded while the last session
+            // was offline has been sitting on disk since, and this is the first chance to send it.
+            runCatching { repository.flushProgress() }
+        }
     }
 
     fun openPlayer() {
@@ -277,7 +282,7 @@ private fun capabilityLines(c: ServerCapabilities): List<CapabilityLine> = listO
     CapabilityLine("Bookmarks", c.bookmarks, usedByClient = false),
     CapabilityLine("Cross-library queue", c.queue, usedByClient = false),
     CapabilityLine("Follow / unfollow", c.follows, usedByClient = false),
-    CapabilityLine("Batch progress sync", c.batchProgress, usedByClient = false),
+    CapabilityLine("Batch progress sync", c.batchProgress, usedByClient = true),
     CapabilityLine("Delta sync", c.deltaSync, usedByClient = false),
     CapabilityLine("Read-along", c.readalong, usedByClient = false),
     CapabilityLine("Audiobook export", c.audiobookExport, usedByClient = false),

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackSync.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackSync.kt
@@ -1,0 +1,75 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Json
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/**
+ * One recorded listening position, waiting to reach the server.
+ *
+ * [clientUpdatedAt] is the whole point. `/playback/progress` writes whatever it is handed, so a
+ * position recorded on this machine while offline overwrites a newer one reached in the browser
+ * since. `/playback/sync` orders writes by this stamp and only lets a strictly newer one win.
+ */
+data class PendingProgress(
+    val fictionId: Int,
+    val chapterId: Int,
+    val positionSeconds: Double,
+    val isPlayed: Boolean,
+    val clientUpdatedAt: String,
+)
+
+/**
+ * Now, as a stamp the backend will actually accept.
+ *
+ * Truncated to milliseconds deliberately. `Instant.now().toString()` emits as many fractional
+ * digits as the platform clock has — up to nine — and the backend's `parse_iso8601` hands the
+ * string to `datetime.fromisoformat`, which before Python 3.11 accepts only three or six. A
+ * nine-digit stamp would come back as `invalid_client_updated_at` and the write would be dropped,
+ * which is the exact failure this endpoint exists to prevent.
+ */
+fun nowStamp(): String = Instant.now().truncatedTo(ChronoUnit.MILLIS).toString()
+
+data class PlaybackSyncItem(
+    @param:Json(name = "chapter_id") val chapterId: Int,
+    @param:Json(name = "position_seconds") val positionSeconds: Double,
+    @param:Json(name = "is_played") val isPlayed: Boolean,
+    @param:Json(name = "client_updated_at") val clientUpdatedAt: String,
+)
+
+data class PlaybackSyncRequest(val items: List<PlaybackSyncItem>)
+
+data class PlaybackSyncAccepted(
+    @param:Json(name = "chapter_id") val chapterId: Int = 0,
+    @param:Json(name = "position_seconds") val positionSeconds: Double = 0.0,
+    @param:Json(name = "is_played") val isPlayed: Boolean = false,
+)
+
+/**
+ * An item the server refused. Every [reason] it can give — `not_found`, `stale`, `empty`,
+ * `missing_client_updated_at`, `invalid_client_updated_at` — is terminal for that item: re-sending
+ * the same payload gets the same answer, so a rejection means drop it, not retry it.
+ */
+data class PlaybackSyncRejected(
+    @param:Json(name = "chapter_id") val chapterId: Int = 0,
+    val reason: String = "",
+    @param:Json(name = "server_updated_at") val serverUpdatedAt: String? = null,
+)
+
+/** What the server holds for a chapter after the batch was applied. */
+data class PlaybackStateRow(
+    @param:Json(name = "chapter_id") val chapterId: Int = 0,
+    @param:Json(name = "position_seconds") val positionSeconds: Double = 0.0,
+    @param:Json(name = "is_played") val isPlayed: Boolean = false,
+    @param:Json(name = "last_listened_at") val lastListenedAt: String? = null,
+    @param:Json(name = "updated_at") val updatedAt: String? = null,
+    @param:Json(name = "client_updated_at") val clientUpdatedAt: String? = null,
+)
+
+data class PlaybackSyncResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    @param:Json(name = "server_time") val serverTime: String? = null,
+    val accepted: List<PlaybackSyncAccepted> = emptyList(),
+    val rejected: List<PlaybackSyncRejected> = emptyList(),
+    @param:Json(name = "server_state") val serverState: List<PlaybackStateRow> = emptyList(),
+)

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ProgressOutbox.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ProgressOutbox.kt
@@ -1,0 +1,64 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.io.File
+
+/**
+ * Listening positions that have not reached the server yet, held on disk.
+ *
+ * On disk rather than in memory because the case that loses data is the one where the app is closed
+ * before the network comes back. An in-memory queue would drop exactly the writes that most need
+ * keeping.
+ *
+ * At most one entry per chapter: only the furthest position matters, and the server compares by
+ * timestamp anyway, so an older entry for the same chapter could never win once a newer one exists.
+ * That also bounds the file by the number of chapters actually listened to offline rather than by
+ * how long the session ran.
+ */
+class ProgressOutbox(private val file: File) {
+    private val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    private val adapter = moshi.adapter<List<PendingProgress>>(
+        Types.newParameterizedType(List::class.java, PendingProgress::class.java),
+    )
+
+    private val lock = Any()
+    private val pending: LinkedHashMap<Int, PendingProgress> = load()
+
+    fun record(entry: PendingProgress) = synchronized(lock) {
+        pending[entry.chapterId] = entry
+        persist()
+    }
+
+    fun snapshot(): List<PendingProgress> = synchronized(lock) { pending.values.toList() }
+
+    fun drop(chapterIds: Collection<Int>) = synchronized(lock) {
+        if (chapterIds.isEmpty()) return@synchronized
+        chapterIds.forEach { pending.remove(it) }
+        persist()
+    }
+
+    /** Used when the credential dies: an unauthenticated queue can never be flushed. */
+    fun clear() = synchronized(lock) {
+        if (pending.isEmpty()) return@synchronized
+        pending.clear()
+        persist()
+    }
+
+    private fun persist() {
+        runCatching {
+            file.parentFile?.mkdirs()
+            file.writeText(adapter.toJson(pending.values.toList()))
+        }
+    }
+
+    private fun load(): LinkedHashMap<Int, PendingProgress> {
+        val stored = runCatching {
+            if (file.isFile) adapter.fromJson(file.readText()) else null
+        }.getOrNull().orEmpty()
+        return LinkedHashMap<Int, PendingProgress>().apply {
+            stored.forEach { put(it.chapterId, it) }
+        }
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import retrofit2.HttpException
@@ -34,8 +35,21 @@ class TtsRoadRepository(private val sessionStore: SessionStore) {
 
     private val apiCache = HashMap<String, TtsRoadApi>()
 
+    private val outbox = ProgressOutbox(configDir().resolve("progress-outbox.json"))
+
     private val _capabilities = MutableStateFlow(ServerCapabilities())
     private val _limits = MutableStateFlow(ServerLimits())
+    private val _serverPlaybackState = MutableStateFlow<Map<Int, PlaybackStateRow>>(emptyMap())
+
+    /**
+     * What the server says it holds for chapters this client has written to, as of the last flush.
+     *
+     * This is how a losing write gets noticed. `/playback/sync` returns the server's own state for
+     * every chapter in the batch, so when an offline position loses to a newer one from the
+     * browser, the newer position is right here — and playback resumes from it instead of from the
+     * stale local one.
+     */
+    val serverPlaybackState: StateFlow<Map<Int, PlaybackStateRow>> = _serverPlaybackState.asStateFlow()
 
     /**
      * What the currently-connected server supports. Starts all-false and stays that way until
@@ -103,6 +117,10 @@ class TtsRoadRepository(private val sessionStore: SessionStore) {
 
     suspend fun logout() = withContext(Dispatchers.IO) {
         val session = sessionStore.current()
+        // Last chance to save: the token is about to be revoked, and anything still queued after
+        // that can never be sent under it. A clean sign-out should not cost the user their place.
+        runCatching { flushProgress() }
+        outbox.clear()
         runCatching {
             session.authorizationHeader?.let { auth -> api(session.serverUrl).logout(auth) }
         }
@@ -120,18 +138,100 @@ class TtsRoadRepository(private val sessionStore: SessionStore) {
     suspend fun markPlayed(chapterIds: List<Int>, played: Boolean): PlaybackMarkResponse =
         withAuthorizedApi { api, auth -> api.markPlayback(auth, PlaybackMarkRequest(chapterIds, played)) }
 
-    suspend fun saveProgress(
+    /**
+     * Record a listening position and try to get it to the server.
+     *
+     * The write is stamped and queued to disk first, then flushed. That ordering is the fix for
+     * #36: if the flush fails — offline, server down, laptop closed — the position survives with
+     * the time it was actually reached, so when it does reach the server it can be ordered against
+     * whatever else has happened since instead of blindly overwriting it.
+     *
+     * A flush failure is not raised to the caller. Playback must not stall because progress could
+     * not be saved; the entry stays queued and the next call retries it.
+     */
+    suspend fun recordProgress(
         fictionId: Int,
         chapterId: Int,
         positionSeconds: Double,
         isPlayed: Boolean,
-    ): PlaybackProgressResponse? = withContext(Dispatchers.IO) {
-        val session = sessionStore.current()
-        val auth = session.authorizationHeader ?: return@withContext null
-        api(session.serverUrl).saveProgress(
-            auth,
-            PlaybackProgressRequest(fictionId, chapterId, positionSeconds.coerceAtLeast(0.0), isPlayed),
+    ) {
+        outbox.record(
+            PendingProgress(
+                fictionId = fictionId,
+                chapterId = chapterId,
+                positionSeconds = positionSeconds.coerceAtLeast(0.0),
+                isPlayed = isPlayed,
+                clientUpdatedAt = nowStamp(),
+            ),
         )
+        runCatching { flushProgress() }
+    }
+
+    /**
+     * Send everything queued.
+     *
+     * Batched through `/playback/sync` when the server has it, in chunks of the server's published
+     * `max_playback_sync_items` — it answers an oversized batch with a 400 rather than truncating,
+     * so ignoring the limit would lose the whole batch.
+     *
+     * Falls back to `/playback/progress` when `batch_progress` is false. That endpoint cannot order
+     * writes, so the overwrite this all exists to prevent is still possible against an older
+     * server — but losing the position entirely would be worse, and the backend keeps the endpoint
+     * working deliberately.
+     */
+    suspend fun flushProgress() = withContext(Dispatchers.IO) {
+        val session = sessionStore.current()
+        val auth = session.authorizationHeader ?: return@withContext
+        val pending = outbox.snapshot()
+        if (pending.isEmpty()) return@withContext
+        val api = api(session.serverUrl)
+
+        try {
+            if (capabilities.value.batchProgress) {
+                val batchSize = limits.value.maxPlaybackSyncItems.coerceAtLeast(1)
+                pending.chunked(batchSize).forEach { batch ->
+                    val response = api.syncProgress(
+                        auth,
+                        PlaybackSyncRequest(
+                            batch.map {
+                                PlaybackSyncItem(
+                                    chapterId = it.chapterId,
+                                    positionSeconds = it.positionSeconds,
+                                    isPlayed = it.isPlayed,
+                                    clientUpdatedAt = it.clientUpdatedAt,
+                                )
+                            },
+                        ),
+                    )
+                    // Rejections are as final as acceptances — every reason the server can give is
+                    // terminal for that item, so re-sending would just get the same answer.
+                    outbox.drop(response.accepted.map { it.chapterId } + response.rejected.map { it.chapterId })
+                    if (response.serverState.isNotEmpty()) {
+                        _serverPlaybackState.update { known ->
+                            known + response.serverState.associateBy { it.chapterId }
+                        }
+                    }
+                }
+            } else {
+                pending.forEach { entry ->
+                    api.saveProgress(
+                        auth,
+                        PlaybackProgressRequest(
+                            entry.fictionId,
+                            entry.chapterId,
+                            entry.positionSeconds,
+                            entry.isPlayed,
+                        ),
+                    )
+                    outbox.drop(listOf(entry.chapterId))
+                }
+            }
+        } catch (e: HttpException) {
+            // 401 means the credential is gone, so this queue can never be flushed under it.
+            // Anything else is transient as far as this client can tell — keep the queue.
+            if (e.code() == 401) outbox.clear()
+            throw e
+        }
     }
 
     /** Authorization header that audio requests must carry (bearer-protected MP3s). */

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/SessionStore.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/SessionStore.kt
@@ -47,17 +47,22 @@ class SessionStore {
     private fun load(): SessionState =
         runCatching { if (file.isFile) adapter.fromJson(file.readText()) else null }
             .getOrNull() ?: SessionState()
+}
 
-    private fun configDir(): File {
-        val home = System.getProperty("user.home")
-        val os = System.getProperty("os.name").lowercase()
-        val base = when {
-            os.contains("win") -> System.getenv("APPDATA")?.let { File(it) } ?: File(home, "AppData/Roaming")
-            os.contains("mac") -> File(home, "Library/Application Support")
-            else -> System.getenv("XDG_CONFIG_HOME")?.let { File(it) } ?: File(home, ".config")
-        }
-        return File(base, "TTSRoad")
+/**
+ * Per-user config directory: %APPDATA%/TTSRoad on Windows, ~/Library/Application Support/TTSRoad on
+ * macOS, $XDG_CONFIG_HOME/TTSRoad (or ~/.config/TTSRoad) elsewhere. Shared by everything that
+ * persists across runs, so the session and the unsent-progress outbox live side by side.
+ */
+fun configDir(): File {
+    val home = System.getProperty("user.home")
+    val os = System.getProperty("os.name").lowercase()
+    val base = when {
+        os.contains("win") -> System.getenv("APPDATA")?.let { File(it) } ?: File(home, "AppData/Roaming")
+        os.contains("mac") -> File(home, "Library/Application Support")
+        else -> System.getenv("XDG_CONFIG_HOME")?.let { File(it) } ?: File(home, ".config")
     }
+    return File(base, "TTSRoad")
 }
 
 fun normalizeBaseUrl(input: String): String {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -38,6 +38,12 @@ interface TtsRoadApi {
         @Body request: PlaybackProgressRequest,
     ): PlaybackProgressResponse
 
+    @POST("api/mobile/playback/sync")
+    suspend fun syncProgress(
+        @Header("Authorization") auth: String,
+        @Body request: PlaybackSyncRequest,
+    ): PlaybackSyncResponse
+
     @POST("api/mobile/playback/mark")
     suspend fun markPlayback(
         @Header("Authorization") auth: String,

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackController.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackController.kt
@@ -180,8 +180,19 @@ class Mp3PlaybackController(private val repository: TtsRoadRepository) : Playbac
         wantsPlaying = false
     }
 
-    private fun resumeMsOf(chapter: ChapterSummary): Long =
-        (chapter.resolvedPositionSeconds * 1000).toLong().coerceAtLeast(0L)
+    /**
+     * Where to start this chapter.
+     *
+     * Prefers the server's reconciled state when there is one. That map is only populated by a
+     * `/playback/sync` round-trip, which is strictly later than the chapter list this summary came
+     * from — so when an offline position here lost to a newer one from the browser, this is what
+     * picks up the browser's position instead of silently restarting from the stale local one.
+     */
+    private fun resumeMsOf(chapter: ChapterSummary): Long {
+        val reconciled = repository.serverPlaybackState.value[chapter.resolvedChapterId]
+        val seconds = reconciled?.positionSeconds ?: chapter.resolvedPositionSeconds
+        return (seconds * 1000).toLong().coerceAtLeast(0L)
+    }
 
     private suspend fun beginPlayback(startIndex: Int, startMs: Long) {
         playJob?.cancelAndJoin()
@@ -312,7 +323,7 @@ class Mp3PlaybackController(private val repository: TtsRoadRepository) : Playbac
 
     private suspend fun saveProgress(chapter: ChapterSummary, positionMs: Long, isPlayed: Boolean) {
         runCatching {
-            repository.saveProgress(
+            repository.recordProgress(
                 fictionId = chapter.resolvedFictionId,
                 chapterId = chapter.resolvedChapterId,
                 positionSeconds = positionMs / 1000.0,

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ProgressOutboxTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ProgressOutboxTest.kt
@@ -1,0 +1,114 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ProgressOutboxTest {
+    private lateinit var dir: File
+    private lateinit var file: File
+
+    @BeforeTest
+    fun setUp() {
+        dir = Files.createTempDirectory("ttsroad-outbox").toFile()
+        file = dir.resolve("progress-outbox.json")
+    }
+
+    @AfterTest
+    fun tearDown() {
+        dir.deleteRecursively()
+    }
+
+    private fun entry(chapterId: Int, position: Double, stamp: String) = PendingProgress(
+        fictionId = 1,
+        chapterId = chapterId,
+        positionSeconds = position,
+        isPlayed = false,
+        clientUpdatedAt = stamp,
+    )
+
+    @Test
+    fun `survives a restart`() {
+        ProgressOutbox(file).record(entry(7, 120.0, "2026-08-11T10:00:00.000Z"))
+
+        val reopened = ProgressOutbox(file).snapshot()
+
+        assertEquals(1, reopened.size)
+        assertEquals(7, reopened.first().chapterId)
+        assertEquals(120.0, reopened.first().positionSeconds)
+        assertEquals("2026-08-11T10:00:00.000Z", reopened.first().clientUpdatedAt)
+    }
+
+    @Test
+    fun `keeps only the latest entry per chapter`() {
+        val outbox = ProgressOutbox(file)
+        outbox.record(entry(7, 120.0, "2026-08-11T10:00:00.000Z"))
+        outbox.record(entry(7, 340.0, "2026-08-11T10:05:00.000Z"))
+
+        val snapshot = outbox.snapshot()
+
+        assertEquals(1, snapshot.size)
+        assertEquals(340.0, snapshot.first().positionSeconds)
+        assertEquals("2026-08-11T10:05:00.000Z", snapshot.first().clientUpdatedAt)
+    }
+
+    @Test
+    fun `tracks chapters independently`() {
+        val outbox = ProgressOutbox(file)
+        outbox.record(entry(7, 120.0, "2026-08-11T10:00:00.000Z"))
+        outbox.record(entry(8, 60.0, "2026-08-11T10:01:00.000Z"))
+
+        assertEquals(setOf(7, 8), outbox.snapshot().map { it.chapterId }.toSet())
+    }
+
+    @Test
+    fun `dropping an acknowledged chapter leaves the rest queued`() {
+        val outbox = ProgressOutbox(file)
+        outbox.record(entry(7, 120.0, "2026-08-11T10:00:00.000Z"))
+        outbox.record(entry(8, 60.0, "2026-08-11T10:01:00.000Z"))
+
+        outbox.drop(listOf(7))
+
+        assertEquals(listOf(8), outbox.snapshot().map { it.chapterId })
+        assertEquals(listOf(8), ProgressOutbox(file).snapshot().map { it.chapterId })
+    }
+
+    @Test
+    fun `clear empties the queue on disk too`() {
+        val outbox = ProgressOutbox(file)
+        outbox.record(entry(7, 120.0, "2026-08-11T10:00:00.000Z"))
+
+        outbox.clear()
+
+        assertTrue(outbox.snapshot().isEmpty())
+        assertTrue(ProgressOutbox(file).snapshot().isEmpty())
+    }
+
+    @Test
+    fun `an unreadable file starts empty rather than throwing`() {
+        file.parentFile.mkdirs()
+        file.writeText("{ this is not the json you are looking for")
+
+        assertTrue(ProgressOutbox(file).snapshot().isEmpty())
+    }
+
+    /**
+     * The backend hands `client_updated_at` to `datetime.fromisoformat`, which before Python 3.11
+     * accepts only three or six fractional digits. `Instant.now().toString()` can emit nine, and a
+     * stamp it cannot parse comes back as `invalid_client_updated_at` — the write is dropped, which
+     * is the exact data loss this whole path exists to prevent.
+     */
+    @Test
+    fun `now stamp is parseable by the backend`() {
+        val pattern = Regex("""^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$""")
+
+        repeat(50) {
+            val stamp = nowStamp()
+            assertTrue(pattern.matches(stamp), "unparseable stamp: $stamp")
+        }
+    }
+}


### PR DESCRIPTION
Fixes the data-loss half of #36. **Stacked on #43** — review that first; the base retargets to `master` once #43 merges.

## The bug

`Mp3PlaybackController` saved progress through `/api/mobile/playback/progress`: untimestamped, one chapter at a time, and a failed save was swallowed by a bare `runCatching`. That endpoint writes whatever it is handed. Listen here while offline, listen in the browser afterwards, reconnect — the older position wins, because the server has no way to order the two writes.

## The fix

Positions are **stamped and queued to disk, then sent**. The ordering is the point: if the flush fails, the position survives with the time it was *actually reached*, so when it eventually lands it can be ordered against everything that happened since.

- `ProgressOutbox` — on disk, because the case that loses data is the one where the app closes before the network returns. One entry per chapter (only the furthest position matters, and the server compares by stamp anyway), which bounds the file by chapters listened to rather than by session length.
- `/playback/sync` when `batch_progress` is true, chunked to the server's published `max_playback_sync_items`. That limit is not advisory — an oversized batch gets a 400 rather than being truncated, so ignoring it loses *all* of it.
- Falls back to `/playback/progress` when the capability is false. That server still cannot order writes, but losing the position entirely is worse, and the backend keeps the endpoint working deliberately.

## Where `server_state` actually gets used

`/playback/sync` returns what the server holds for every chapter in the batch. `resumeMsOf` now prefers that over the chapter payload, because it comes from a strictly later round-trip. So the concrete user-visible outcome: **a chapter whose local write lost now resumes from the browser's position** instead of silently restarting from the stale local one. That is the bug in #36 closing.

## Retry policy

Rejections are dropped, not retried — `not_found`, `stale`, `empty`, `missing_client_updated_at`, `invalid_client_updated_at` are all terminal for that item, so re-sending gets the same answer. Only transport failure keeps the queue. A 401 clears it (nothing queued can be sent under a dead credential); a clean sign-out flushes first so signing out does not cost you your place.

## One bug found while writing this

`Instant.now().toString()` emits as many fractional digits as the platform clock has — up to nine. The backend's `parse_iso8601` hands the string to `datetime.fromisoformat`, which before Python 3.11 accepts only three or six. A nine-digit stamp comes back as `invalid_client_updated_at` and the write is dropped — the exact data loss this endpoint exists to prevent. `nowStamp()` truncates to milliseconds; there's a test pinning the format.

## The clock question in #36 is already answered

The issue asks whether to trust the device wall clock. The backend already does `effective = min(stamp, now)`, so a fast clock cannot stamp into the future and win every comparison. Trusting the local clock is safe as written — no client-side skew detection needed.

## Not included: delta sync

#36 also asks for `GET /api/mobile/sync` feeding `LibraryDiskCache`. **There is no library disk cache in this repo** — the library is fetched fresh into memory on every visit to `LibraryScreen`. Adding the endpoint now would mean an API method nothing calls, which is the exact thing #35 objects to. It needs a persistent cache first. Leaving #36 open for that half.

## Verification

`./gradlew compileKotlin` and `./gradlew test` pass — 7 tests, 0 failures, covering outbox persistence across restart, per-chapter dedupe, selective drop, clear, corrupt-file recovery, and the stamp format.

Adds a test source set; there was none. Not exercised against a running server — no TTSRoad instance in this environment, so the request/response wire format is unverified at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)