### PR TITLE
Add bookmarks

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -50,6 +50,7 @@ import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.player.Mp3PlaybackController
 import dk.perspektiva.ttsroad.desktop.ui.AarisCard
 import dk.perspektiva.ttsroad.desktop.ui.AarisColor
+import dk.perspektiva.ttsroad.desktop.ui.BookmarksScreen
 import dk.perspektiva.ttsroad.desktop.ui.ContentMaxWidth
 import dk.perspektiva.ttsroad.desktop.ui.FictionDetailScreen
 import dk.perspektiva.ttsroad.desktop.ui.LibraryScreen
@@ -66,15 +67,18 @@ private sealed interface Screen {
     data object Library : Screen
     data class Fiction(val fiction: FictionSummary) : Screen
     data object Player : Screen
+    data object Bookmarks : Screen
     data object Settings : Screen
 }
 
 @Composable
 fun App() {
+    val scope = rememberCoroutineScope()
     val sessionStore = remember { SessionStore() }
     val repository = remember { TtsRoadRepository(sessionStore) }
     val playback = remember { Mp3PlaybackController(repository) }
     val session by sessionStore.session.collectAsState()
+    val capabilities by repository.capabilities.collectAsState()
     var screen by remember { mutableStateOf<Screen>(Screen.Library) }
     // Where the full player collapses back to, so expanding the bar never loses browse context.
     var playerReturn by remember { mutableStateOf<Screen>(Screen.Library) }
@@ -104,6 +108,7 @@ fun App() {
                 HeaderBar(
                     serverName = session.serverName,
                     current = screen,
+                    showBookmarks = capabilities.bookmarks,
                     onSelect = { screen = it },
                 )
                 HorizontalDivider(thickness = 1.dp, color = AarisColor.Line)
@@ -121,7 +126,16 @@ fun App() {
                             playback,
                             onBack = { screen = Screen.Library },
                         )
-                        Screen.Player -> PlayerScreen(playback, onBack = { screen = playerReturn })
+                        Screen.Player -> PlayerScreen(playback, repository, onBack = { screen = playerReturn })
+                        Screen.Bookmarks -> BookmarksScreen(
+                            repository,
+                            onOpenChapter = { fictionId, chapterId, positionSeconds ->
+                                scope.launch {
+                                    playFromBookmark(repository, playback, fictionId, chapterId, positionSeconds)
+                                }
+                                openPlayer()
+                            },
+                        )
                         Screen.Settings -> SettingsScreen(sessionStore, repository)
                     }
                 }
@@ -133,8 +147,33 @@ fun App() {
     }
 }
 
+/**
+ * Start a bookmarked position.
+ *
+ * The whole fiction is loaded so next/previous and auto-advance behave as they do anywhere else —
+ * a bookmark is a place in a book, not a detached clip. The position is passed into [playQueue]
+ * rather than seeked to afterwards, because a seek issued before the media loads is discarded.
+ */
+private suspend fun playFromBookmark(
+    repository: TtsRoadRepository,
+    playback: Mp3PlaybackController,
+    fictionId: Int,
+    chapterId: Int,
+    positionSeconds: Double,
+) {
+    runCatching {
+        val response = repository.chapters(fictionId)
+        playback.playQueue(response.chapters, chapterId, response.fiction, startPositionSeconds = positionSeconds)
+    }
+}
+
 @Composable
-private fun HeaderBar(serverName: String, current: Screen, onSelect: (Screen) -> Unit) {
+private fun HeaderBar(
+    serverName: String,
+    current: Screen,
+    showBookmarks: Boolean,
+    onSelect: (Screen) -> Unit,
+) {
     Box(Modifier.fillMaxWidth().background(AarisColor.Bg)) {
         Row(
             Modifier
@@ -162,6 +201,9 @@ private fun HeaderBar(serverName: String, current: Screen, onSelect: (Screen) ->
                 "Library",
                 active = current is Screen.Library || current is Screen.Fiction,
             ) { onSelect(Screen.Library) }
+            if (showBookmarks) {
+                NavItem("Bookmarks", active = current is Screen.Bookmarks) { onSelect(Screen.Bookmarks) }
+            }
             NavItem("Settings", active = current is Screen.Settings) { onSelect(Screen.Settings) }
         }
     }
@@ -279,7 +321,7 @@ private data class CapabilityLine(
 
 private fun capabilityLines(c: ServerCapabilities): List<CapabilityLine> = listOf(
     CapabilityLine("Global search", c.search, usedByClient = false),
-    CapabilityLine("Bookmarks", c.bookmarks, usedByClient = false),
+    CapabilityLine("Bookmarks", c.bookmarks, usedByClient = true),
     CapabilityLine("Cross-library queue", c.queue, usedByClient = false),
     CapabilityLine("Follow / unfollow", c.follows, usedByClient = false),
     CapabilityLine("Batch progress sync", c.batchProgress, usedByClient = true),

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Bookmarks.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Bookmarks.kt
@@ -1,0 +1,91 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Json
+
+/**
+ * One bookmark, in the same shape the web reads from `/api/bookmarks` — same rows, different door,
+ * so a mark made here shows up in the browser.
+ *
+ * [chapterId] is nullable because it really can be null: when a chapter is hard-deleted the server
+ * soft-deletes its marks and clears the link rather than letting the foreign key cascade take the
+ * rows silently. Such a bookmark has no position left to seek to.
+ *
+ * Chapter and fiction titles ride along so an account-wide list can render without a second request
+ * per row.
+ */
+data class Bookmark(
+    val id: Int = 0,
+    @param:Json(name = "user_id") val userId: Int = 0,
+    @param:Json(name = "chapter_id") val chapterId: Int? = null,
+    @param:Json(name = "fiction_id") val fictionId: Int? = null,
+    @param:Json(name = "position_seconds") val positionSeconds: Double = 0.0,
+    @param:Json(name = "position_label") val positionLabel: String? = null,
+    val label: String? = null,
+    val note: String? = null,
+    val color: String? = null,
+    val kind: String = BookmarkKind.MANUAL,
+    @param:Json(name = "created_at") val createdAt: String? = null,
+    @param:Json(name = "updated_at") val updatedAt: String? = null,
+    @param:Json(name = "deleted_at") val deletedAt: String? = null,
+    @param:Json(name = "chapter_title") val chapterTitle: String? = null,
+    @param:Json(name = "chapter_number") val chapterNumber: Double? = null,
+    @param:Json(name = "fiction_title") val fictionTitle: String? = null,
+    @param:Json(name = "fiction_slug") val fictionSlug: String? = null,
+) {
+    /** A retired mark points at a chapter that no longer exists, so it cannot be played. */
+    val isPlayable: Boolean get() = chapterId != null
+}
+
+object BookmarkKind {
+    /** A mark the user chose to make. */
+    const val MANUAL = "manual"
+
+    /**
+     * A breadcrumb recorded because playback stopped somewhere, not because anyone chose it. Shares
+     * the table so both can sync on one endpoint, but filterable so a list of chosen marks is not
+     * drowned in them. This client only writes MANUAL.
+     */
+    const val AUTO = "auto"
+}
+
+data class BookmarkCreateRequest(
+    @param:Json(name = "chapter_id") val chapterId: Int,
+    @param:Json(name = "position_seconds") val positionSeconds: Double,
+    val label: String? = null,
+    val note: String? = null,
+    val color: String? = null,
+    val kind: String = BookmarkKind.MANUAL,
+)
+
+/**
+ * A partial update. Moshi omits null fields, and the server reads an absent key as "leave it
+ * alone" — so a request that sets only [label] does not blank the note.
+ */
+data class BookmarkUpdateRequest(
+    @param:Json(name = "position_seconds") val positionSeconds: Double? = null,
+    val label: String? = null,
+    val note: String? = null,
+    val color: String? = null,
+    val kind: String? = null,
+)
+
+data class BookmarkListResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    @param:Json(name = "server_time") val serverTime: String? = null,
+    @param:Json(name = "updated_since") val updatedSince: String? = null,
+    val bookmarks: List<Bookmark> = emptyList(),
+    /** Tombstoned ids — only populated on a delta pull, empty on a full one. */
+    val deleted: List<Int> = emptyList(),
+)
+
+data class BookmarkWriteResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    val bookmark: Bookmark,
+)
+
+data class BookmarkDeleteResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    val status: String = "",
+    val id: Int = 0,
+    @param:Json(name = "deleted_at") val deletedAt: String? = null,
+)

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -138,6 +138,51 @@ class TtsRoadRepository(private val sessionStore: SessionStore) {
     suspend fun markPlayed(chapterIds: List<Int>, played: Boolean): PlaybackMarkResponse =
         withAuthorizedApi { api, auth -> api.markPlayback(auth, PlaybackMarkRequest(chapterIds, played)) }
 
+    /** Every live mark on the account, or just one book's when [fictionId] is given. */
+    suspend fun bookmarks(fictionId: Int? = null): List<Bookmark> =
+        withAuthorizedApi { api, auth -> api.bookmarks(auth, fictionId = fictionId).bookmarks }
+
+    suspend fun createBookmark(
+        chapterId: Int,
+        positionSeconds: Double,
+        label: String? = null,
+        note: String? = null,
+    ): Bookmark = withAuthorizedApi { api, auth ->
+        api.createBookmark(
+            auth,
+            BookmarkCreateRequest(
+                chapterId = chapterId,
+                positionSeconds = positionSeconds.coerceAtLeast(0.0),
+                label = label?.trim()?.ifBlank { null },
+                note = note?.trim()?.ifBlank { null },
+            ),
+        ).bookmark
+    }
+
+    /**
+     * Patch one field. Null means "not mentioned" here, not "clear it" — Moshi omits nulls and the
+     * server leaves absent keys alone, so renaming a mark cannot wipe its note.
+     */
+    suspend fun updateBookmark(
+        bookmarkId: Int,
+        label: String? = null,
+        note: String? = null,
+        positionSeconds: Double? = null,
+    ): Bookmark = withAuthorizedApi { api, auth ->
+        api.updateBookmark(
+            auth,
+            bookmarkId,
+            BookmarkUpdateRequest(
+                label = label,
+                note = note,
+                positionSeconds = positionSeconds,
+            ),
+        ).bookmark
+    }
+
+    suspend fun deleteBookmark(bookmarkId: Int): BookmarkDeleteResponse =
+        withAuthorizedApi { api, auth -> api.deleteBookmark(auth, bookmarkId) }
+
     /**
      * Record a listening position and try to get it to the server.
      *

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -1,8 +1,10 @@
 package dk.perspektiva.ttsroad.desktop.data
 
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Header
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -37,6 +39,33 @@ interface TtsRoadApi {
         @Header("Authorization") auth: String,
         @Body request: PlaybackProgressRequest,
     ): PlaybackProgressResponse
+
+    @GET("api/mobile/bookmarks")
+    suspend fun bookmarks(
+        @Header("Authorization") auth: String,
+        @Query("fiction_id") fictionId: Int? = null,
+        @Query("chapter_id") chapterId: Int? = null,
+        @Query("kind") kind: String? = null,
+    ): BookmarkListResponse
+
+    @POST("api/mobile/bookmarks")
+    suspend fun createBookmark(
+        @Header("Authorization") auth: String,
+        @Body request: BookmarkCreateRequest,
+    ): BookmarkWriteResponse
+
+    @PATCH("api/mobile/bookmarks/{bookmark_id}")
+    suspend fun updateBookmark(
+        @Header("Authorization") auth: String,
+        @Path("bookmark_id") bookmarkId: Int,
+        @Body request: BookmarkUpdateRequest,
+    ): BookmarkWriteResponse
+
+    @DELETE("api/mobile/bookmarks/{bookmark_id}")
+    suspend fun deleteBookmark(
+        @Header("Authorization") auth: String,
+        @Path("bookmark_id") bookmarkId: Int,
+    ): BookmarkDeleteResponse
 
     @POST("api/mobile/playback/sync")
     suspend fun syncProgress(

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackController.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackController.kt
@@ -57,8 +57,17 @@ interface PlaybackController {
     /**
      * Play a whole fiction as a queue, starting at [startChapterId] — enables next/previous,
      * auto-advance, and the up-next list (mirrors the Android client's playQueue).
+     *
+     * [startPositionSeconds] overrides where that chapter resumes from. Seeking after the call
+     * would not work: the position is only settable once media has loaded, so a seek issued
+     * immediately after starting is dropped. Jumping to a bookmark needs the position up front.
      */
-    suspend fun playQueue(chapters: List<ChapterSummary>, startChapterId: Int, fiction: FictionSummary?)
+    suspend fun playQueue(
+        chapters: List<ChapterSummary>,
+        startChapterId: Int,
+        fiction: FictionSummary?,
+        startPositionSeconds: Double? = null,
+    )
     fun togglePlayPause()
     fun seekTo(positionMs: Long)
     fun skipBy(deltaMs: Long)
@@ -114,7 +123,12 @@ class Mp3PlaybackController(private val repository: TtsRoadRepository) : Playbac
         beginPlayback(0, resumeMsOf(chapter))
     }
 
-    override suspend fun playQueue(chapters: List<ChapterSummary>, startChapterId: Int, fiction: FictionSummary?) {
+    override suspend fun playQueue(
+        chapters: List<ChapterSummary>,
+        startChapterId: Int,
+        fiction: FictionSummary?,
+        startPositionSeconds: Double?,
+    ) {
         val playable = chapters.filter { it.audio != null }
         if (playable.isEmpty()) {
             _state.update { it.copy(error = "No playable chapters yet") }
@@ -123,7 +137,10 @@ class Mp3PlaybackController(private val repository: TtsRoadRepository) : Playbac
         queue = playable
         queueFiction = fiction
         val startIndex = playable.indexOfFirst { it.resolvedChapterId == startChapterId }.coerceAtLeast(0)
-        beginPlayback(startIndex, resumeMsOf(playable[startIndex]))
+        val startMs = startPositionSeconds
+            ?.let { (it * 1000).toLong().coerceAtLeast(0L) }
+            ?: resumeMsOf(playable[startIndex])
+        beginPlayback(startIndex, startMs)
     }
 
     override fun togglePlayPause() {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/BookmarksScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/BookmarksScreen.kt
@@ -1,0 +1,243 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.data.Bookmark
+import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
+import kotlinx.coroutines.launch
+
+/**
+ * The account's marks, newest book first.
+ *
+ * Grouped by fiction because a flat list of positions with no book attached is unreadable once
+ * there is more than one book in it — and the payload carries the titles precisely so this can be
+ * rendered without a request per row.
+ */
+@Composable
+fun BookmarksScreen(
+    repository: TtsRoadRepository,
+    onOpenChapter: (fictionId: Int, chapterId: Int, positionSeconds: Double) -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    var state by remember { mutableStateOf<Load<List<Bookmark>>>(Load.Loading) }
+    var actionError by remember { mutableStateOf<String?>(null) }
+    var editing by remember { mutableStateOf<Int?>(null) }
+
+    suspend fun load() {
+        state = runCatching { repository.bookmarks() }
+            .fold({ Load.Ok(it) }, { Load.Err(it.message ?: "Could not load bookmarks") })
+    }
+
+    LaunchedEffect(Unit) { load() }
+
+    when (val s = state) {
+        Load.Loading -> CenterProgress()
+        is Load.Err -> CenterError(s.message)
+        is Load.Ok -> PageScroll {
+            SectionTitle("01", "Bookmarks — ${s.value.size}")
+            Spacer(Modifier.height(8.dp))
+            actionError?.let {
+                Text(it, color = MaterialTheme.colorScheme.error)
+                Spacer(Modifier.height(8.dp))
+            }
+            if (s.value.isEmpty()) {
+                MetaText("No bookmarks yet — mark a position from the player")
+            } else {
+                s.value.groupBy { it.fictionTitle ?: "Unknown fiction" }
+                    .forEach { (fictionTitle, marks) ->
+                        Spacer(Modifier.height(20.dp))
+                        MetaText("// $fictionTitle", color = AarisColor.Accent)
+                        Spacer(Modifier.height(8.dp))
+                        marks.sortedWith(compareBy({ it.chapterNumber ?: 0.0 }, { it.positionSeconds }))
+                            .forEach { bookmark ->
+                                BookmarkRow(
+                                    bookmark = bookmark,
+                                    isEditing = editing == bookmark.id,
+                                    onPlay = {
+                                        val chapterId = bookmark.chapterId
+                                        val fictionId = bookmark.fictionId
+                                        if (chapterId != null && fictionId != null) {
+                                            onOpenChapter(fictionId, chapterId, bookmark.positionSeconds)
+                                        }
+                                    },
+                                    onStartEdit = { editing = bookmark.id },
+                                    onCancelEdit = { editing = null },
+                                    onRename = { label ->
+                                        scope.launch {
+                                            actionError = null
+                                            runCatching {
+                                                repository.updateBookmark(bookmark.id, label = label)
+                                                editing = null
+                                                load()
+                                            }.onFailure { actionError = it.message ?: "Could not rename bookmark" }
+                                        }
+                                    },
+                                    onDelete = {
+                                        scope.launch {
+                                            actionError = null
+                                            runCatching {
+                                                repository.deleteBookmark(bookmark.id)
+                                                load()
+                                            }.onFailure { actionError = it.message ?: "Could not delete bookmark" }
+                                        }
+                                    },
+                                )
+                                HorizontalDivider(thickness = 1.dp, color = AarisColor.LineSoft)
+                            }
+                    }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BookmarkRow(
+    bookmark: Bookmark,
+    isEditing: Boolean,
+    onPlay: () -> Unit,
+    onStartEdit: () -> Unit,
+    onCancelEdit: () -> Unit,
+    onRename: (String) -> Unit,
+    onDelete: () -> Unit,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    val playable = bookmark.isPlayable
+
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .hoverable(interaction)
+            .let { if (playable && !isEditing) it.pointerHoverIcon(PointerIcon.Hand) else it }
+            .clickable(
+                interactionSource = interaction,
+                indication = null,
+                enabled = playable && !isEditing,
+                onClick = onPlay,
+            )
+            .background(if (hovered && playable && !isEditing) AarisColor.BgRaise else Color.Transparent)
+            .padding(horizontal = 12.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        MetaText(
+            bookmark.positionLabel ?: formatDuration((bookmark.positionSeconds * 1000).toLong()),
+            color = if (playable) AarisColor.Accent else AarisColor.Dim,
+            modifier = Modifier.width(72.dp),
+        )
+        Column(Modifier.weight(1f)) {
+            if (isEditing) {
+                var draft by remember(bookmark.id) { mutableStateOf(bookmark.label.orEmpty()) }
+                OutlinedTextField(
+                    value = draft,
+                    onValueChange = { draft = it },
+                    label = { Text("LABEL") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(8.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    RowIconAction(Icons.Default.Check, "Save label", AarisColor.Ok) { onRename(draft) }
+                    RowIconAction(Icons.Default.Close, "Cancel", AarisColor.Dim) { onCancelEdit() }
+                }
+            } else {
+                Text(
+                    bookmark.label?.takeIf { it.isNotBlank() } ?: bookmark.chapterTitle ?: "Bookmark",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = if (playable) AarisColor.Ink else AarisColor.Dim,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                val meta = listOfNotNull(
+                    bookmark.chapterTitle.takeIf { !bookmark.label.isNullOrBlank() },
+                    bookmark.note?.takeIf { it.isNotBlank() },
+                    "chapter removed".takeIf { !playable },
+                ).joinToString("  ·  ")
+                if (meta.isNotBlank()) {
+                    Spacer(Modifier.height(2.dp))
+                    MetaText(meta, color = AarisColor.Dim)
+                }
+            }
+        }
+        if (!isEditing) {
+            Spacer(Modifier.width(12.dp))
+            if (hovered) {
+                RowIconAction(Icons.Default.Edit, "Rename bookmark", AarisColor.Dim) { onStartEdit() }
+                Spacer(Modifier.width(8.dp))
+                RowIconAction(Icons.Default.Delete, "Delete bookmark", AarisColor.Danger) { onDelete() }
+                if (playable) {
+                    Spacer(Modifier.width(8.dp))
+                    Box(Modifier.size(30.dp).background(AarisColor.Accent), contentAlignment = Alignment.Center) {
+                        Icon(
+                            Icons.Default.PlayArrow,
+                            contentDescription = "Play from here",
+                            tint = AarisColor.Bg,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** Borderless hover-reveal icon action used inside list rows. */
+@Composable
+private fun RowIconAction(
+    icon: ImageVector,
+    contentDescription: String?,
+    tint: Color,
+    onClick: () -> Unit,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    Box(
+        Modifier
+            .size(30.dp)
+            .background(if (hovered) AarisColor.BgHover else Color.Transparent)
+            .hoverable(interaction)
+            .pointerHoverIcon(PointerIcon.Hand)
+            .clickable(interactionSource = interaction, indication = null, onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(icon, contentDescription, tint = if (hovered) AarisColor.Ink else tint, modifier = Modifier.size(18.dp))
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BookmarkAdd
 import androidx.compose.material.icons.filled.Forward30
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
@@ -32,6 +33,7 @@ import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
@@ -40,10 +42,12 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
@@ -51,19 +55,25 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.player.PlaybackController
 import dk.perspektiva.ttsroad.desktop.player.PlayerUiState
+import kotlinx.coroutines.launch
 
 /** Whether the mini-player should be visible: something has been loaded (or tried to load). */
 val PlayerUiState.hasSession: Boolean
     get() = hasMedia || durationMs > 0 || error != null
 
 @Composable
-fun PlayerScreen(playback: PlaybackController, onBack: () -> Unit) {
+fun PlayerScreen(playback: PlaybackController, repository: TtsRoadRepository, onBack: () -> Unit) {
+    val scope = rememberCoroutineScope()
     val s: PlayerUiState by playback.state.collectAsState()
+    val capabilities by repository.capabilities.collectAsState()
     // Track the drag locally and only seek on release — the MP3 backend re-decodes from the
     // start of the file per seek, so seeking on every drag tick would stutter badly.
     var dragMs by remember { mutableStateOf<Float?>(null) }
+    var bookmarkNote by remember { mutableStateOf<String?>(null) }
+    var bookmarkFailed by remember { mutableStateOf(false) }
 
     Box(Modifier.fillMaxSize().padding(horizontal = PageGutter, vertical = 20.dp)) {
         BackLink("Back", onBack)
@@ -130,6 +140,46 @@ fun PlayerScreen(playback: PlaybackController, onBack: () -> Unit) {
                         }
                         TransportButton(Icons.Default.SkipNext, "Next chapter", enabled = s.hasNext, size = 48.dp) {
                             playback.skipToNextChapter()
+                        }
+                    }
+                    // Gated on the server actually having bookmarks — offering a control that
+                    // 404s would be worse than not offering it.
+                    if (capabilities.bookmarks) {
+                        Spacer(Modifier.height(18.dp))
+                        val chapterId = s.queue.getOrNull(s.currentIndex)?.chapterId
+                        val positionMs = s.positionMs
+                        OutlinedButton(
+                            onClick = {
+                                val target = chapterId ?: return@OutlinedButton
+                                scope.launch {
+                                    bookmarkFailed = false
+                                    bookmarkNote = null
+                                    runCatching {
+                                        repository.createBookmark(
+                                            chapterId = target,
+                                            positionSeconds = positionMs / 1000.0,
+                                            label = s.title,
+                                        )
+                                    }.fold(
+                                        onSuccess = { bookmarkNote = "Bookmarked at ${formatDuration(positionMs)}" },
+                                        onFailure = {
+                                            bookmarkFailed = true
+                                            bookmarkNote = it.message ?: "Could not save bookmark"
+                                        },
+                                    )
+                                }
+                            },
+                            enabled = s.hasMedia && chapterId != null,
+                            shape = RectangleShape,
+                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                        ) {
+                            Icon(Icons.Default.BookmarkAdd, contentDescription = null, Modifier.size(18.dp))
+                            Spacer(Modifier.width(8.dp))
+                            Text("BOOKMARK THIS POSITION")
+                        }
+                        bookmarkNote?.let {
+                            Spacer(Modifier.height(8.dp))
+                            MetaText(it, color = if (bookmarkFailed) AarisColor.Danger else AarisColor.Ok)
                         }
                     }
                     Spacer(Modifier.height(12.dp))


### PR DESCRIPTION
Closes #37. **Stacked on #44** (which is stacked on #43) — the base retargets as those merge.

## What was there

`/api/mobile/bookmarks` ships `GET`, `POST` (201), `PATCH /{id}` and `DELETE /{id}`, backed by `app/services/bookmarks.py`. Same rows and same shapes as the web's `/api/bookmarks` — only the door differs, so a bookmark made here shows up in the browser. This client did nothing with any of it.

## What this adds

- The four calls plus DTOs in `data/Bookmarks.kt`.
- A **bookmark action in the player**, capturing the live position of the current chapter.
- An **account-wide list** grouped by fiction, with rename, delete, and play-from-here. Grouped because a flat list of timestamps with no book attached is unreadable past the first book — and the payload carries chapter and fiction titles precisely so this renders without a request per row.
- A "Bookmarks" nav item, and the Settings capability row flips to "Ready".

All of it gated on the `bookmarks` capability.

## Two things the contract forced

**`chapter_id` is nullable.** When a chapter is hard-deleted the server soft-deletes its marks and *clears the link* rather than letting the foreign key cascade take the rows silently — the reasoning is written out in `retire_bookmarks_for_chapters`. So a bookmark can outlive its audio. Those rows render as "chapter removed" and are not playable, rather than blowing up on a null.

**Playing a bookmark needed a change to `playQueue`.** `seekTo` returns early unless `hasMedia` is true, and media is not loaded until the chapter MP3 finishes downloading. So the obvious `playQueue(...)` then `seekTo(position)` silently drops the seek and starts at the top of the chapter. `playQueue` now takes an explicit `startPositionSeconds`. The whole fiction is still loaded so next/previous and auto-advance behave normally — a bookmark is a place in a book, not a detached clip.

**Renaming sends only the label.** Moshi omits null fields and the server reads an absent key as "leave it alone" (an explicit null means "clear it"), so a rename cannot blank the note.

## Deliberately not here

`kind` is written as `manual` only. `auto` is the jump-back breadcrumb the backend reserves for a client that records where playback stopped; this client has no such feature, and writing `auto` marks it does not own would pollute the shared table.

A keyboard shortcut, which #37 suggests — there is no shortcut layer in this repo to hang it off (`nav/Shortcuts.kt` does not exist here despite what #35 says). Worth its own issue if wanted.

## Verification

`./gradlew compileKotlin` and `./gradlew test` pass. UI paths are compile-checked only — there is no TTSRoad server in this environment, so nothing here has been clicked against real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)