### PR TITLE
Add server-side global search

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -60,6 +60,7 @@ import dk.perspektiva.ttsroad.desktop.ui.NowPlayingBar
 import dk.perspektiva.ttsroad.desktop.ui.PageGutter
 import dk.perspektiva.ttsroad.desktop.ui.PageScroll
 import dk.perspektiva.ttsroad.desktop.ui.PlayerScreen
+import dk.perspektiva.ttsroad.desktop.ui.SearchScreen
 import dk.perspektiva.ttsroad.desktop.ui.hasSession
 import kotlinx.coroutines.launch
 
@@ -68,6 +69,7 @@ private sealed interface Screen {
     data class Fiction(val fiction: FictionSummary) : Screen
     data object Player : Screen
     data object Bookmarks : Screen
+    data object Search : Screen
     data object Settings : Screen
 }
 
@@ -108,6 +110,7 @@ fun App() {
                 HeaderBar(
                     serverName = session.serverName,
                     current = screen,
+                    showSearch = capabilities.search,
                     showBookmarks = capabilities.bookmarks,
                     onSelect = { screen = it },
                 )
@@ -131,8 +134,16 @@ fun App() {
                             repository,
                             onOpenChapter = { fictionId, chapterId, positionSeconds ->
                                 scope.launch {
-                                    playFromBookmark(repository, playback, fictionId, chapterId, positionSeconds)
+                                    playChapterAt(repository, playback, fictionId, chapterId, positionSeconds)
                                 }
+                                openPlayer()
+                            },
+                        )
+                        Screen.Search -> SearchScreen(
+                            repository,
+                            onOpenFiction = { screen = Screen.Fiction(it) },
+                            onPlayChapter = { fictionId, chapterId ->
+                                scope.launch { playChapterAt(repository, playback, fictionId, chapterId) }
                                 openPlayer()
                             },
                         )
@@ -148,18 +159,21 @@ fun App() {
 }
 
 /**
- * Start a bookmarked position.
+ * Start one chapter, reached from somewhere that only knows its id — a bookmark, a search hit.
  *
- * The whole fiction is loaded so next/previous and auto-advance behave as they do anywhere else —
- * a bookmark is a place in a book, not a detached clip. The position is passed into [playQueue]
- * rather than seeked to afterwards, because a seek issued before the media loads is discarded.
+ * The whole fiction is loaded so next/previous and auto-advance behave as they do anywhere else: a
+ * bookmark or a search result is a place in a book, not a detached clip.
+ *
+ * [positionSeconds] is passed into [Mp3PlaybackController.playQueue] rather than seeked to
+ * afterwards, because a seek issued before the media has loaded is discarded — the jump would
+ * silently land at the top of the chapter.
  */
-private suspend fun playFromBookmark(
+private suspend fun playChapterAt(
     repository: TtsRoadRepository,
     playback: Mp3PlaybackController,
     fictionId: Int,
     chapterId: Int,
-    positionSeconds: Double,
+    positionSeconds: Double? = null,
 ) {
     runCatching {
         val response = repository.chapters(fictionId)
@@ -171,6 +185,7 @@ private suspend fun playFromBookmark(
 private fun HeaderBar(
     serverName: String,
     current: Screen,
+    showSearch: Boolean,
     showBookmarks: Boolean,
     onSelect: (Screen) -> Unit,
 ) {
@@ -201,6 +216,9 @@ private fun HeaderBar(
                 "Library",
                 active = current is Screen.Library || current is Screen.Fiction,
             ) { onSelect(Screen.Library) }
+            if (showSearch) {
+                NavItem("Search", active = current is Screen.Search) { onSelect(Screen.Search) }
+            }
             if (showBookmarks) {
                 NavItem("Bookmarks", active = current is Screen.Bookmarks) { onSelect(Screen.Bookmarks) }
             }
@@ -320,7 +338,7 @@ private data class CapabilityLine(
 )
 
 private fun capabilityLines(c: ServerCapabilities): List<CapabilityLine> = listOf(
-    CapabilityLine("Global search", c.search, usedByClient = false),
+    CapabilityLine("Global search", c.search, usedByClient = true),
     CapabilityLine("Bookmarks", c.bookmarks, usedByClient = true),
     CapabilityLine("Cross-library queue", c.queue, usedByClient = false),
     CapabilityLine("Follow / unfollow", c.follows, usedByClient = false),

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -138,6 +138,17 @@ class TtsRoadRepository(private val sessionStore: SessionStore) {
     suspend fun markPlayed(chapterIds: List<Int>, played: Boolean): PlaybackMarkResponse =
         withAuthorizedApi { api, auth -> api.markPlayback(auth, PlaybackMarkRequest(chapterIds, played)) }
 
+    /**
+     * Server-side search across fiction metadata, chapter titles and narration text.
+     *
+     * The library screen's filter cannot do this: it only sees what has already been fetched, and
+     * never sees chapter text at all.
+     */
+    suspend fun search(query: String, fictionId: Int? = null, limit: Int? = null): SearchResponse =
+        withAuthorizedApi { api, auth ->
+            api.search(auth, query = query.trim(), limit = limit, fictionId = fictionId)
+        }
+
     /** Every live mark on the account, or just one book's when [fictionId] is given. */
     suspend fun bookmarks(fictionId: Int? = null): List<Bookmark> =
         withAuthorizedApi { api, auth -> api.bookmarks(auth, fictionId = fictionId).bookmarks }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Search.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Search.kt
@@ -1,0 +1,81 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Json
+
+/**
+ * One search hit.
+ *
+ * The server uses a single item shape across all three groups and fills the irrelevant keys with
+ * nulls rather than omitting them, specifically so a client decodes every hit with one type and
+ * switches on [kind]. This mirrors that.
+ */
+data class SearchHit(
+    val kind: String = "",
+    val score: Double = 0.0,
+    @param:Json(name = "fiction_id") val fictionId: Int = 0,
+    @param:Json(name = "fiction_title") val fictionTitle: String? = null,
+    @param:Json(name = "fiction_slug") val fictionSlug: String? = null,
+    val author: String? = null,
+    @param:Json(name = "cover_image_url") val coverImageUrl: String? = null,
+    val tags: List<String> = emptyList(),
+    @param:Json(name = "chapter_id") val chapterId: Int? = null,
+    @param:Json(name = "chapter_title") val chapterTitle: String? = null,
+    @param:Json(name = "chapter_number") val chapterNumber: Double? = null,
+    @param:Json(name = "audio_duration") val audioDuration: Double = 0.0,
+    val status: String? = null,
+    val excluded: Boolean = false,
+    val playable: Boolean = false,
+    @param:Json(name = "has_timings") val hasTimings: Boolean = false,
+    val audio: AudioInfo? = null,
+    /**
+     * Where in the chapter's text the match starts — a character offset, not a timestamp. Turning
+     * it into an audio position needs the read-along timings, which this client does not fetch.
+     */
+    @param:Json(name = "char_offset") val charOffset: Int? = null,
+    @param:Json(name = "matched_fields") val matchedFields: List<String> = emptyList(),
+    val snippet: String = "",
+    /**
+     * Ranges to emphasise within [snippet], as `[start, end]` pairs. Computed server-side over
+     * Python string indices, which count code points; Kotlin indexes UTF-16 units, so a snippet
+     * containing astral characters (emoji) can shift these. Treated as a hint and bounds-checked
+     * at render time rather than trusted.
+     */
+    val highlights: List<List<Int>> = emptyList(),
+    val url: String? = null,
+) {
+    val isFiction: Boolean get() = kind == SearchKind.FICTION
+}
+
+object SearchKind {
+    const val FICTION = "fiction"
+    const val CHAPTER = "chapter"
+    const val TEXT = "text"
+}
+
+data class SearchGroup(
+    val items: List<SearchHit> = emptyList(),
+    val total: Int = 0,
+    /** The server stops counting at a cap; when true, [total] is a floor rather than a figure. */
+    val capped: Boolean = false,
+    @param:Json(name = "has_more") val hasMore: Boolean = false,
+)
+
+/**
+ * Groups are always present, even when empty, and their order is the global rank order: fictions,
+ * then chapter titles, then narration text.
+ */
+data class SearchResponse(
+    val query: String = "",
+    val tokens: List<String> = emptyList(),
+    val limit: Int = 0,
+    val offset: Int = 0,
+    val fictions: SearchGroup = SearchGroup(),
+    val chapters: SearchGroup = SearchGroup(),
+    val text: SearchGroup = SearchGroup(),
+    /**
+     * Whether a real text index is behind the narration search. False means the server fell back to
+     * scanning, which still answers but is slower and worth not hiding from the user.
+     */
+    val indexed: Boolean = false,
+    val total: Int = 0,
+)

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -40,6 +40,14 @@ interface TtsRoadApi {
         @Body request: PlaybackProgressRequest,
     ): PlaybackProgressResponse
 
+    @GET("api/mobile/search")
+    suspend fun search(
+        @Header("Authorization") auth: String,
+        @Query("q") query: String,
+        @Query("limit") limit: Int? = null,
+        @Query("fiction_id") fictionId: Int? = null,
+    ): SearchResponse
+
     @GET("api/mobile/bookmarks")
     suspend fun bookmarks(
         @Header("Authorization") auth: String,

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SearchScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SearchScreen.kt
@@ -1,0 +1,265 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.SearchGroup
+import dk.perspektiva.ttsroad.desktop.data.SearchHit
+import dk.perspektiva.ttsroad.desktop.data.SearchResponse
+import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
+import kotlinx.coroutines.launch
+
+/**
+ * Server-side search, as an explicit action rather than as-you-type.
+ *
+ * The library screen keeps its instant local filter — it works with no network and no latency, and
+ * removing it would be a regression. This is the second, deliberate path: it reaches chapter titles
+ * and narration text, neither of which a filter over the loaded list can see.
+ */
+@Composable
+fun SearchScreen(
+    repository: TtsRoadRepository,
+    onOpenFiction: (FictionSummary) -> Unit,
+    onPlayChapter: (fictionId: Int, chapterId: Int) -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    var query by remember { mutableStateOf("") }
+    var busy by remember { mutableStateOf(false) }
+    var result by remember { mutableStateOf<SearchResponse?>(null) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    fun run() {
+        val q = query.trim()
+        if (q.isBlank() || busy) return
+        scope.launch {
+            busy = true
+            error = null
+            runCatching { repository.search(q) }
+                .fold({ result = it }, { error = it.message ?: "Search failed" })
+            busy = false
+        }
+    }
+
+    PageScroll {
+        SectionTitle("01", "Search")
+        Spacer(Modifier.height(16.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            OutlinedTextField(
+                value = query,
+                onValueChange = { query = it },
+                label = { Text("SEARCH FICTIONS, CHAPTERS AND NARRATION TEXT") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(onSearch = { run() }),
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(Modifier.width(12.dp))
+            Button(
+                onClick = ::run,
+                enabled = !busy && query.isNotBlank(),
+                shape = RectangleShape,
+                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+            ) { Text(if (busy) "SEARCHING" else "SEARCH") }
+        }
+
+        error?.let {
+            Spacer(Modifier.height(16.dp))
+            Text(it, color = MaterialTheme.colorScheme.error)
+        }
+
+        if (busy && result == null) {
+            Spacer(Modifier.height(40.dp))
+            Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(color = AarisColor.Accent)
+            }
+        }
+
+        result?.let { response ->
+            Spacer(Modifier.height(20.dp))
+            if (response.total == 0) {
+                MetaText("No matches for \"${response.query}\"")
+            } else {
+                // The server stops counting at a cap rather than paying for an exact total, so
+                // "500 results" would be a lie when it is really "at least 500".
+                MetaText(
+                    buildString {
+                        append(if (response.capped()) "At least " else "")
+                        append("${response.total} result${if (response.total == 1) "" else "s"}")
+                        if (!response.indexed) append("  ·  unindexed server, narration search is a scan")
+                    },
+                    color = AarisColor.Dim,
+                )
+                ResultGroup("Fictions", response.fictions, repository, onOpenFiction, onPlayChapter)
+                ResultGroup("Chapters", response.chapters, repository, onOpenFiction, onPlayChapter)
+                ResultGroup("In the text", response.text, repository, onOpenFiction, onPlayChapter)
+            }
+        }
+    }
+}
+
+private fun SearchResponse.capped(): Boolean = fictions.capped || chapters.capped || text.capped
+
+@Composable
+private fun ResultGroup(
+    title: String,
+    group: SearchGroup,
+    repository: TtsRoadRepository,
+    onOpenFiction: (FictionSummary) -> Unit,
+    onPlayChapter: (fictionId: Int, chapterId: Int) -> Unit,
+) {
+    if (group.items.isEmpty()) return
+    Spacer(Modifier.height(28.dp))
+    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        MetaText("// $title", color = AarisColor.Accent)
+        Spacer(Modifier.weight(1f))
+        MetaText(
+            buildString {
+                append("${group.items.size} of ")
+                if (group.capped) append("at least ")
+                append(group.total)
+            },
+            color = AarisColor.Dim,
+        )
+    }
+    Spacer(Modifier.height(8.dp))
+    group.items.forEach { hit ->
+        SearchResultRow(hit, repository) {
+            if (hit.isFiction) {
+                // Built from the hit rather than refetched: FictionDetailScreen reloads the
+                // fiction with its chapters anyway, so this only has to carry the header until
+                // that lands — and it saves a round trip before the screen can open.
+                onOpenFiction(
+                    FictionSummary(
+                        id = hit.fictionId,
+                        title = hit.fictionTitle ?: "Untitled",
+                        author = hit.author,
+                        slug = hit.fictionSlug,
+                        coverImageUrl = hit.coverImageUrl,
+                        tags = hit.tags,
+                    ),
+                )
+            } else {
+                hit.chapterId?.let { onPlayChapter(hit.fictionId, it) }
+            }
+        }
+        HorizontalDivider(thickness = 1.dp, color = AarisColor.LineSoft)
+    }
+}
+
+@Composable
+private fun SearchResultRow(hit: SearchHit, repository: TtsRoadRepository, onOpen: () -> Unit) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    // A text or chapter hit is only actionable if there is audio behind it; a fiction hit always
+    // opens its detail screen.
+    val actionable = hit.isFiction || (hit.chapterId != null && hit.playable)
+
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .hoverable(interaction)
+            .let { if (actionable) it.pointerHoverIcon(PointerIcon.Hand) else it }
+            .clickable(interactionSource = interaction, indication = null, enabled = actionable, onClick = onOpen)
+            .background(if (hovered && actionable) AarisColor.BgRaise else Color.Transparent)
+            .padding(horizontal = 12.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CoverImage(
+            hit.fictionTitle ?: "?",
+            hit.coverImageUrl?.let(repository::resolveUrl),
+            Modifier.width(44.dp).aspectRatio(2f / 3f),
+        )
+        Spacer(Modifier.width(14.dp))
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+            Text(
+                hit.chapterTitle ?: hit.fictionTitle ?: "Untitled",
+                style = MaterialTheme.typography.titleMedium,
+                color = if (actionable) AarisColor.Ink else AarisColor.Dim,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (hit.chapterTitle != null) {
+                hit.fictionTitle?.let { MetaText(it, color = AarisColor.Dim) }
+            }
+            if (hit.snippet.isNotBlank()) {
+                HighlightedSnippet(hit.snippet, hit.highlights)
+            }
+            if (!actionable && !hit.isFiction) {
+                MetaText(hit.status ?: "no audio yet", color = AarisColor.Dim)
+            }
+        }
+    }
+}
+
+/**
+ * The snippet with the server's matched ranges emphasised.
+ *
+ * Ranges are bounds-checked rather than trusted: they are computed over Python string indices,
+ * which count code points, while Kotlin indexes UTF-16 units. A snippet containing an emoji shifts
+ * them, and an out-of-range span would throw. A wrong highlight is cosmetic; a crash is not.
+ */
+@Composable
+private fun HighlightedSnippet(snippet: String, highlights: List<List<Int>>) {
+    val annotated = remember(snippet, highlights) {
+        buildAnnotatedString {
+            append(snippet)
+            highlights.forEach { span ->
+                val start = span.getOrNull(0) ?: return@forEach
+                val end = span.getOrNull(1) ?: return@forEach
+                if (start in 0..snippet.length && end in start..snippet.length) {
+                    addStyle(
+                        SpanStyle(color = AarisColor.Accent, fontWeight = FontWeight.Bold),
+                        start,
+                        end,
+                    )
+                }
+            }
+        }
+    }
+    Text(
+        annotated,
+        style = MaterialTheme.typography.bodySmall,
+        color = AarisColor.Muted,
+        maxLines = 3,
+        overflow = TextOverflow.Ellipsis,
+    )
+}


### PR DESCRIPTION
Closes #40. **Stacked on #45** → #44 → #43.

## The gap

`LibraryScreen`'s "SEARCH TITLE, AUTHOR OR TAG" field filters the fictions already in memory. It cannot match a fiction that has not been fetched, and it cannot match chapter text at all. `GET /api/mobile/search` does both — fiction metadata, chapter titles, and narration text, grouped and ranked, backed by a per-dialect index.

## The local filter stays

#40 asks for this explicitly and it is right: the filter works with no network and no latency, and replacing it with a round trip would be a regression. Server search is a **second, explicit action** on its own screen (Enter or the button — not as-you-type, which would hammer a text index on every keystroke). Gated on the `search` capability.

## Decisions

**One hit type, not three.** The server fills irrelevant keys with nulls rather than omitting them, specifically so a client decodes every hit with one type and switches on `kind`. Mirrored rather than fought.

**Highlight ranges are bounds-checked, not trusted.** They are computed server-side over Python string indices, which count code points; Kotlin indexes UTF-16 units. A snippet containing an emoji shifts them, and an out-of-range span would throw at render. A wrong highlight is cosmetic; a crash is not.

**"At least N results"** when a group reports `capped` — the server stops counting at a cap rather than paying for an exact total, and rendering that as an exact figure would be a lie. The `indexed: false` case is surfaced too, since narration search degrades to a scan there.

**Fiction hits build the summary from the hit** instead of refetching. `FictionDetailScreen` reloads the fiction with its chapters anyway, so the summary only has to carry the header until that lands — and it saves a round trip before the screen can open.

## Not doing: landing on the matched passage

#40 wonders whether a text hit could open at the matched passage. It cannot, yet, and it is worth being precise about why: `char_offset` is a **character offset into `clean_text`, not an audio timestamp**. Converting it would need the read-along timings from `/chapters/{id}/readalong` — and there is no reader in this repo at all (`ReaderScreen.kt` does not exist here, despite what #35 claims). Text hits currently play the chapter from its normal resume point. Precise positioning is a real feature, but it needs a reader first.

## Verification

`./gradlew compileKotlin` and `./gradlew test` pass. UI is compile-checked only — no TTSRoad server in this environment, so no result has actually been rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)