### PR TITLE
Add the cross-library server queue as a browsable surface

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -60,6 +60,7 @@ import dk.perspektiva.ttsroad.desktop.ui.NowPlayingBar
 import dk.perspektiva.ttsroad.desktop.ui.PageGutter
 import dk.perspektiva.ttsroad.desktop.ui.PageScroll
 import dk.perspektiva.ttsroad.desktop.ui.PlayerScreen
+import dk.perspektiva.ttsroad.desktop.ui.QueueScreen
 import dk.perspektiva.ttsroad.desktop.ui.SearchScreen
 import dk.perspektiva.ttsroad.desktop.ui.hasSession
 import kotlinx.coroutines.launch
@@ -70,6 +71,7 @@ private sealed interface Screen {
     data object Player : Screen
     data object Bookmarks : Screen
     data object Search : Screen
+    data object Queue : Screen
     data object Settings : Screen
 }
 
@@ -111,6 +113,7 @@ fun App() {
                     serverName = session.serverName,
                     current = screen,
                     showSearch = capabilities.search,
+                    showQueue = capabilities.queue,
                     showBookmarks = capabilities.bookmarks,
                     onSelect = { screen = it },
                 )
@@ -142,6 +145,13 @@ fun App() {
                         Screen.Search -> SearchScreen(
                             repository,
                             onOpenFiction = { screen = Screen.Fiction(it) },
+                            onPlayChapter = { fictionId, chapterId ->
+                                scope.launch { playChapterAt(repository, playback, fictionId, chapterId) }
+                                openPlayer()
+                            },
+                        )
+                        Screen.Queue -> QueueScreen(
+                            repository,
                             onPlayChapter = { fictionId, chapterId ->
                                 scope.launch { playChapterAt(repository, playback, fictionId, chapterId) }
                                 openPlayer()
@@ -186,6 +196,7 @@ private fun HeaderBar(
     serverName: String,
     current: Screen,
     showSearch: Boolean,
+    showQueue: Boolean,
     showBookmarks: Boolean,
     onSelect: (Screen) -> Unit,
 ) {
@@ -218,6 +229,9 @@ private fun HeaderBar(
             ) { onSelect(Screen.Library) }
             if (showSearch) {
                 NavItem("Search", active = current is Screen.Search) { onSelect(Screen.Search) }
+            }
+            if (showQueue) {
+                NavItem("Up next", active = current is Screen.Queue) { onSelect(Screen.Queue) }
             }
             if (showBookmarks) {
                 NavItem("Bookmarks", active = current is Screen.Bookmarks) { onSelect(Screen.Bookmarks) }
@@ -340,7 +354,7 @@ private data class CapabilityLine(
 private fun capabilityLines(c: ServerCapabilities): List<CapabilityLine> = listOf(
     CapabilityLine("Global search", c.search, usedByClient = true),
     CapabilityLine("Bookmarks", c.bookmarks, usedByClient = true),
-    CapabilityLine("Cross-library queue", c.queue, usedByClient = false),
+    CapabilityLine("Cross-library queue", c.queue, usedByClient = true),
     CapabilityLine("Follow / unfollow", c.follows, usedByClient = true),
     CapabilityLine("Batch progress sync", c.batchProgress, usedByClient = true),
     CapabilityLine("Delta sync", c.deltaSync, usedByClient = false),

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Queue.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Queue.kt
@@ -1,0 +1,83 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Json
+
+/**
+ * One row of the shared Up Next queue — the same rows the browser reads.
+ *
+ * Named for the server to keep it apart from `player.QueueItem`, which is this client's local
+ * reading-order queue for a single fiction. They are different things: this one is explicit,
+ * curated and cross-fiction; that one is derived and always one book.
+ *
+ * The entry carries the fiction slug, cover and audio descriptor rather than assuming the caller
+ * can look them up, because a cross-fiction queue gets played from places that know nothing about
+ * the fiction in question.
+ */
+data class ServerQueueItem(
+    /** The queue row's own id — what reorder and remove address. Not the chapter id. */
+    val id: Int = 0,
+    val position: Int = 0,
+    @param:Json(name = "chapter_id") val chapterId: Int = 0,
+    @param:Json(name = "chapter_title") val chapterTitle: String? = null,
+    @param:Json(name = "chapter_number") val chapterNumber: Double? = null,
+    @param:Json(name = "fiction_id") val fictionId: Int = 0,
+    @param:Json(name = "fiction_title") val fictionTitle: String? = null,
+    @param:Json(name = "fiction_slug") val fictionSlug: String? = null,
+    @param:Json(name = "cover_image_url") val coverImageUrl: String? = null,
+    @param:Json(name = "audio_duration") val audioDuration: Double = 0.0,
+    @param:Json(name = "audio_duration_label") val audioDurationLabel: String? = null,
+    @param:Json(name = "has_timings") val hasTimings: Boolean = false,
+    @param:Json(name = "is_played") val isPlayed: Boolean = false,
+    @param:Json(name = "position_seconds") val positionSeconds: Double = 0.0,
+    val audio: AudioInfo? = null,
+)
+
+data class QueueState(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    val status: String? = null,
+    val items: List<ServerQueueItem> = emptyList(),
+    val total: Int = 0,
+    /**
+     * What the account wants when the queue runs dry — `stop` or `continue`. Read here only to
+     * describe the queue; this client does not act on it (see [QueueAction.ADVANCE]).
+     */
+    @param:Json(name = "when_empty") val whenEmpty: String = "stop",
+    @param:Json(name = "max_items") val maxItems: Int = 500,
+)
+
+object QueueAction {
+    const val ADD = "add"
+    const val FILL = "fill"
+    const val REORDER = "reorder"
+    const val REMOVE = "remove"
+    const val CLEAR = "clear"
+
+    /**
+     * Pops the head and tells the caller what to play, falling back to the oldest unplayed chapter
+     * when the queue is empty and the account's `queue_when_empty` is `continue`.
+     *
+     * Deliberately unused by this client. Calling it would make the server queue decide what plays
+     * after a chapter ends, which is the coupling the queue design in #38 explicitly avoids for
+     * now — the queue is a surface you play *from*, not a replacement for reading order.
+     */
+    const val ADVANCE = "advance"
+}
+
+object QueueMode {
+    const val END = "end"
+    const val NEXT = "next"
+}
+
+/**
+ * Every queue mutation goes through one POST with an [action], which is the server's design: it
+ * keeps a client's retry logic to one code path and lets the server add actions without new URLs.
+ */
+data class QueueUpdateRequest(
+    val action: String,
+    @param:Json(name = "chapter_ids") val chapterIds: List<Int> = emptyList(),
+    @param:Json(name = "item_ids") val itemIds: List<Int> = emptyList(),
+    val mode: String = QueueMode.END,
+    val source: String? = null,
+    @param:Json(name = "fiction_id") val fictionId: Int? = null,
+    val count: Int = 5,
+)

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -156,6 +156,37 @@ class TtsRoadRepository(private val sessionStore: SessionStore) {
     suspend fun markPlayed(chapterIds: List<Int>, played: Boolean): PlaybackMarkResponse =
         withAuthorizedApi { api, auth -> api.markPlayback(auth, PlaybackMarkRequest(chapterIds, played)) }
 
+    /** The shared Up Next queue — the same rows the browser reads. */
+    suspend fun queue(): QueueState = withAuthorizedApi { api, auth -> api.queue(auth) }
+
+    /**
+     * Queue chapters. [mode] decides whether they land at the end or immediately next.
+     *
+     * Every mutation returns the whole queue as the server now holds it, so the caller replaces its
+     * copy rather than trying to predict the result.
+     */
+    suspend fun addToQueue(chapterIds: List<Int>, mode: String = QueueMode.END): QueueState =
+        withAuthorizedApi { api, auth ->
+            api.updateQueue(auth, QueueUpdateRequest(action = QueueAction.ADD, chapterIds = chapterIds, mode = mode))
+        }
+
+    /** Removes by queue-row id, not chapter id — the same chapter can sit in the queue twice. */
+    suspend fun removeFromQueue(itemIds: List<Int>): QueueState =
+        withAuthorizedApi { api, auth ->
+            api.updateQueue(auth, QueueUpdateRequest(action = QueueAction.REMOVE, itemIds = itemIds))
+        }
+
+    /** [itemIds] is the complete desired order, not a delta. */
+    suspend fun reorderQueue(itemIds: List<Int>): QueueState =
+        withAuthorizedApi { api, auth ->
+            api.updateQueue(auth, QueueUpdateRequest(action = QueueAction.REORDER, itemIds = itemIds))
+        }
+
+    suspend fun clearQueue(): QueueState =
+        withAuthorizedApi { api, auth ->
+            api.updateQueue(auth, QueueUpdateRequest(action = QueueAction.CLEAR))
+        }
+
     /**
      * Server-side search across fiction metadata, chapter titles and narration text.
      *

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -55,6 +55,15 @@ interface TtsRoadApi {
         @Body request: PlaybackProgressRequest,
     ): PlaybackProgressResponse
 
+    @GET("api/mobile/queue")
+    suspend fun queue(@Header("Authorization") auth: String): QueueState
+
+    @POST("api/mobile/queue")
+    suspend fun updateQueue(
+        @Header("Authorization") auth: String,
+        @Body request: QueueUpdateRequest,
+    ): QueueState
+
     @GET("api/mobile/search")
     suspend fun search(
         @Header("Authorization") auth: String,

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionDetailScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionDetailScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.PlaylistAdd
+import androidx.compose.material.icons.filled.PlaylistPlay
 import androidx.compose.material3.Button
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -45,6 +47,7 @@ import androidx.compose.ui.unit.dp
 import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
 import dk.perspektiva.ttsroad.desktop.data.ChaptersResponse
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.QueueMode
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.player.PlaybackController
 import kotlinx.coroutines.launch
@@ -137,8 +140,16 @@ fun FictionDetailScreen(
                 chapters.forEach { chapter ->
                     ChapterListRow(
                         chapter = chapter,
+                        canQueue = capabilities.queue,
                         onPlay = {
                             scope.launch { playback.playQueue(chapters, chapter.resolvedChapterId, s.value.fiction) }
+                        },
+                        onQueue = { mode ->
+                            scope.launch {
+                                actionError = null
+                                runCatching { repository.addToQueue(listOf(chapter.resolvedChapterId), mode) }
+                                    .onFailure { actionError = it.message ?: "Could not queue chapter" }
+                            }
                         },
                         onMarkPlayed = { played ->
                             scope.launch {
@@ -294,7 +305,9 @@ private fun FictionHeader(
 @Composable
 private fun ChapterListRow(
     chapter: ChapterSummary,
+    canQueue: Boolean,
     onPlay: () -> Unit,
+    onQueue: (String) -> Unit,
     onMarkPlayed: (Boolean) -> Unit,
 ) {
     val playable = chapter.audio != null
@@ -342,6 +355,20 @@ private fun ChapterListRow(
                     contentDescription = if (isPlayed) "Mark unplayed" else "Mark played",
                     tint = if (isPlayed) AarisColor.Ok else AarisColor.Dim,
                 ) { onMarkPlayed(!isPlayed) }
+            }
+            if (hovered && canQueue) {
+                Spacer(Modifier.width(8.dp))
+                RowIconAction(
+                    icon = Icons.Default.PlaylistPlay,
+                    contentDescription = "Play next",
+                    tint = AarisColor.Dim,
+                ) { onQueue(QueueMode.NEXT) }
+                Spacer(Modifier.width(8.dp))
+                RowIconAction(
+                    icon = Icons.Default.PlaylistAdd,
+                    contentDescription = "Add to queue",
+                    tint = AarisColor.Dim,
+                ) { onQueue(QueueMode.END) }
             }
             if (hovered) {
                 Spacer(Modifier.width(8.dp))

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/QueueScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/QueueScreen.kt
@@ -1,0 +1,256 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.data.QueueState
+import dk.perspektiva.ttsroad.desktop.data.ServerQueueItem
+import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
+import kotlinx.coroutines.launch
+
+/**
+ * The shared Up Next queue.
+ *
+ * A surface you play *from*, not a replacement for reading order. Playing an item does not consume
+ * it and nothing here changes what happens when a chapter ends — see #38 for why that coupling is
+ * left alone for now.
+ */
+@Composable
+fun QueueScreen(
+    repository: TtsRoadRepository,
+    onPlayChapter: (fictionId: Int, chapterId: Int) -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    var state by remember { mutableStateOf<Load<QueueState>>(Load.Loading) }
+    var actionError by remember { mutableStateOf<String?>(null) }
+    var busy by remember { mutableStateOf(false) }
+
+    suspend fun load() {
+        state = runCatching { repository.queue() }
+            .fold({ Load.Ok(it) }, { Load.Err(it.message ?: "Could not load the queue") })
+    }
+
+    LaunchedEffect(Unit) { load() }
+
+    /** Every mutation answers with the whole queue, so the result replaces local state wholesale. */
+    fun mutate(block: suspend () -> QueueState) {
+        if (busy) return
+        scope.launch {
+            busy = true
+            actionError = null
+            runCatching { block() }
+                .fold(
+                    onSuccess = { state = Load.Ok(it) },
+                    onFailure = { actionError = it.message ?: "Could not update the queue" },
+                )
+            busy = false
+        }
+    }
+
+    when (val s = state) {
+        Load.Loading -> CenterProgress()
+        is Load.Err -> CenterError(s.message)
+        is Load.Ok -> {
+            val queue = s.value
+            PageScroll {
+                Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    Column(Modifier.weight(1f)) {
+                        SectionTitle("01", "Up next — ${queue.total}")
+                    }
+                    if (queue.items.isNotEmpty()) {
+                        Spacer(Modifier.width(16.dp))
+                        TextAction("CLEAR", enabled = !busy) { mutate { repository.clearQueue() } }
+                    }
+                }
+                Spacer(Modifier.height(8.dp))
+                actionError?.let {
+                    Text(it, color = MaterialTheme.colorScheme.error)
+                    Spacer(Modifier.height(8.dp))
+                }
+                if (queue.items.isEmpty()) {
+                    MetaText("The queue is empty — add chapters from a fiction")
+                } else {
+                    MetaText(
+                        "${queue.total} of ${queue.maxItems} · when empty: ${queue.whenEmpty}",
+                        color = AarisColor.Dim,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    queue.items.forEachIndexed { index, item ->
+                        QueueItemRow(
+                            item = item,
+                            repository = repository,
+                            index = index,
+                            isFirst = index == 0,
+                            isLast = index == queue.items.lastIndex,
+                            enabled = !busy,
+                            onPlay = { onPlayChapter(item.fictionId, item.chapterId) },
+                            onRemove = { mutate { repository.removeFromQueue(listOf(item.id)) } },
+                            onMove = { delta ->
+                                // The server takes the complete desired order, not a delta, so the
+                                // swap happens here and the whole list is sent.
+                                val reordered = queue.items.map { it.id }.toMutableList()
+                                val target = index + delta
+                                if (target in reordered.indices) {
+                                    reordered[index] = reordered[target].also { reordered[target] = reordered[index] }
+                                    mutate { repository.reorderQueue(reordered) }
+                                }
+                            },
+                        )
+                        HorizontalDivider(thickness = 1.dp, color = AarisColor.LineSoft)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun QueueItemRow(
+    item: ServerQueueItem,
+    repository: TtsRoadRepository,
+    index: Int,
+    isFirst: Boolean,
+    isLast: Boolean,
+    enabled: Boolean,
+    onPlay: () -> Unit,
+    onRemove: () -> Unit,
+    onMove: (Int) -> Unit,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .hoverable(interaction)
+            .pointerHoverIcon(PointerIcon.Hand)
+            .clickable(interactionSource = interaction, indication = null, onClick = onPlay)
+            .background(if (hovered) AarisColor.BgRaise else Color.Transparent)
+            .padding(horizontal = 12.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        MetaText("%02d".format(index + 1), color = AarisColor.Dim, modifier = Modifier.width(36.dp))
+        CoverImage(
+            item.fictionTitle ?: "?",
+            item.coverImageUrl?.let(repository::resolveUrl),
+            Modifier.width(40.dp).aspectRatio(2f / 3f),
+        )
+        Spacer(Modifier.width(14.dp))
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                item.chapterTitle ?: "Untitled chapter",
+                style = MaterialTheme.typography.titleMedium,
+                color = AarisColor.Ink,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            MetaText(
+                listOfNotNull(
+                    item.fictionTitle,
+                    item.audioDurationLabel,
+                    "played".takeIf { item.isPlayed },
+                ).joinToString("  ·  "),
+                color = AarisColor.Dim,
+            )
+        }
+        Spacer(Modifier.width(12.dp))
+        if (hovered) {
+            if (!isFirst) {
+                RowIconAction(Icons.Default.ArrowUpward, "Move up", AarisColor.Dim, enabled) { onMove(-1) }
+            }
+            if (!isLast) {
+                RowIconAction(Icons.Default.ArrowDownward, "Move down", AarisColor.Dim, enabled) { onMove(1) }
+            }
+            RowIconAction(Icons.Default.Close, "Remove from queue", AarisColor.Danger, enabled, onRemove)
+            Spacer(Modifier.width(8.dp))
+            Box(Modifier.size(30.dp).background(AarisColor.Accent), contentAlignment = Alignment.Center) {
+                Icon(
+                    Icons.Default.PlayArrow,
+                    contentDescription = "Play",
+                    tint = AarisColor.Bg,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TextAction(label: String, enabled: Boolean, onClick: () -> Unit) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    Box(
+        Modifier
+            .hoverable(interaction)
+            .let { if (enabled) it.pointerHoverIcon(PointerIcon.Hand) else it }
+            .clickable(interactionSource = interaction, indication = null, enabled = enabled, onClick = onClick)
+            .padding(horizontal = 10.dp, vertical = 6.dp),
+    ) {
+        MetaText(label, color = if (hovered && enabled) AarisColor.Danger else AarisColor.Dim)
+    }
+}
+
+@Composable
+private fun RowIconAction(
+    icon: ImageVector,
+    contentDescription: String?,
+    tint: Color,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    Box(
+        Modifier
+            .size(30.dp)
+            .background(if (hovered && enabled) AarisColor.BgHover else Color.Transparent)
+            .hoverable(interaction)
+            .let { if (enabled) it.pointerHoverIcon(PointerIcon.Hand) else it }
+            .clickable(interactionSource = interaction, indication = null, enabled = enabled, onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            icon,
+            contentDescription,
+            tint = if (hovered && enabled) AarisColor.Ink else tint,
+            modifier = Modifier.size(18.dp),
+        )
+    }
+}


### PR DESCRIPTION
Refs #38 — **leaves the issue open on purpose**, see below. Stacked on #47 → #46 → #45 → #44 → #43.

## The design question first, because #38 says that is the real work

The issue lists three ways to reconcile the server's explicit cross-fiction queue with this client's local one (which `QueuePlaybackController`… does not exist here, but `Mp3PlaybackController` builds the same thing: reading order, one fiction, gone on restart).

This PR takes **option 3** — the server queue is a separate surface you can play from, and nothing about end-of-chapter behaviour changes.

Why: it is the only one of the three that adds the feature without coupling playback to the network. The local queue is what keeps working when the server is unreachable, and options 1 and 2 both put a network call on the path between one chapter ending and the next starting. **This does not foreclose either of them** — it adds the API layer and the surface they would both need. I'm leaving #38 open for that decision rather than closing it on my own judgement, since the issue explicitly asks for it to be settled alongside Android.

**`advance` is therefore deliberately not called.** It pops the head and decides what plays next, which is precisely the coupling being deferred. The visible consequence is that `queue_when_empty` is read and shown but not acted on — stated in the UI rather than quietly ignored.

## What this adds

- `GET`/`POST /api/mobile/queue` with the full action set, DTOs in `data/Queue.kt`.
- An "Up next" screen: play, remove, reorder up/down, clear.
- "Play next" / "Add to queue" on chapter rows in fiction detail.
- Gated on the `queue` capability; Settings row flips to "Ready".

## Details worth checking

**Reorder sends the complete desired order**, not a delta — that is what `reorder_queue` takes. The swap happens client-side and the whole id list goes up.

**Removal addresses queue-row ids, not chapter ids.** The same chapter can legitimately sit in the queue twice, so `item.id` and `item.chapterId` are genuinely different keys. Easy thing to get wrong.

**Every mutation returns the whole queue** as the server holds it after the write, so the screen replaces its copy wholesale rather than predicting the outcome.

**`ServerQueueItem`, not `QueueItem`** — `player.QueueItem` already exists and means something different (derived reading order for one book, versus an explicit curated cross-fiction list). Same word, different concept; worth keeping apart.

## Verification

`./gradlew compileKotlin` and `./gradlew test` pass. Compile-checked only — no server in this environment, so no queue has actually been reordered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)