### PR TITLE
Stop offline progress from overwriting newer positions

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -236,6 +236,11 @@ fun App(container: AppContainer = remember { AppContainer() }) {
             // Local values are already usable; a capable server can now replace them with this
             // account's cross-device reader settings. Older/offline servers leave them alone.
             container.readerPreferences.refreshFromServer()
+            // Relaunching is the reconnect that matters: positions recorded while the last run was
+            // offline have been on disk since, and this is the first chance to send them. After
+            // discovery, so the flush knows whether the server can order writes. Failure is fine —
+            // the queue survives and the next save retries it.
+            runCatching { repository.flushProgress() }
         }
     }
 

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackSync.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackSync.kt
@@ -1,0 +1,63 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Json
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/**
+ * Now, as a stamp the backend will actually accept.
+ *
+ * Truncated to milliseconds deliberately. `Instant.now().toString()` emits as many fractional
+ * digits as the platform clock has — up to nine — and the backend hands the string to
+ * `datetime.fromisoformat`, which before Python 3.11 accepts only three or six. The backend's
+ * stated floor is 3.10, so a nine-digit stamp comes back as `invalid_client_updated_at` and the
+ * write is dropped: the exact data loss this endpoint exists to prevent, visible only on some
+ * deployments. Filed upstream as jonarihen/TTSRoad#88; this holds regardless of that.
+ */
+fun nowStamp(): String = Instant.now().truncatedTo(ChronoUnit.MILLIS).toString()
+
+data class PlaybackSyncItem(
+    @param:Json(name = "chapter_id") val chapterId: Int,
+    @param:Json(name = "position_seconds") val positionSeconds: Double,
+    @param:Json(name = "is_played") val isPlayed: Boolean,
+    @param:Json(name = "client_updated_at") val clientUpdatedAt: String,
+)
+
+data class PlaybackSyncRequest(val items: List<PlaybackSyncItem>)
+
+data class PlaybackSyncAccepted(
+    @param:Json(name = "chapter_id") val chapterId: Int = 0,
+    @param:Json(name = "position_seconds") val positionSeconds: Double = 0.0,
+    @param:Json(name = "is_played") val isPlayed: Boolean = false,
+)
+
+/**
+ * An item the server refused.
+ *
+ * Every [reason] it can give — `not_found`, `stale`, `empty`, `missing_client_updated_at`,
+ * `invalid_client_updated_at` — is terminal for that item: re-sending the same payload gets the
+ * same answer. A rejection means drop it, not retry it.
+ */
+data class PlaybackSyncRejected(
+    @param:Json(name = "chapter_id") val chapterId: Int = 0,
+    val reason: String = "",
+    @param:Json(name = "server_updated_at") val serverUpdatedAt: String? = null,
+)
+
+/** What the server holds for a chapter after the batch was applied. */
+data class PlaybackStateRow(
+    @param:Json(name = "chapter_id") val chapterId: Int = 0,
+    @param:Json(name = "position_seconds") val positionSeconds: Double = 0.0,
+    @param:Json(name = "is_played") val isPlayed: Boolean = false,
+    @param:Json(name = "last_listened_at") val lastListenedAt: String? = null,
+    @param:Json(name = "updated_at") val updatedAt: String? = null,
+    @param:Json(name = "client_updated_at") val clientUpdatedAt: String? = null,
+)
+
+data class PlaybackSyncResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    @param:Json(name = "server_time") val serverTime: String? = null,
+    val accepted: List<PlaybackSyncAccepted> = emptyList(),
+    val rejected: List<PlaybackSyncRejected> = emptyList(),
+    @param:Json(name = "server_state") val serverState: List<PlaybackStateRow> = emptyList(),
+)

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ProgressOutbox.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ProgressOutbox.kt
@@ -1,0 +1,154 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dk.perspektiva.ttsroad.desktop.security.SecureFiles
+import java.io.File
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * One recorded listening position, waiting to reach the server.
+ *
+ * [clientUpdatedAt] is the whole point. `/playback/progress` writes whatever it is handed, so a
+ * position recorded here while offline overwrites a newer one reached in the browser since.
+ * `/playback/sync` orders writes by this stamp and only lets a strictly newer one win.
+ */
+data class PendingProgress(
+    val fictionId: Int,
+    val chapterId: Int,
+    val positionSeconds: Double,
+    val isPlayed: Boolean,
+    val clientUpdatedAt: String,
+)
+
+private data class StoredOutbox(
+    val version: Int = ProgressOutbox.CurrentVersion,
+    val entries: List<PendingProgress> = emptyList(),
+)
+
+/**
+ * The pure rules for the unsent-progress queue. No file, no clock, no coroutine.
+ *
+ * Split from [FileProgressOutboxStore] for the same reason [dk.perspektiva.ttsroad.desktop
+ * .download.DownloadIndex] is: the transitions that matter — a second position for a chapter
+ * already queued, a partial acknowledgement, a rejection that must not be retried — are asserted
+ * in plain unit tests rather than against a temp directory.
+ */
+object ProgressOutbox {
+
+    const val CurrentVersion: Int = 1
+
+    /**
+     * Queue a position, replacing any earlier one for the same chapter.
+     *
+     * At most one entry per chapter because only the furthest position matters and the server
+     * compares by timestamp anyway — an older entry for a chapter could never win once a newer one
+     * exists. That also bounds the file by chapters actually listened to rather than by how long
+     * the session ran.
+     *
+     * Insertion order is preserved for chapters already present, so a long-running session does not
+     * keep shuffling the file and rewriting bytes that did not change.
+     */
+    fun record(entries: List<PendingProgress>, entry: PendingProgress): List<PendingProgress> {
+        val index = entries.indexOfFirst { it.chapterId == entry.chapterId }
+        if (index < 0) return entries + entry
+        return entries.toMutableList().apply { this[index] = entry }
+    }
+
+    /**
+     * Drop everything the server has now spoken about — accepted *and* rejected.
+     *
+     * A rejection is as final as an acceptance: every reason the endpoint can give is terminal for
+     * that item, so keeping it queued would mean re-sending a payload guaranteed to be refused
+     * again. Only a transport failure leaves the queue untouched, and that is expressed by not
+     * calling this at all.
+     */
+    fun drop(entries: List<PendingProgress>, chapterIds: Collection<Int>): List<PendingProgress> {
+        if (chapterIds.isEmpty()) return entries
+        val gone = chapterIds.toSet()
+        return entries.filterNot { it.chapterId in gone }
+    }
+
+    /**
+     * Split into batches the server will accept.
+     *
+     * [maxItems] is the server's published `max_playback_sync_items`. It is not advisory: an
+     * oversized batch is answered with a 400 rather than truncated, so ignoring it loses the whole
+     * batch instead of part of it. A non-positive limit would mean infinitely many empty batches,
+     * so it is floored at one.
+     */
+    fun batches(entries: List<PendingProgress>, maxItems: Int): List<List<PendingProgress>> =
+        if (entries.isEmpty()) emptyList() else entries.chunked(maxItems.coerceAtLeast(1))
+}
+
+/** Storage for positions that have not reached the server yet. */
+interface ProgressOutboxStore {
+    val entries: StateFlow<List<PendingProgress>>
+    fun record(entry: PendingProgress)
+    fun drop(chapterIds: Collection<Int>)
+    fun clear()
+}
+
+/**
+ * The outbox on disk.
+ *
+ * On disk rather than in memory because the case that loses data is precisely the one where the app
+ * closes before the network comes back — an in-memory queue would drop exactly the writes that most
+ * need keeping.
+ *
+ * Written through [SecureFiles.writeAtomically] so a crash mid-write cannot leave a truncated file
+ * where a listening position used to be, and so the file carries owner-only permissions like the
+ * rest of the per-user state.
+ */
+class FileProgressOutboxStore(private val file: File) : ProgressOutboxStore {
+
+    private val adapter = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+        .adapter(StoredOutbox::class.java)
+
+    private val _entries = MutableStateFlow(load())
+    override val entries: StateFlow<List<PendingProgress>> = _entries.asStateFlow()
+
+    /**
+     * Synchronised because every mutation is read-modify-write and the writers genuinely differ:
+     * the playback controller's ten-second tick, its save-on-pause/seek/stop paths, and the flush
+     * acknowledging a batch. Two of those working from the same base list would lose one edit.
+     */
+    @Synchronized
+    override fun record(entry: PendingProgress) {
+        write(ProgressOutbox.record(_entries.value, entry))
+    }
+
+    @Synchronized
+    override fun drop(chapterIds: Collection<Int>) {
+        write(ProgressOutbox.drop(_entries.value, chapterIds))
+    }
+
+    /** Used when the credential dies: a queue that cannot be authenticated can never be flushed. */
+    @Synchronized
+    override fun clear() {
+        write(emptyList())
+    }
+
+    private fun write(next: List<PendingProgress>) {
+        if (next == _entries.value) return
+        _entries.value = next
+        file.parentFile?.mkdirs()
+        SecureFiles.writeAtomically(file, adapter.toJson(StoredOutbox(entries = next)))
+    }
+
+    /**
+     * A file this build cannot read starts empty rather than throwing.
+     *
+     * Losing a few queued positions is bad; failing to construct the repository — and so refusing
+     * to play anything at all — because of one malformed JSON file is worse.
+     */
+    private fun load(): List<PendingProgress> = runCatching {
+        if (!file.isFile) return@runCatching emptyList()
+        val stored = adapter.fromJson(file.readText()) ?: return@runCatching emptyList()
+        if (stored.version != ProgressOutbox.CurrentVersion) emptyList() else stored.entries
+    }.getOrElse { emptyList() }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -21,6 +21,13 @@ import retrofit2.converter.moshi.MoshiConverterFactory
  */
 private val CapabilityTtlMillis = TimeUnit.HOURS.toMillis(6)
 
+/**
+ * Batch size used when the server has `/playback/sync` but published no limit. Matches the
+ * backend's own `MAX_PLAYBACK_SYNC_ITEMS`, and is a floor rather than a guess: sending fewer items
+ * than allowed only costs an extra round trip, while sending more loses the whole batch to a 400.
+ */
+private const val DefaultMaxPlaybackSyncItems = 500
+
 /** Outcome of a login attempt. */
 sealed interface LoginResult {
     data object Success : LoginResult
@@ -51,6 +58,23 @@ interface TtsRoadRepository {
 
     /** Why the stored credential was dropped, or null while the session is usable. */
     val sessionEnd: StateFlow<SessionEnd?>
+
+    /**
+     * What the server says it holds for chapters this client has written to, as of the last flush.
+     *
+     * This is how a losing write gets noticed. `/playback/sync` returns the server's own state for
+     * every chapter in a batch, so when an offline position loses to a newer one from the browser,
+     * the newer position is here — and playback can resume from it rather than the stale local one.
+     */
+    val serverPlaybackState: StateFlow<Map<Int, PlaybackStateRow>>
+
+    /**
+     * Send everything queued but unsent. Safe to call when there is nothing to do.
+     *
+     * Separate from [saveProgress] so a reconnect — app launch, session restored — can drain a
+     * queue left behind by an earlier run without first having to play something.
+     */
+    suspend fun flushProgress()
 
     suspend fun login(
         baseUrl: String,
@@ -128,12 +152,25 @@ interface TtsRoadRepository {
 
     suspend fun markPlayed(chapterIds: List<Int>, played: Boolean): PlaybackMarkResponse
 
+    /**
+     * Record a listening position and try to get it to the server.
+     *
+     * Queued to disk with a timestamp *before* being sent. That ordering is the fix for #36: if the
+     * send fails — offline, server down, laptop closed — the position survives with the time it was
+     * actually reached, so when it does land it can be ordered against whatever happened since
+     * instead of blindly overwriting it.
+     *
+     * Failures propagate, as they did before the queue existed — a 401 in particular still has to
+     * reach the session-end handling. The caller ([dk.perspektiva.ttsroad.desktop.player
+     * .QueuePlaybackController]) already treats a failed save as non-fatal, and the position stays
+     * queued either way, so the next save retries it.
+     */
     suspend fun saveProgress(
         fictionId: Int,
         chapterId: Int,
         positionSeconds: Double,
         isPlayed: Boolean,
-    ): PlaybackProgressResponse?
+    )
 
     /** Whether a bearer credential exists at all, so the audio path can fail fast when signed out. */
     fun authHeaderValue(): String?
@@ -156,6 +193,13 @@ class RetrofitTtsRoadRepository(
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val clock: () -> Long = System::currentTimeMillis,
     private val deviceNameProvider: () -> String = ::defaultDeviceName,
+    /**
+     * Unsent listening positions. Injected so a test can hold the queue in memory instead of
+     * writing to the user's real config directory, the same reason the session store is.
+     */
+    private val progressOutbox: ProgressOutboxStore =
+        FileProgressOutboxStore(AppDirectories.configDir().resolve("progress-outbox.json")),
+    private val stamp: () -> String = ::nowStamp,
 ) : TtsRoadRepository {
     private val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
 
@@ -177,6 +221,10 @@ class RetrofitTtsRoadRepository(
 
     private val _sessionEnd = MutableStateFlow<SessionEnd?>(null)
     override val sessionEnd: StateFlow<SessionEnd?> = _sessionEnd.asStateFlow()
+
+    private val _serverPlaybackState = MutableStateFlow<Map<Int, PlaybackStateRow>>(emptyMap())
+    override val serverPlaybackState: StateFlow<Map<Int, PlaybackStateRow>> =
+        _serverPlaybackState.asStateFlow()
 
     override suspend fun login(
         baseUrl: String,
@@ -342,12 +390,93 @@ class RetrofitTtsRoadRepository(
         chapterId: Int,
         positionSeconds: Double,
         isPlayed: Boolean,
-    ): PlaybackProgressResponse? {
-        if (!sessionStore.current().isLoggedIn) return null
-        return withAuthorizedApi {
-            it.saveProgress(
-                PlaybackProgressRequest(fictionId, chapterId, positionSeconds.coerceAtLeast(0.0), isPlayed),
+    ) {
+        // Nothing is queued while signed out. A position recorded with no account behind it
+        // belongs to nobody, and keeping it would mean the next person to sign in on this machine
+        // flushes the last one's listening history to their own account.
+        if (!sessionStore.current().isLoggedIn) return
+        progressOutbox.record(
+            PendingProgress(
+                fictionId = fictionId,
+                chapterId = chapterId,
+                positionSeconds = positionSeconds.coerceAtLeast(0.0),
+                isPlayed = isPlayed,
+                clientUpdatedAt = stamp(),
+            ),
+        )
+        flushProgress()
+    }
+
+    /**
+     * Drain the outbox.
+     *
+     * Batched through `/playback/sync` when the server has it, in chunks of the published
+     * `max_playback_sync_items`. Falls back to `/playback/progress` otherwise — that endpoint
+     * cannot order writes, so the overwrite this exists to prevent is still possible against an
+     * older server, but losing the position entirely would be worse and the backend keeps it
+     * working deliberately.
+     */
+    override suspend fun flushProgress() {
+        if (!sessionStore.current().isLoggedIn) return
+        val pending = progressOutbox.entries.value
+        if (pending.isEmpty()) return
+
+        try {
+            if (currentCapabilities.value.batchProgress) {
+                flushBatched(pending)
+            } else {
+                flushOneByOne(pending)
+            }
+        } catch (e: HttpException) {
+            // A dead credential can never flush this queue, so holding it would mean carrying a
+            // growing file forever. Anything else is transient as far as this client can tell.
+            if (e.code() == 401) progressOutbox.clear()
+            throw e
+        }
+    }
+
+    private suspend fun flushBatched(pending: List<PendingProgress>) {
+        val limit = currentCapabilities.value.maxPlaybackSyncItems ?: DefaultMaxPlaybackSyncItems
+        for (batch in ProgressOutbox.batches(pending, limit)) {
+            val response = withAuthorizedApi { api ->
+                api.syncProgress(
+                    PlaybackSyncRequest(
+                        batch.map {
+                            PlaybackSyncItem(
+                                chapterId = it.chapterId,
+                                positionSeconds = it.positionSeconds,
+                                isPlayed = it.isPlayed,
+                                clientUpdatedAt = it.clientUpdatedAt,
+                            )
+                        },
+                    ),
+                )
+            }
+            // Rejections are as final as acceptances — every reason the server can give is terminal
+            // for that item, so re-sending would only get the same answer.
+            progressOutbox.drop(
+                response.accepted.map { it.chapterId } + response.rejected.map { it.chapterId },
             )
+            if (response.serverState.isNotEmpty()) {
+                _serverPlaybackState.value =
+                    _serverPlaybackState.value + response.serverState.associateBy { it.chapterId }
+            }
+        }
+    }
+
+    private suspend fun flushOneByOne(pending: List<PendingProgress>) {
+        for (entry in pending) {
+            withAuthorizedApi {
+                it.saveProgress(
+                    PlaybackProgressRequest(
+                        entry.fictionId,
+                        entry.chapterId,
+                        entry.positionSeconds,
+                        entry.isPlayed,
+                    ),
+                )
+            }
+            progressOutbox.drop(listOf(entry.chapterId))
         }
     }
 
@@ -364,6 +493,9 @@ class RetrofitTtsRoadRepository(
     private fun forgetSessionScopedState(serverUrl: String) {
         forgetCapabilities(serverUrl)
         _currentCapabilities.value = ServerCapabilities.Baseline
+        // Chapter ids are per server; carrying reconciled positions across a sign-out would let one
+        // account's resume point leak into another's.
+        _serverPlaybackState.value = emptyMap()
     }
 
     /**

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
@@ -45,6 +45,14 @@ data class ServerCapabilities(
     val audioContentHash: Boolean = false,
     val deviceManagement: Boolean = false,
     val maxChaptersPerPage: Int? = null,
+    /**
+     * How many items `/playback/sync` accepts in one batch.
+     *
+     * Null until discovery reaches a server that publishes it. Not advisory: an oversized batch is
+     * answered with a 400 rather than truncated, so a client that guesses high loses the whole
+     * batch rather than part of it.
+     */
+    val maxPlaybackSyncItems: Int? = null,
 ) {
     /** True once discovery has actually reached a TTSRoad server (only it reports a version). */
     val isDiscovered: Boolean get() = serverVersion != null
@@ -66,6 +74,7 @@ data class ServerCapabilities(
             audioContentHash = response.capabilities.flag("audio_content_hash"),
             deviceManagement = response.capabilities.flag("device_management"),
             maxChaptersPerPage = response.limits.intLimit("max_chapters_per_page"),
+            maxPlaybackSyncItems = response.limits.intLimit("max_playback_sync_items"),
         )
 
         /**

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -86,6 +86,9 @@ interface TtsRoadApi {
     @POST("api/mobile/playback/progress")
     suspend fun saveProgress(@Body request: PlaybackProgressRequest): PlaybackProgressResponse
 
+    @POST("api/mobile/playback/sync")
+    suspend fun syncProgress(@Body request: PlaybackSyncRequest): PlaybackSyncResponse
+
     @POST("api/mobile/playback/mark")
     suspend fun markPlayback(@Body request: PlaybackMarkRequest): PlaybackMarkResponse
 }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
@@ -330,8 +330,20 @@ class QueuePlaybackController(
         scope.cancel()
     }
 
-    private fun resumeMsOf(chapter: ChapterSummary): Long =
-        (chapter.resolvedPositionSeconds * 1000).toLong().coerceAtLeast(0L)
+    /**
+     * Where to start this chapter.
+     *
+     * Prefers the server's reconciled state when there is one. That map is only populated by a
+     * `/playback/sync` round trip, which is strictly later than the chapter list this summary came
+     * from — so when a position saved here lost to a newer one reached in the browser, this picks
+     * up the browser's position instead of silently restarting from the stale local one. That is
+     * the user-visible half of #36.
+     */
+    private fun resumeMsOf(chapter: ChapterSummary): Long {
+        val reconciled = repository.serverPlaybackState.value[chapter.resolvedChapterId]
+        val seconds = reconciled?.positionSeconds ?: chapter.resolvedPositionSeconds
+        return (seconds * 1000).toLong().coerceAtLeast(0L)
+    }
 
     private suspend fun stopInternal(clearQueue: Boolean) {
         playJob?.cancelAndJoin()

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -8,7 +8,7 @@ import dk.perspektiva.ttsroad.desktop.data.LibraryResponse
 import dk.perspektiva.ttsroad.desktop.data.LoginResult
 import dk.perspektiva.ttsroad.desktop.data.MobileUser
 import dk.perspektiva.ttsroad.desktop.data.PlaybackMarkResponse
-import dk.perspektiva.ttsroad.desktop.data.PlaybackProgressResponse
+import dk.perspektiva.ttsroad.desktop.data.PlaybackStateRow
 import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
 import dk.perspektiva.ttsroad.desktop.data.SessionEnd
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
@@ -161,9 +161,19 @@ open class FakeRepository(
         chapterId: Int,
         positionSeconds: Double,
         isPlayed: Boolean,
-    ): PlaybackProgressResponse {
+    ) {
         savedProgress += Triple(chapterId, positionSeconds, isPlayed)
-        return PlaybackProgressResponse(status = "saved", chapterId = chapterId)
+    }
+
+    /** Positions the server would report back; set by a test that wants a losing write reconciled. */
+    val serverPlaybackStateFlow = MutableStateFlow<Map<Int, PlaybackStateRow>>(emptyMap())
+    override val serverPlaybackState: StateFlow<Map<Int, PlaybackStateRow>> = serverPlaybackStateFlow
+
+    var flushCount: Int = 0
+        private set
+
+    override suspend fun flushProgress() {
+        flushCount++
     }
 
     override fun authHeaderValue(): String? = "Bearer test-token"

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackSyncTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackSyncTest.kt
@@ -1,0 +1,238 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import dk.perspektiva.ttsroad.desktop.authedClient
+import dk.perspektiva.ttsroad.desktop.bodyText
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.Headers
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import retrofit2.HttpException
+
+/** The outbox, in memory, so a test never touches the user's real config directory. */
+private class RecordingOutbox(initial: List<PendingProgress> = emptyList()) : ProgressOutboxStore {
+    private val _entries = MutableStateFlow(initial)
+    override val entries: StateFlow<List<PendingProgress>> = _entries
+    var cleared: Boolean = false
+        private set
+
+    override fun record(entry: PendingProgress) {
+        _entries.value = ProgressOutbox.record(_entries.value, entry)
+    }
+
+    override fun drop(chapterIds: Collection<Int>) {
+        _entries.value = ProgressOutbox.drop(_entries.value, chapterIds)
+    }
+
+    override fun clear() {
+        cleared = true
+        _entries.value = emptyList()
+    }
+}
+
+/**
+ * `/playback/sync` on the wire: what gets sent, what gets kept, and what a losing write does.
+ *
+ * The point of the endpoint is that an offline position must not overwrite a newer one, so these
+ * assert the ordering guarantees rather than just that a request was made.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PlaybackSyncTest {
+    private lateinit var server: MockWebServer
+    private lateinit var sessionStore: InMemorySessionStore
+    private lateinit var outbox: RecordingOutbox
+
+    private val jsonHeaders = Headers.headersOf("Content-Type", "application/json")
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        sessionStore = InMemorySessionStore(
+            SessionState(
+                serverUrl = server.url("/").toString(),
+                token = "ttsr_token",
+                username = "admin",
+            ),
+        )
+        outbox = RecordingOutbox()
+    }
+
+    @AfterEach
+    fun tearDown() = server.close()
+
+    private fun enqueue(code: Int, body: String) {
+        server.enqueue(MockResponse(code = code, headers = jsonHeaders, body = body))
+    }
+
+    private fun capabilities(batchProgress: Boolean, maxItems: Int? = null): String {
+        val limits = buildString {
+            append("""{"max_chapters_per_page": 200""")
+            if (maxItems != null) append(""", "max_playback_sync_items": $maxItems""")
+            append("}")
+        }
+        return """
+            {
+              "api_version": 1,
+              "server": {"name": "TTSRoad", "version": "1.5.0", "base_url": "${server.url("/")}"},
+              "capabilities": {"batch_progress": $batchProgress},
+              "limits": $limits
+            }
+        """.trimIndent()
+    }
+
+    private suspend fun repositoryWith(
+        batchProgress: Boolean,
+        maxItems: Int? = null,
+        stamp: String = "2026-08-11T10:00:00.000Z",
+    ): RetrofitTtsRoadRepository {
+        val repository = RetrofitTtsRoadRepository(
+            sessionStore = sessionStore,
+            client = authedClient(sessionStore),
+            ioDispatcher = UnconfinedTestDispatcher(),
+            deviceNameProvider = { "test-host" },
+            progressOutbox = outbox,
+            stamp = { stamp },
+        )
+        enqueue(200, capabilities(batchProgress, maxItems))
+        repository.refreshCurrentCapabilities(forceRefresh = true)
+        server.takeRequest()
+        return repository
+    }
+
+    @Test
+    fun `a capable server gets a timestamped batch`() = runTest {
+        val repository = repositoryWith(batchProgress = true)
+        enqueue(
+            200,
+            """{"accepted": [{"chapter_id": 7}], "rejected": [], "server_state": []}""",
+        )
+
+        repository.saveProgress(fictionId = 1, chapterId = 7, positionSeconds = 412.5, isPlayed = false)
+
+        val request = server.takeRequest()
+        assertEquals("/api/mobile/playback/sync", request.url.encodedPath)
+        val body = request.bodyText()
+        assertContains(body, """"chapter_id":7""")
+        assertContains(body, """"position_seconds":412.5""")
+        assertContains(body, """"client_updated_at":"2026-08-11T10:00:00.000Z"""")
+    }
+
+    @Test
+    fun `an accepted position leaves the queue`() = runTest {
+        val repository = repositoryWith(batchProgress = true)
+        enqueue(200, """{"accepted": [{"chapter_id": 7}], "rejected": [], "server_state": []}""")
+
+        repository.saveProgress(1, 7, 412.5, false)
+
+        assertTrue(outbox.entries.value.isEmpty())
+    }
+
+    /**
+     * Every rejection reason is terminal for that item, so a rejected write is dropped rather than
+     * retried — otherwise the queue would grow forever re-sending something guaranteed to be
+     * refused.
+     */
+    @Test
+    fun `a rejected position also leaves the queue`() = runTest {
+        val repository = repositoryWith(batchProgress = true)
+        enqueue(
+            200,
+            """{"accepted": [], "rejected": [{"chapter_id": 7, "reason": "stale"}], "server_state": []}""",
+        )
+
+        repository.saveProgress(1, 7, 100.0, false)
+
+        assertTrue(outbox.entries.value.isEmpty())
+    }
+
+    /** The user-visible half of #36: the browser's newer position wins and is what resumes. */
+    @Test
+    fun `a losing write picks up the server's newer position`() = runTest {
+        val repository = repositoryWith(batchProgress = true)
+        enqueue(
+            200,
+            """
+            {
+              "accepted": [],
+              "rejected": [{"chapter_id": 7, "reason": "stale"}],
+              "server_state": [{"chapter_id": 7, "position_seconds": 4820.0, "is_played": false}]
+            }
+            """.trimIndent(),
+        )
+
+        repository.saveProgress(1, 7, 100.0, false)
+
+        assertEquals(4820.0, repository.serverPlaybackState.value[7]?.positionSeconds)
+    }
+
+    @Test
+    fun `an older server gets the single-item endpoint instead`() = runTest {
+        val repository = repositoryWith(batchProgress = false)
+        enqueue(200, """{"status": "saved", "chapter_id": 7}""")
+
+        repository.saveProgress(1, 7, 412.5, false)
+
+        assertEquals("/api/mobile/playback/progress", server.takeRequest().url.encodedPath)
+        assertTrue(outbox.entries.value.isEmpty())
+    }
+
+    /** An oversized batch is answered with a 400 rather than truncated, so the limit is obeyed. */
+    @Test
+    fun `batches are split at the server's published limit`() = runTest {
+        val repository = repositoryWith(batchProgress = true, maxItems = 2)
+        repeat(3) { enqueue(200, """{"accepted": [], "rejected": [], "server_state": []}""") }
+        repeat(5) { outbox.record(PendingProgress(1, it + 1, 10.0, false, "2026-08-11T10:00:00.000Z")) }
+
+        repository.flushProgress()
+
+        val sizes = (1..3).map { server.takeRequest().bodyText().split("\"chapter_id\"").size - 1 }
+        assertEquals(listOf(2, 2, 1), sizes)
+    }
+
+    /** Transport failure is the one case the queue must survive — that is the whole point. */
+    @Test
+    fun `a server error keeps the position queued for the next attempt`() = runTest {
+        val repository = repositoryWith(batchProgress = true)
+        enqueue(500, """{"detail": "boom"}""")
+
+        // The failure propagates — the playback controller treats it as non-fatal — but the
+        // position it was carrying is still on the queue for the next attempt.
+        assertThrows<HttpException> { repository.saveProgress(1, 7, 412.5, false) }
+
+        assertEquals(listOf(7), outbox.entries.value.map { it.chapterId })
+        assertTrue(!outbox.cleared)
+    }
+
+    @Test
+    fun `a dead credential drops the queue rather than carrying it forever`() = runTest {
+        val repository = repositoryWith(batchProgress = true)
+        outbox.record(PendingProgress(1, 7, 10.0, false, "2026-08-11T10:00:00.000Z"))
+        enqueue(401, """{"detail": "Not authenticated"}""")
+
+        assertThrows<HttpException> { repository.flushProgress() }
+
+        assertTrue(outbox.cleared)
+        assertTrue(outbox.entries.value.isEmpty())
+    }
+
+    @Test
+    fun `flushing an empty queue makes no request at all`() = runTest {
+        val repository = repositoryWith(batchProgress = true)
+        val afterDiscovery = server.requestCount
+
+        repository.flushProgress()
+
+        assertEquals(afterDiscovery, server.requestCount)
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ProgressOutboxTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ProgressOutboxTest.kt
@@ -1,0 +1,189 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ProgressOutboxTest {
+
+    private fun entry(chapterId: Int, position: Double, stamp: String = "2026-08-11T10:00:00.000Z") =
+        PendingProgress(
+            fictionId = 1,
+            chapterId = chapterId,
+            positionSeconds = position,
+            isPlayed = false,
+            clientUpdatedAt = stamp,
+        )
+
+    @Test
+    fun `a second position for the same chapter replaces the first`() {
+        val queued = ProgressOutbox.record(
+            listOf(entry(7, 120.0, "2026-08-11T10:00:00.000Z")),
+            entry(7, 340.0, "2026-08-11T10:05:00.000Z"),
+        )
+
+        assertEquals(1, queued.size)
+        assertEquals(340.0, queued.single().positionSeconds)
+        assertEquals("2026-08-11T10:05:00.000Z", queued.single().clientUpdatedAt)
+    }
+
+    @Test
+    fun `replacing keeps the chapter where it was in the queue`() {
+        val queued = ProgressOutbox.record(
+            listOf(entry(7, 10.0), entry(8, 20.0), entry(9, 30.0)),
+            entry(8, 999.0),
+        )
+
+        assertEquals(listOf(7, 8, 9), queued.map { it.chapterId })
+    }
+
+    @Test
+    fun `different chapters queue independently`() {
+        val queued = ProgressOutbox.record(listOf(entry(7, 120.0)), entry(8, 60.0))
+
+        assertEquals(listOf(7, 8), queued.map { it.chapterId })
+    }
+
+    /**
+     * A rejection is as final as an acceptance — every reason `/playback/sync` can give is terminal
+     * for that item, so both sets are dropped together and neither is retried.
+     */
+    @Test
+    fun `dropping acknowledged chapters leaves the rest queued`() {
+        val queued = ProgressOutbox.drop(
+            listOf(entry(7, 1.0), entry(8, 2.0), entry(9, 3.0)),
+            listOf(7, 9),
+        )
+
+        assertEquals(listOf(8), queued.map { it.chapterId })
+    }
+
+    @Test
+    fun `dropping nothing changes nothing`() {
+        val before = listOf(entry(7, 1.0))
+
+        assertEquals(before, ProgressOutbox.drop(before, emptyList()))
+    }
+
+    @Test
+    fun `batches respect the server limit`() {
+        val entries = (1..5).map { entry(it, it.toDouble()) }
+
+        val batches = ProgressOutbox.batches(entries, maxItems = 2)
+
+        assertEquals(listOf(2, 2, 1), batches.map { it.size })
+        assertEquals(entries, batches.flatten())
+    }
+
+    @Test
+    fun `an empty queue produces no batches`() {
+        assertTrue(ProgressOutbox.batches(emptyList(), maxItems = 500).isEmpty())
+    }
+
+    /** A zero limit would otherwise mean infinitely many empty batches. */
+    @Test
+    fun `a nonsensical limit still makes progress`() {
+        val batches = ProgressOutbox.batches(listOf(entry(1, 1.0), entry(2, 2.0)), maxItems = 0)
+
+        assertEquals(listOf(1, 1), batches.map { it.size })
+    }
+
+    /**
+     * The backend hands `client_updated_at` to `datetime.fromisoformat`, which before Python 3.11
+     * accepts only three or six fractional digits, and its stated floor is 3.10. A stamp it cannot
+     * parse is rejected as `invalid_client_updated_at` and the write is dropped — the exact data
+     * loss this path exists to prevent. Repeated because the digit count varies with the clock, so
+     * a single sample can pass by luck.
+     */
+    @Test
+    fun `now stamp is parseable by the backend`() {
+        val pattern = Regex("""^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$""")
+
+        repeat(200) {
+            val stamp = nowStamp()
+            assertTrue(pattern.matches(stamp), "unparseable stamp: $stamp")
+        }
+    }
+}
+
+class FileProgressOutboxStoreTest {
+    private lateinit var dir: File
+    private lateinit var file: File
+
+    @BeforeTest
+    fun setUp() {
+        dir = Files.createTempDirectory("ttsroad-outbox").toFile()
+        file = dir.resolve("progress-outbox.json")
+    }
+
+    @AfterTest
+    fun tearDown() {
+        dir.deleteRecursively()
+    }
+
+    private fun entry(chapterId: Int, position: Double) = PendingProgress(
+        fictionId = 1,
+        chapterId = chapterId,
+        positionSeconds = position,
+        isPlayed = false,
+        clientUpdatedAt = "2026-08-11T10:00:00.000Z",
+    )
+
+    /** The whole reason the queue is on disk: the app closing is the case that loses data. */
+    @Test
+    fun `a queued position survives a restart`() {
+        FileProgressOutboxStore(file).record(entry(7, 120.0))
+
+        val reopened = FileProgressOutboxStore(file).entries.value
+
+        assertEquals(1, reopened.size)
+        assertEquals(7, reopened.single().chapterId)
+        assertEquals(120.0, reopened.single().positionSeconds)
+        assertEquals("2026-08-11T10:00:00.000Z", reopened.single().clientUpdatedAt)
+    }
+
+    @Test
+    fun `a drop is persisted, not just applied in memory`() {
+        val store = FileProgressOutboxStore(file)
+        store.record(entry(7, 120.0))
+        store.record(entry(8, 60.0))
+
+        store.drop(listOf(7))
+
+        assertEquals(listOf(8), FileProgressOutboxStore(file).entries.value.map { it.chapterId })
+    }
+
+    @Test
+    fun `clear empties the file too`() {
+        val store = FileProgressOutboxStore(file)
+        store.record(entry(7, 120.0))
+
+        store.clear()
+
+        assertTrue(FileProgressOutboxStore(file).entries.value.isEmpty())
+    }
+
+    /**
+     * Refusing to construct the repository — and so refusing to play anything — because of one
+     * malformed file would be worse than losing the few positions it held.
+     */
+    @Test
+    fun `an unreadable file starts empty rather than throwing`() {
+        file.parentFile.mkdirs()
+        file.writeText("{ this is not the json you are looking for")
+
+        assertTrue(FileProgressOutboxStore(file).entries.value.isEmpty())
+    }
+
+    @Test
+    fun `a file from a future version is discarded rather than half-read`() {
+        file.parentFile.mkdirs()
+        file.writeText("""{"version":99,"entries":[{"fictionId":1,"chapterId":7,"positionSeconds":5.0,"isPlayed":false,"clientUpdatedAt":"2026-08-11T10:00:00.000Z"}]}""")
+
+        assertTrue(FileProgressOutboxStore(file).entries.value.isEmpty())
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/RepositoryTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/RepositoryTest.kt
@@ -200,9 +200,8 @@ class RepositoryTest {
     fun `saveProgress is a no-op when signed out, so a stray progress tick cannot crash playback`() = runTest {
         sessionStore.clearToken()
 
-        val response = repository.saveProgress(7, 101, 12.0, isPlayed = false)
+        repository.saveProgress(7, 101, 12.0, isPlayed = false)
 
-        assertNull(response)
         assertEquals(0, server.requestCount)
     }
 


### PR DESCRIPTION
Addresses the `/playback/sync` half of #36. Built against real `master` (`b92a087`, v1.0.2).

*(Supersedes the closed #44, which I built against a stale checkout — see the retraction on #35.)*

## The bug

`QueuePlaybackController` saved through `/api/mobile/playback/progress`: untimestamped, one chapter at a time, and its `saveProgress` wrapper swallows failures in a bare `runCatching`. That endpoint writes whatever it is handed. Listen offline here, listen in the browser afterwards, reconnect — the older position wins, because the server has no way to order the two writes. With `download/` in this client, that is a normal Tuesday, not an edge case.

## The fix

Positions are **stamped and queued to disk, then sent**. If the send fails, the position survives with the time it was *actually reached*, so when it lands it can be ordered against everything since.

- `ProgressOutbox` — pure rules (record/drop/batch), split from `FileProgressOutboxStore` the same way `DownloadIndex` is split from its store, so the transitions are asserted without a temp directory.
- One entry per chapter: only the furthest position matters and the server compares by stamp anyway, which bounds the file by chapters listened to rather than session length.
- Written via `SecureFiles.writeAtomically`, so a crash mid-write cannot leave a truncated file where a position used to be.
- `max_playback_sync_items` is now parsed into `ServerCapabilities` and obeyed — an oversized batch gets a 400 rather than being truncated, so ignoring it loses *all* of it.

## Where `server_state` earns its keep

`resumeMsOf` now prefers the reconciled state, which is only populated by a `/playback/sync` round trip and so is strictly later than the chapter list. Concretely: **a chapter whose local write lost now resumes from the browser's position** instead of silently restarting from the stale local one. That is #36 closing, and there's a test for it.

## Three judgement calls worth your eye

**Nothing is queued while signed out.** A position with no account behind it belongs to nobody; queuing it would flush one user's listening history into the next account signed in on this machine. This also preserves the existing "no-op when signed out" contract.

**Failures still propagate.** I initially swallowed them in `saveProgress` and it broke `a 401 on a progress save ends the session too` — correctly. A 401 has to reach the session-end handling, and `QueuePlaybackController` already treats a failed save as non-fatal. I fixed my code rather than the test; the position stays queued either way.

**Rejections are dropped, not retried** — `not_found`, `stale`, `empty`, `missing_client_updated_at`, `invalid_client_updated_at` are all terminal, so re-sending gets the same answer forever.

## A latent bug found while building this

`Instant.now().toString()` emits up to nine fractional digits. `parse_iso8601` feeds `datetime.fromisoformat`, which before Python 3.11 accepts only three or six — and the backend's stated floor is 3.10. A nine-digit stamp comes back as `invalid_client_updated_at` and the write is **dropped**: the exact loss this endpoint prevents, reproducing only on some deployments. `nowStamp()` truncates to milliseconds, with a test that samples 200 times because the digit count varies with the clock. Filed upstream as jonarihen/TTSRoad#88 and flagged for Android as jonarihen/TTSRoad-App#72.

## Also settled: the clock question in #36

The issue asks whether to trust the device wall clock. The backend already does `effective = min(stamp, now)`, so a fast clock cannot stamp into the future and win every conflict. Trusting it is safe as written — no client-side skew detection needed.

## Not included: delta sync

#36 also asks for `GET /api/mobile/sync` feeding `LibraryDiskCache`. That cache **does** exist here, so it is genuinely doable — but it is a separate concern (library freshness, not progress loss) and this change is already the data-loss fix on its own. Leaving #36 open for it rather than bundling.

## Verification

`./gradlew build` passes: **827 tests, 0 failures** — 804 pre-existing plus 23 new (9 outbox rules, 5 file store, 9 wire-level against MockWebServer covering batching, the drop-on-reject rule, `server_state` reconciliation, the older-server fallback, queue retention on 5xx, and queue clearing on 401).

Not exercised against a live TTSRoad server — there is no instance in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)