### PR TITLE
Search chapters and narration text on the server

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -78,11 +78,14 @@ import dk.perspektiva.ttsroad.desktop.ui.NowPlayingBar
 import dk.perspektiva.ttsroad.desktop.ui.PageGutter
 import dk.perspektiva.ttsroad.desktop.ui.PlayerScreen
 import dk.perspektiva.ttsroad.desktop.ui.ReaderScreen
+import dk.perspektiva.ttsroad.desktop.ui.SearchScreen
+import dk.perspektiva.ttsroad.desktop.ui.SearchStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.SettingsScreen
 import dk.perspektiva.ttsroad.desktop.ui.SettingsSection
 import dk.perspektiva.ttsroad.desktop.ui.SettingsStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.ShortcutsDialog
 import dk.perspektiva.ttsroad.desktop.ui.WindowSizeClass
+import dk.perspektiva.ttsroad.desktop.ui.fictionForHit
 import dk.perspektiva.ttsroad.desktop.ui.hasSession
 import dk.perspektiva.ttsroad.desktop.ui.rememberChapterDownloads
 import dk.perspektiva.ttsroad.desktop.ui.UpdateStateHolder
@@ -114,6 +117,9 @@ fun App(container: AppContainer = remember { AppContainer() }) {
     val settings = rememberStateHolder(repository, sessionStore) {
         SettingsStateHolder(repository, sessionStore, offlineStorage = container.downloads)
     }
+    // Hoisted for the same reason: following a hit and coming back must find the results still
+    // there. A search you have to run twice to use is not a search.
+    val search = rememberStateHolder(repository) { SearchStateHolder(repository) }
 
     // Capability discovery is the only source of the server's stable advertised identity. Feed it
     // into the download namespace as soon as it arrives; using it only for feature flags would
@@ -134,6 +140,7 @@ fun App(container: AppContainer = remember { AppContainer() }) {
             Destination.Library -> cache.refreshLibrary()
             is Destination.Fiction -> cache.refreshChapters(destination.fiction.id)
             Destination.Settings, Destination.Devices -> settings.refreshCurrentSection()
+            Destination.Search -> search.refresh()
             Destination.Player, is Destination.Reader -> Unit
         }
     }
@@ -224,6 +231,7 @@ fun App(container: AppContainer = remember { AppContainer() }) {
             cache.clear()
             container.readAlongCache.clear()
             settings.sessionEnded()
+            search.sessionEnded()
         } else {
             // Cheap, and it is what makes optional UI correct after a restart, where login did
             // not run but a keyring-backed session was restored.
@@ -313,6 +321,34 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                     historyOwnerKey = container.historyOwnerKey(),
                                     onOpenFiction = { nav.open(Destination.Fiction(it)) },
                                     onOpenPlayer = { nav.open(Destination.Player) },
+                                    // The local filter stays the instant path; this is the second,
+                                    // explicit one that can reach narration text.
+                                    serverSearchAvailable = capabilities.search,
+                                    onSearchServer = { query ->
+                                        search.search(query)
+                                        nav.open(Destination.Search)
+                                    },
+                                )
+
+                                Destination.Search -> SearchScreen(
+                                    holder = search,
+                                    // Same gate the chapter rows use: without the endpoint there
+                                    // is no reader to land a text hit in.
+                                    readAlongAvailable = capabilities.readAlong,
+                                    onOpenFiction = { hit ->
+                                        nav.open(
+                                            Destination.Fiction(
+                                                fictionForHit(
+                                                    cache.library.value.value?.fictions.orEmpty(),
+                                                    hit,
+                                                ),
+                                            ),
+                                        )
+                                    },
+                                    onOpenReader = { chapterId, title ->
+                                        nav.open(Destination.Reader(chapterId, title))
+                                    },
+                                    onBack = { nav.back() },
                                 )
 
                                 is Destination.Fiction -> FictionDetailScreen(
@@ -411,6 +447,9 @@ fun App(container: AppContainer = remember { AppContainer() }) {
 private val Destination.isRefreshable: Boolean
     get() = when (this) {
         Destination.Library, is Destination.Fiction, Destination.Settings, Destination.Devices -> true
+        // Refresh re-runs the query the results belong to; it is dead until one has been run, but
+        // enabling it is cheaper to reason about than a state-dependent header button.
+        Destination.Search -> true
         Destination.Player, is Destination.Reader -> false
     }
 

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -141,6 +141,20 @@ interface TtsRoadRepository {
 
     suspend fun chapters(fictionId: Int, playableOnly: Boolean = false): ChaptersResponse
 
+    /**
+     * Server-side search, or **null when this server has no search endpoint**.
+     *
+     * Null rather than an empty result for the same reason [devices] uses it: "nothing matched" is
+     * a normal answer the UI phrases one way, and "this server cannot search" is a different one it
+     * has to phrase another. The `search` capability is the gate; this is the fallback for a server
+     * that advertised it and then answered 404 anyway.
+     */
+    suspend fun search(
+        query: String,
+        limit: Int = SearchLimits.Default,
+        offset: Int = 0,
+    ): SearchResponse?
+
     /** Conditional reader document request; 404 is a normal [ReadAlongFetchResult.NotFound]. */
     suspend fun readAlong(chapterId: Int, ifNoneMatch: String? = null): ReadAlongFetchResult
 
@@ -361,6 +375,17 @@ class RetrofitTtsRoadRepository(
 
     override suspend fun chapters(fictionId: Int, playableOnly: Boolean): ChaptersResponse =
         withAuthorizedApi { it.chapters(fictionId = fictionId, playableOnly = playableOnly) }
+
+    override suspend fun search(query: String, limit: Int, offset: Int): SearchResponse? =
+        ifEndpointExists {
+            it.search(
+                // Trimmed and bounded here rather than at the call site: the server rejects an
+                // over-long `q` with a 422, and a 422 is not something a listener can act on.
+                query = query.trim().take(SearchLimits.MaxQueryLength),
+                limit = limit.coerceIn(1, SearchLimits.Max),
+                offset = offset.coerceAtLeast(0),
+            )
+        }
 
     override suspend fun readAlong(chapterId: Int, ifNoneMatch: String?): ReadAlongFetchResult =
         withAuthorizedApi { api ->

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/SearchModels.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/SearchModels.kt
@@ -1,0 +1,135 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Json
+
+/**
+ * `GET /api/mobile/search`.
+ *
+ * Three groups, always present even when empty, returned in rank order — fictions, then chapter
+ * titles, then narration text (`app/services/search.py`). Everything is defaulted because the
+ * endpoint is additive like the rest of the mobile surface: a server that grows a fourth group must
+ * not fail this decode.
+ */
+data class SearchResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    val query: String = "",
+    val tokens: List<String> = emptyList(),
+    val limit: Int = SearchLimits.Default,
+    val offset: Int = 0,
+    /**
+     * Whether the server answered from its narration-text index or from a scan. Reported because a
+     * non-indexed server still answers, just less well — not because the client does anything
+     * differently.
+     */
+    val indexed: Boolean = false,
+    val total: Int = 0,
+    val fictions: SearchGroup = SearchGroup(),
+    val chapters: SearchGroup = SearchGroup(),
+    val text: SearchGroup = SearchGroup(),
+) {
+    val isEmpty: Boolean
+        get() = fictions.items.isEmpty() && chapters.items.isEmpty() && text.items.isEmpty()
+}
+
+data class SearchGroup(
+    val items: List<SearchHit> = emptyList(),
+    val total: Int = 0,
+    /** The server stopped counting at its cap; "500 results" would be a guess dressed as a number. */
+    val capped: Boolean = false,
+    @param:Json(name = "has_more") val hasMore: Boolean = false,
+)
+
+/**
+ * One hit, in the single shape all three groups share.
+ *
+ * The server deliberately sends null rather than omitting a field, so a client decodes every hit
+ * with one type and switches on [kind]. This mirrors that: the chapter fields are null on a fiction
+ * hit rather than modelled as a separate class.
+ */
+data class SearchHit(
+    /** `fiction`, `chapter` or `text`. Compared as a string: an unknown kind must not fail a decode. */
+    val kind: String = "",
+    val score: Double = 0.0,
+    @param:Json(name = "fiction_id") val fictionId: Int = 0,
+    @param:Json(name = "fiction_title") val fictionTitle: String? = null,
+    @param:Json(name = "fiction_slug") val fictionSlug: String? = null,
+    val author: String? = null,
+    @param:Json(name = "cover_image_url") val coverImageUrl: String? = null,
+    val tags: List<String> = emptyList(),
+    @param:Json(name = "chapter_id") val chapterId: Int? = null,
+    @param:Json(name = "chapter_title") val chapterTitle: String? = null,
+    @param:Json(name = "chapter_number") val chapterNumber: Int? = null,
+    @param:Json(name = "audio_duration") val audioDuration: Double = 0.0,
+    val status: String? = null,
+    /** Excluded chapters stay searchable and are flagged rather than hidden — the server's choice. */
+    val excluded: Boolean = false,
+    val playable: Boolean = false,
+    @param:Json(name = "has_timings") val hasTimings: Boolean = false,
+    val audio: AudioInfo? = null,
+    /**
+     * Where the match starts in the chapter's `clean_text`, in characters.
+     *
+     * **Not an audio timestamp.** Turning one into the other needs the read-along timings, so this
+     * is decoded and not yet acted on; a text hit opens the chapter, not the passage.
+     */
+    @param:Json(name = "char_offset") val charOffset: Int? = null,
+    @param:Json(name = "matched_fields") val matchedFields: List<String> = emptyList(),
+    val snippet: String = "",
+    /**
+     * `[[start, end], …]` over [snippet], in **Unicode code points** — see [snippetSpans], which is
+     * the only thing that should read this field.
+     */
+    val highlights: List<List<Int>> = emptyList(),
+) {
+    val resolvedChapterId: Int get() = chapterId ?: 0
+
+    /** A chapter row the reader can be opened on. Fiction hits carry no chapter at all. */
+    val isChapterHit: Boolean get() = resolvedChapterId > 0
+}
+
+/** What the server will accept, so the client never sends a request it has told us it will reject. */
+object SearchLimits {
+    const val Default: Int = 20
+    const val Max: Int = 50
+    const val MaxQueryLength: Int = 200
+}
+
+/** A half-open `[start, end)` range of **UTF-16 indices** into a snippet. */
+data class SnippetSpan(val start: Int, val end: Int)
+
+/**
+ * Resolves a hit's [SearchHit.highlights] against its snippet.
+ *
+ * Two corrections happen here, and both are load-bearing:
+ *
+ * The offsets are computed over Python string indices, which count **code points**. Kotlin indexes
+ * UTF-16 units, so a snippet containing an astral character — an emoji anywhere before the match —
+ * shifts every span after it. Converting rather than trusting is what keeps the highlight on the
+ * word that actually matched.
+ *
+ * And a span outside the snippet is *dropped*, not clamped-and-drawn: an out-of-range index throws
+ * when it reaches an `AnnotatedString`, so a malformed payload would take down the results list
+ * rather than merely mis-highlighting one row.
+ */
+fun snippetSpans(snippet: String, highlights: List<List<Int>>): List<SnippetSpan> {
+    if (snippet.isEmpty() || highlights.isEmpty()) return emptyList()
+    val codePoints = snippet.codePointCount(0, snippet.length)
+    // The overwhelmingly common case: no surrogate pairs, so a code point index *is* a char index.
+    val simple = codePoints == snippet.length
+    val spans = ArrayList<SnippetSpan>(highlights.size)
+    for (pair in highlights) {
+        if (pair.size < 2) continue
+        val startCodePoint = pair[0]
+        val endCodePoint = pair[1].coerceAtMost(codePoints)
+        if (startCodePoint < 0 || endCodePoint <= startCodePoint || startCodePoint >= codePoints) continue
+        spans += if (simple) {
+            SnippetSpan(startCodePoint, endCodePoint)
+        } else {
+            SnippetSpan(
+                snippet.offsetByCodePoints(0, startCodePoint),
+                snippet.offsetByCodePoints(0, endCodePoint),
+            )
+        }
+    }
+    return spans
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -63,6 +63,19 @@ interface TtsRoadApi {
     @GET("api/mobile/library")
     suspend fun library(): LibraryResponse
 
+    /**
+     * Library-wide search across fiction metadata, chapter titles and narration text.
+     *
+     * Advertised as the `search` capability; 404 on a server older than the endpoint. An empty
+     * query is an empty result rather than a 422, which is what lets the field clear itself.
+     */
+    @GET("api/mobile/search")
+    suspend fun search(
+        @Query("q") query: String,
+        @Query("limit") limit: Int = SearchLimits.Default,
+        @Query("offset") offset: Int = 0,
+    ): SearchResponse
+
     @GET("api/mobile/fictions/{fiction_id}/chapters")
     suspend fun chapters(
         @Path("fiction_id") fictionId: Int,

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/nav/AppNavigation.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/nav/AppNavigation.kt
@@ -34,6 +34,16 @@ sealed interface Destination {
      */
     data class Reader(val chapterId: Int, val title: String) : Destination
 
+    /**
+     * Server-side search results.
+     *
+     * Carries no query. The query and its results live in the hoisted search holder, so opening a
+     * hit and coming back finds the list still there — and so re-opening this destination from the
+     * library with a *new* query is not defeated by the pop-back-to-existing rule below, which
+     * keeps the older entry's payload.
+     */
+    data object Search : Destination
+
     data object Settings : Destination
 
     data object Devices : Destination
@@ -53,6 +63,7 @@ val Destination.key: String
         is Destination.Fiction -> "Fiction:${fiction.id}"
         Destination.Player -> "Player"
         is Destination.Reader -> "Reader:$chapterId"
+        Destination.Search -> "Search"
         Destination.Settings -> "Settings"
         Destination.Devices -> "Devices"
     }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/LibraryScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/LibraryScreen.kt
@@ -33,11 +33,15 @@ import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.itemsIndexed as itemsIndexedInRow
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -61,6 +65,7 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
@@ -102,6 +107,14 @@ fun LibraryScreen(
     playback: PlaybackController,
     onOpenFiction: (FictionSummary) -> Unit,
     onOpenPlayer: () -> Unit,
+    /**
+     * Whether the signed-in server advertises the `search` capability.
+     *
+     * False hides the escalation entirely rather than disabling it: the field above still filters
+     * what is loaded, which is the whole feature on a server that cannot do more.
+     */
+    serverSearchAvailable: Boolean = false,
+    onSearchServer: (String) -> Unit = {},
     /**
      * Local listening history, for the "Jump back in" strip. Defaulted to an in-memory store so a
      * screen test never reads or writes the real config directory.
@@ -216,8 +229,25 @@ fun LibraryScreen(
                                     onValueChange = { query = it },
                                     label = { Text("SEARCH TITLE, AUTHOR OR TAG") },
                                     singleLine = true,
+                                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                                    // Enter escalates rather than filtering again: the filter has
+                                    // already applied itself on every keystroke, so the only thing
+                                    // left for the key to mean is "look further than this".
+                                    keyboardActions = KeyboardActions(
+                                        onSearch = {
+                                            if (serverSearchAvailable && query.isNotBlank()) onSearchServer(query)
+                                        },
+                                    ),
                                     modifier = Modifier.fillMaxWidth(),
                                 )
+                                if (serverSearchAvailable) {
+                                    Spacer(Modifier.height(10.dp))
+                                    SearchServerAction(
+                                        query = query,
+                                        matches = filtered.size,
+                                        onSearch = { onSearchServer(query) },
+                                    )
+                                }
                             }
                         }
                     }
@@ -331,6 +361,40 @@ private fun JumpBackShelf(
                     )
                 }
             }
+        }
+    }
+}
+
+const val SearchServerTestTag: String = "librarySearchServer"
+
+/**
+ * The escalation from the local filter to the server's own index.
+ *
+ * Phrased as what it adds — chapter titles and narration text — rather than as "search", because
+ * the field directly above it is also search and the difference between the two is the only reason
+ * this control exists. Disabled rather than hidden while the field is empty, so it does not appear
+ * and disappear under the cursor as the user types.
+ */
+@Composable
+private fun SearchServerAction(query: String, matches: Int, onSearch: () -> Unit) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        OutlinedButton(
+            onClick = onSearch,
+            enabled = query.isNotBlank(),
+            shape = RectangleShape,
+            modifier = Modifier
+                .pointerHoverIcon(PointerIcon.Hand)
+                .testTag(SearchServerTestTag),
+        ) {
+            Icon(Icons.Default.Search, contentDescription = null, Modifier.size(16.dp))
+            Spacer(Modifier.width(8.dp))
+            MetaText("Search chapters and text on the server", color = AarisColor.Ink)
+        }
+        // The case this is really for: the words are in a chapter, not in a title, so the shelf
+        // below is empty and the server is the only thing that can answer.
+        if (query.isNotBlank() && matches == 0) {
+            Spacer(Modifier.width(12.dp))
+            MetaText("Nothing here matches — the server may still find it", color = AarisColor.Dim)
         }
     }
 }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SearchScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SearchScreen.kt
@@ -1,0 +1,361 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.SearchGroup
+import dk.perspektiva.ttsroad.desktop.data.SearchHit
+import dk.perspektiva.ttsroad.desktop.data.snippetSpans
+
+const val SearchFieldTestTag: String = "searchField"
+const val SearchHitTestTag: String = "searchHit"
+const val SearchSubmitTestTag: String = "searchSubmit"
+
+/**
+ * Server-side search across fiction metadata, chapter titles and **narration text**.
+ *
+ * Deliberately a second, explicit path rather than a replacement for the library's own filter. That
+ * filter is instant, needs no network and keeps working against a downloaded library with the
+ * server unreachable; this one can find a sentence inside a chapter, which the local filter
+ * structurally cannot do. Both are worth having and they are not the same tool.
+ */
+@Composable
+fun SearchScreen(
+    holder: SearchStateHolder,
+    readAlongAvailable: Boolean,
+    onOpenFiction: (SearchHit) -> Unit,
+    onOpenReader: (chapterId: Int, title: String) -> Unit,
+    onBack: () -> Unit,
+) {
+    val state by holder.state.collectAsState()
+    val field = remember { FocusRequester() }
+    // Arriving on an empty search screen means typing, so put the caret where the typing goes.
+    LaunchedEffect(Unit) { runCatching { field.requestFocus() } }
+
+    Box(Modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .widthIn(max = ContentMaxWidth)
+                .fillMaxSize(),
+            contentPadding = PaddingValues(PageGutter),
+        ) {
+            item(key = "head", contentType = "header") {
+                Column {
+                    BackLink("Back", onBack)
+                    Spacer(Modifier.height(20.dp))
+                    SectionTitle("01", "Search the server")
+                    Spacer(Modifier.height(16.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        OutlinedTextField(
+                            value = state.query,
+                            onValueChange = holder::queryChanged,
+                            label = { Text("TITLE, AUTHOR, CHAPTER OR ANYTHING SAID IN ONE") },
+                            singleLine = true,
+                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                            keyboardActions = KeyboardActions(onSearch = { holder.submit() }),
+                            modifier = Modifier
+                                .weight(1f)
+                                .focusRequester(field)
+                                .testTag(SearchFieldTestTag),
+                        )
+                        Spacer(Modifier.width(12.dp))
+                        Button(
+                            onClick = holder::submit,
+                            enabled = !state.busy && state.query.isNotBlank(),
+                            shape = RectangleShape,
+                            modifier = Modifier
+                                .pointerHoverIcon(PointerIcon.Hand)
+                                .testTag(SearchSubmitTestTag),
+                        ) {
+                            Icon(Icons.Default.Search, contentDescription = null, Modifier.size(18.dp))
+                            Spacer(Modifier.width(8.dp))
+                            Text(if (state.busy) "SEARCHING" else "SEARCH")
+                        }
+                    }
+                    state.error?.let {
+                        Spacer(Modifier.height(12.dp))
+                        Text(it, color = MaterialTheme.colorScheme.error)
+                    }
+                    state.result?.let { result ->
+                        Spacer(Modifier.height(12.dp))
+                        MetaText(resultSummary(result.total, state.resultQuery), color = AarisColor.Dim)
+                    }
+                    Spacer(Modifier.height(20.dp))
+                }
+            }
+
+            when {
+                state.unsupported -> item(key = "unsupported", contentType = "empty") {
+                    EmptyState(
+                        "This server cannot search",
+                        "It advertised the search feature but has no /api/mobile/search endpoint. " +
+                            "The library filter above still works.",
+                    )
+                }
+
+                state.result?.isEmpty == true -> item(key = "no-matches", contentType = "empty") {
+                    EmptyState(
+                        "No matches for \"${state.resultQuery}\"",
+                        "Nothing in a title, a chapter name or any chapter's narration text.",
+                    )
+                }
+
+                state.result == null && !state.hasSearched -> item(key = "prompt", contentType = "empty") {
+                    EmptyState(
+                        "Search every chapter",
+                        "Unlike the library filter, this reaches chapter titles and the words inside them.",
+                    )
+                }
+            }
+
+            state.result?.let { result ->
+                group("02", "Fictions", result.fictions) { hit ->
+                    HitRow(hit, action = null) { onOpenFiction(hit) }
+                }
+                group("03", "Chapters", result.chapters) { hit ->
+                    HitRow(hit, action = readerAction(hit, readAlongAvailable)) {
+                        openHit(hit, readAlongAvailable, onOpenFiction, onOpenReader)
+                    }
+                }
+                group("04", "In the text", result.text) { hit ->
+                    HitRow(hit, action = readerAction(hit, readAlongAvailable)) {
+                        openHit(hit, readAlongAvailable, onOpenFiction, onOpenReader)
+                    }
+                }
+            }
+        }
+        RefreshingStrip(state.busy)
+    }
+}
+
+/**
+ * Where a hit goes when it is clicked.
+ *
+ * A chapter opens the reader, which is where its *text* is — that is the whole point of having
+ * matched narration. Without the read-along capability there is no reader to open, so it falls back
+ * to the fiction's chapter list, which is also where a fiction hit goes.
+ *
+ * It does **not** start playback. `char_offset` is a character offset into `clean_text`, not an
+ * audio timestamp, so there is no position to start at; and beginning to play a chapter somebody
+ * clicked to *read* is not what they asked for.
+ */
+private fun openHit(
+    hit: SearchHit,
+    readAlongAvailable: Boolean,
+    onOpenFiction: (SearchHit) -> Unit,
+    onOpenReader: (Int, String) -> Unit,
+) {
+    if (readAlongAvailable && hit.isChapterHit) {
+        onOpenReader(hit.resolvedChapterId, hit.chapterTitle.orEmpty().ifBlank { "Chapter" })
+    } else {
+        onOpenFiction(hit)
+    }
+}
+
+private fun readerAction(hit: SearchHit, readAlongAvailable: Boolean): String? =
+    if (readAlongAvailable && hit.isChapterHit) "Read" else null
+
+/** One ranked group, drawn only when it has hits — an empty "Fictions" heading is noise. */
+private fun androidx.compose.foundation.lazy.LazyListScope.group(
+    kicker: String,
+    title: String,
+    group: SearchGroup,
+    row: @Composable (SearchHit) -> Unit,
+) {
+    if (group.items.isEmpty()) return
+    item(key = "header-$kicker", contentType = "header") {
+        Column {
+            SectionTitle(kicker, groupTitle(title, group))
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+    items(
+        count = group.items.size,
+        key = { index -> "$kicker:${group.items[index].fictionId}:${group.items[index].resolvedChapterId}:$index" },
+        contentType = { "hit" },
+    ) { index ->
+        Column {
+            row(group.items[index])
+            HorizontalDivider(thickness = 1.dp, color = AarisColor.LineSoft)
+        }
+    }
+    item(key = "spacer-$kicker", contentType = "header") { Spacer(Modifier.height(28.dp)) }
+}
+
+/** "Chapters — 12 shown of 340", or "of 500+" where the server stopped counting. */
+internal fun groupTitle(title: String, group: SearchGroup): String = when {
+    group.total <= group.items.size -> "$title — ${group.items.size}"
+    group.capped -> "$title — ${group.items.size} shown of ${group.total}+"
+    else -> "$title — ${group.items.size} shown of ${group.total}"
+}
+
+internal fun resultSummary(total: Int, query: String): String =
+    if (total == 0) "No matches for \"$query\"" else "$total ${if (total == 1) "match" else "matches"} for \"$query\""
+
+@Composable
+private fun HitRow(hit: SearchHit, action: String?, onOpen: () -> Unit) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    val focused by interaction.collectIsFocusedAsState()
+    val active = hovered || focused
+
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .hoverable(interaction)
+            .pointerHoverIcon(PointerIcon.Hand)
+            .clickable(interactionSource = interaction, indication = null, onClick = onOpen)
+            .background(if (active) AarisColor.BgRaise else Color.Transparent)
+            .border(1.dp, if (focused) AarisColor.Accent else Color.Transparent)
+            .padding(horizontal = 12.dp, vertical = 12.dp)
+            .testTag(SearchHitTestTag),
+        verticalAlignment = Alignment.Top,
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(
+                hitTitle(hit),
+                style = MaterialTheme.typography.titleMedium,
+                color = if (active) AarisColor.Accent else AarisColor.Ink,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            hitContext(hit)?.let {
+                Spacer(Modifier.height(2.dp))
+                MetaText(it, color = AarisColor.Dim)
+            }
+            if (hit.snippet.isNotBlank()) {
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    highlightedSnippet(hit),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = AarisColor.Muted,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        if (action != null) {
+            Spacer(Modifier.width(12.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.AutoMirrored.Filled.MenuBook,
+                    contentDescription = null,
+                    tint = if (active) AarisColor.Accent else AarisColor.Dim,
+                    modifier = Modifier.size(16.dp),
+                )
+                Spacer(Modifier.width(6.dp))
+                MetaText(action, color = if (active) AarisColor.Accent else AarisColor.Dim)
+            }
+        }
+    }
+}
+
+/** The chapter is the headline where there is one; the fiction is the headline otherwise. */
+internal fun hitTitle(hit: SearchHit): String = when {
+    hit.isChapterHit -> hit.chapterTitle.orEmpty().ifBlank { "Untitled chapter" }
+    else -> hit.fictionTitle.orEmpty().ifBlank { "Untitled" }
+}
+
+/** The line under the headline: which book, and anything the row would otherwise hide. */
+internal fun hitContext(hit: SearchHit): String? {
+    val parts = buildList {
+        if (hit.isChapterHit) hit.fictionTitle?.takeIf { it.isNotBlank() }?.let(::add)
+        else hit.author?.takeIf { it.isNotBlank() }?.let { add("by $it") }
+        if (hit.excluded) add("Excluded")
+        // Not a defect: a chapter can be found by its text before its audio has been produced.
+        if (hit.isChapterHit && !hit.playable && !hit.excluded) add("No audio yet")
+    }
+    return parts.joinToString("  ·  ").takeIf { it.isNotBlank() }
+}
+
+/**
+ * The snippet with the matched words emphasised.
+ *
+ * The server sends *ranges*, never markup, precisely so nothing it returns is interpreted as
+ * formatting here — and [snippetSpans] is what makes those ranges safe to index with.
+ */
+@Composable
+private fun highlightedSnippet(hit: SearchHit): AnnotatedString {
+    val spans = remember(hit.snippet, hit.highlights) { snippetSpans(hit.snippet, hit.highlights) }
+    if (spans.isEmpty()) return AnnotatedString(hit.snippet)
+    return buildAnnotatedString {
+        append(hit.snippet)
+        spans.forEach { span ->
+            addStyle(
+                SpanStyle(color = AarisColor.Accent, fontWeight = FontWeight.SemiBold),
+                span.start,
+                span.end,
+            )
+        }
+    }
+}
+
+/**
+ * The library's own fictions, so a hit opens the detail screen with a header it can paint at once.
+ *
+ * A search hit carries less than a library row does — no chapter counts — so a fiction the library
+ * has not loaded gets a summary synthesised from the hit rather than nothing at all; the detail
+ * screen replaces it as soon as the chapter list lands.
+ */
+internal fun fictionForHit(known: List<FictionSummary>, hit: SearchHit): FictionSummary =
+    known.firstOrNull { it.id == hit.fictionId }
+        ?: FictionSummary(
+            id = hit.fictionId,
+            title = hit.fictionTitle.orEmpty().ifBlank { "Untitled" },
+            author = hit.author,
+            slug = hit.fictionSlug,
+            coverImageUrl = hit.coverImageUrl,
+            tags = hit.tags,
+        )

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SearchStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SearchStateHolder.kt
@@ -1,0 +1,121 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.data.SearchResponse
+import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
+import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * What the search screen shows.
+ *
+ * [query] is the text in the field and [resultQuery] is the text [result] actually answers. They
+ * differ while the user is typing a second search over the first one's results, which is why the
+ * screen can say "showing results for …" instead of implying the list matches what is on screen.
+ */
+data class SearchUiState(
+    val query: String = "",
+    val busy: Boolean = false,
+    val error: String? = null,
+    val result: SearchResponse? = null,
+    val resultQuery: String = "",
+    /**
+     * The server answered 404 for the endpoint it advertised.
+     *
+     * Distinct from [error] on purpose, and for the same reason `SettingsStateHolder` separates
+     * "the server cannot answer at all" from "the answer is empty": one is worth a retry and the
+     * other never will be.
+     */
+    val unsupported: Boolean = false,
+) {
+    /** True once a search has completed, so "no matches" is only said about a query that ran. */
+    val hasSearched: Boolean get() = result != null || error != null || unsupported
+}
+
+/**
+ * Server-side search, held above the screen.
+ *
+ * Hoisted like the settings and update holders so results survive opening a hit and coming back —
+ * a search whose results are destroyed by following one of them is a search you have to run twice.
+ * It is also why [Destination.Search][dk.perspektiva.ttsroad.desktop.nav.Destination.Search] can be
+ * a plain object with no payload: the query lives here, not in the back stack.
+ */
+class SearchStateHolder(
+    private val repository: TtsRoadRepository,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : StateHolder(dispatcher) {
+    private val _state = MutableStateFlow(SearchUiState())
+    val state: StateFlow<SearchUiState> = _state.asStateFlow()
+
+    private var searchJob: Job? = null
+
+    /** Every keystroke in the field. Deliberately does not search: see [submit]. */
+    fun queryChanged(query: String) {
+        _state.update { it.copy(query = query) }
+    }
+
+    /**
+     * Runs [query], replacing whatever was in the field.
+     *
+     * The entry point from the library, where the user has already typed the words once. Blank is
+     * accepted and clears rather than asking the server for everything.
+     */
+    fun search(query: String) {
+        _state.update { it.copy(query = query) }
+        submit()
+    }
+
+    /**
+     * Runs whatever is in the field.
+     *
+     * Explicit rather than debounced-as-you-type: the local library filter is the instant path and
+     * still works offline, and this one is a network round trip over every chapter's narration text.
+     * Making it an action is what keeps those two honestly different.
+     */
+    fun submit() {
+        val query = _state.value.query.trim()
+        searchJob?.cancel()
+        if (query.isEmpty()) {
+            _state.update { it.copy(busy = false, error = null, result = null, resultQuery = "", unsupported = false) }
+            return
+        }
+        _state.update { it.copy(busy = true, error = null, unsupported = false) }
+        searchJob = scope.launch {
+            val outcome = runCatching { repository.search(query) }
+            _state.update { current ->
+                outcome.fold(
+                    onSuccess = { response ->
+                        if (response == null) {
+                            current.copy(busy = false, unsupported = true, result = null, resultQuery = query)
+                        } else {
+                            current.copy(busy = false, error = null, result = response, resultQuery = query)
+                        }
+                    },
+                    // Content is kept: a failed search over a list already on screen is the same
+                    // situation as a failed library refresh, and blanking the screen loses more
+                    // than the error explains.
+                    onFailure = { failure ->
+                        current.copy(busy = false, error = userFacingMessage(failure, "Could not search"))
+                    },
+                )
+            }
+        }
+    }
+
+    /** Re-runs the query the results belong to — what Refresh means on this screen. */
+    fun refresh() {
+        if (_state.value.resultQuery.isNotBlank()) search(_state.value.resultQuery)
+    }
+
+    /** The account's search results are the account's. Dropped with the session, like the library. */
+    fun sessionEnded() {
+        searchJob?.cancel()
+        _state.value = SearchUiState()
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -39,6 +39,8 @@ open class FakeRepository(
     ),
     var readerPreferencesResult: Result<dk.perspektiva.ttsroad.desktop.data.ReaderPreferencesResponse?> =
         Result.success(null),
+    /** `success(null)` is the server saying it cannot search — not "nothing matched". */
+    var searchResult: Result<dk.perspektiva.ttsroad.desktop.data.SearchResponse?> = Result.success(null),
 ) : TtsRoadRepository {
     var loginCalls: Int = 0
         private set
@@ -65,6 +67,8 @@ open class FakeRepository(
 
     /** Base URLs discovery was asked about, in order — capability probing is observable. */
     val capabilityProbes: MutableList<String> = mutableListOf()
+    /** Queries the server was actually asked, in order — trimming and debouncing are observable. */
+    val searchQueries: MutableList<String> = mutableListOf()
     val markedPlayed: MutableList<Pair<List<Int>, Boolean>> = mutableListOf()
     val savedProgress: MutableList<Triple<Int, Double, Boolean>> = mutableListOf()
 
@@ -130,6 +134,15 @@ open class FakeRepository(
     override suspend fun chapters(fictionId: Int, playableOnly: Boolean): ChaptersResponse {
         chaptersCalls++
         return chaptersResult.getOrThrow()
+    }
+
+    override suspend fun search(
+        query: String,
+        limit: Int,
+        offset: Int,
+    ): dk.perspektiva.ttsroad.desktop.data.SearchResponse? {
+        searchQueries += query
+        return searchResult.getOrThrow()
     }
 
     override suspend fun readAlong(

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ServerFixtures.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ServerFixtures.kt
@@ -437,6 +437,144 @@ object ServerFixtures {
 
     /** POST /api/mobile/playback/mark — 200. */
     val MARK_OK = """{"status": "ok", "played": true, "chapter_ids": [101], "count": 1}"""
+
+    /**
+     * GET /api/mobile/search — 200, one hit in each of the three groups.
+     *
+     * Reproduces the shape `app/services/search.py` actually emits: one item type across all three
+     * groups with nulls where a field does not apply, `highlights` as `[[start, end], …]` ranges
+     * rather than markup, and `char_offset` present only on a narration-text hit.
+     */
+    val SEARCH = """
+        {
+          "api_version": 1,
+          "query": "ashfall gate",
+          "tokens": ["ashfall", "gate"],
+          "scope": {"fiction_id": null},
+          "limit": 20,
+          "offset": 0,
+          "indexed": true,
+          "total": 3,
+          "fictions": {
+            "items": [
+              {
+                "kind": "fiction",
+                "score": 160.0,
+                "fiction_id": 7,
+                "fiction_title": "A Test Serial",
+                "fiction_slug": "a-test-serial",
+                "author": "Someone",
+                "cover_image_url": "https://ttsroad.example.com/static/covers/7.jpg",
+                "tags": ["LitRPG"],
+                "chapter_id": null,
+                "chapter_title": null,
+                "chapter_number": null,
+                "audio_duration": 0.0,
+                "status": null,
+                "excluded": false,
+                "playable": false,
+                "has_timings": false,
+                "audio": null,
+                "char_offset": null,
+                "matched_fields": ["title"],
+                "snippet": "A Test Serial",
+                "highlights": [[2, 6]],
+                "url": "/fiction/7"
+              }
+            ],
+            "total": 1,
+            "capped": false,
+            "has_more": false
+          },
+          "chapters": {
+            "items": [
+              {
+                "kind": "chapter",
+                "score": 140.0,
+                "fiction_id": 7,
+                "fiction_title": "A Test Serial",
+                "fiction_slug": "a-test-serial",
+                "author": null,
+                "cover_image_url": "https://ttsroad.example.com/static/covers/7.jpg",
+                "tags": [],
+                "chapter_id": 102,
+                "chapter_title": "The Ashfall Gate",
+                "chapter_number": 2,
+                "audio_duration": 1200.0,
+                "status": "done",
+                "excluded": false,
+                "playable": true,
+                "has_timings": true,
+                "audio": {
+                  "filename": "0002.mp3",
+                  "url": "/api/mobile/audio/a-test-serial/0002.mp3",
+                  "requires_bearer_auth": true
+                },
+                "char_offset": null,
+                "matched_fields": ["chapter_title"],
+                "snippet": "The Ashfall Gate",
+                "highlights": [[4, 11]],
+                "url": "/fiction/7?play=102"
+              }
+            ],
+            "total": 1,
+            "capped": false,
+            "has_more": false
+          },
+          "text": {
+            "items": [
+              {
+                "kind": "text",
+                "score": 96.5,
+                "fiction_id": 7,
+                "fiction_title": "A Test Serial",
+                "fiction_slug": "a-test-serial",
+                "author": null,
+                "cover_image_url": null,
+                "tags": [],
+                "chapter_id": 103,
+                "chapter_title": "Descent",
+                "chapter_number": 3,
+                "audio_duration": 980.0,
+                "status": "done",
+                "excluded": false,
+                "playable": true,
+                "has_timings": false,
+                "audio": {
+                  "filename": "0003.mp3",
+                  "url": "/api/mobile/audio/a-test-serial/0003.mp3",
+                  "requires_bearer_auth": true
+                },
+                "char_offset": 4180,
+                "matched_fields": ["clean_text"],
+                "snippet": "…they came at last to the ashfall gate, and it was shut.",
+                "highlights": [[26, 38]],
+                "url": "/fiction/7?play=103"
+              }
+            ],
+            "total": 1,
+            "capped": false,
+            "has_more": false
+          }
+        }
+    """.trimIndent()
+
+    /** A query nothing matched. Every group is present and empty — the server never omits one. */
+    val SEARCH_EMPTY = """
+        {
+          "api_version": 1,
+          "query": "nothingatall",
+          "tokens": ["nothingatall"],
+          "scope": {"fiction_id": null},
+          "limit": 20,
+          "offset": 0,
+          "indexed": true,
+          "total": 0,
+          "fictions": {"items": [], "total": 0, "capped": false, "has_more": false},
+          "chapters": {"items": [], "total": 0, "capped": false, "has_more": false},
+          "text": {"items": [], "total": 0, "capped": false, "has_more": false}
+        }
+    """.trimIndent()
 }
 
 /**
@@ -458,6 +596,12 @@ object ParsedFixtures {
         get() = requireNotNull(
             moshi.adapter(dk.perspektiva.ttsroad.desktop.data.ChaptersResponse::class.java)
                 .fromJson(ServerFixtures.CHAPTERS),
+        )
+
+    val search: dk.perspektiva.ttsroad.desktop.data.SearchResponse
+        get() = requireNotNull(
+            moshi.adapter(dk.perspektiva.ttsroad.desktop.data.SearchResponse::class.java)
+                .fromJson(ServerFixtures.SEARCH),
         )
 
     val devices: List<dk.perspektiva.ttsroad.desktop.data.DeviceSession>

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/SearchTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/SearchTest.kt
@@ -1,0 +1,199 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import dk.perspektiva.ttsroad.desktop.ParsedFixtures
+import dk.perspektiva.ttsroad.desktop.ServerFixtures
+import dk.perspektiva.ttsroad.desktop.authedClient
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.Headers
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import retrofit2.HttpException
+
+/** `GET /api/mobile/search`: the wire, the decode, and the snippet offsets. */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SearchTest {
+    private lateinit var server: MockWebServer
+    private lateinit var repository: RetrofitTtsRoadRepository
+
+    private val jsonHeaders = Headers.headersOf("Content-Type", "application/json")
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        val sessionStore = InMemorySessionStore(
+            SessionState(
+                serverUrl = server.url("/").toString(),
+                token = "ttsr_token",
+                username = "admin",
+                isAdmin = true,
+            ),
+        )
+        repository = RetrofitTtsRoadRepository(
+            sessionStore = sessionStore,
+            client = authedClient(sessionStore),
+            ioDispatcher = UnconfinedTestDispatcher(),
+            deviceNameProvider = { "test-host" },
+        )
+    }
+
+    @AfterEach
+    fun tearDown() = server.close()
+
+    private fun enqueue(code: Int, body: String) {
+        server.enqueue(MockResponse(code = code, headers = jsonHeaders, body = body))
+    }
+
+    // --- The wire --------------------------------------------------------------------------------
+
+    @Test
+    fun `a search sends the query and the bearer header`() = runTest {
+        enqueue(200, ServerFixtures.SEARCH)
+
+        repository.search("ashfall gate")
+
+        val request = server.takeRequest()
+        assertEquals("GET", request.method)
+        assertEquals("/api/mobile/search?q=ashfall%20gate&limit=20&offset=0", request.url.encodedPath + "?" + request.url.encodedQuery)
+        assertEquals("Bearer ttsr_token", request.headers["Authorization"])
+    }
+
+    @Test
+    fun `an over-long query is bounded before it is sent, not rejected as a 422`() = runTest {
+        enqueue(200, ServerFixtures.SEARCH_EMPTY)
+
+        repository.search("x".repeat(SearchLimits.MaxQueryLength + 50))
+
+        assertEquals(
+            SearchLimits.MaxQueryLength,
+            server.takeRequest().url.queryParameter("q")?.length,
+        )
+    }
+
+    @Test
+    fun `a limit above what the server accepts is clamped rather than 422'd`() = runTest {
+        enqueue(200, ServerFixtures.SEARCH_EMPTY)
+
+        repository.search("gate", limit = 500)
+
+        assertEquals("${SearchLimits.Max}", server.takeRequest().url.queryParameter("limit"))
+    }
+
+    @Test
+    fun `a server without the endpoint answers null rather than throwing`() = runTest {
+        // The distinction the UI depends on: null is "cannot search", an empty response is
+        // "searched, nothing matched", and the two want different words on screen.
+        enqueue(404, ServerFixtures.NOT_FOUND)
+
+        assertNull(repository.search("gate"))
+    }
+
+    @Test
+    fun `a 500 still propagates, because the server can search and simply failed`() = runTest {
+        enqueue(500, """{"detail": "boom"}""")
+
+        assertThrows<HttpException> { repository.search("gate") }
+    }
+
+    // --- The decode ------------------------------------------------------------------------------
+
+    @Test
+    fun `the three groups decode into one hit type`() {
+        val result = ParsedFixtures.search
+
+        assertEquals(3, result.total)
+        assertEquals("fiction", result.fictions.items.single().kind)
+        assertEquals("chapter", result.chapters.items.single().kind)
+        assertEquals("text", result.text.items.single().kind)
+    }
+
+    @Test
+    fun `a fiction hit carries no chapter, and a text hit does`() {
+        val result = ParsedFixtures.search
+
+        assertEquals(0, result.fictions.items.single().resolvedChapterId)
+        assertTrue(!result.fictions.items.single().isChapterHit)
+        assertEquals(103, result.text.items.single().resolvedChapterId)
+        assertTrue(result.text.items.single().isChapterHit)
+    }
+
+    @Test
+    fun `char_offset is decoded but is a text offset, never a position`() {
+        // Kept so the field is not lost, and named here so nobody feeds it to seekTo: it indexes
+        // `clean_text`, and converting it to a timestamp needs the read-along timings.
+        assertEquals(4180, ParsedFixtures.search.text.items.single().charOffset)
+        assertNull(ParsedFixtures.search.chapters.items.single().charOffset)
+    }
+
+    @Test
+    fun `an empty result is still three groups, not a missing key`() {
+        val result = requireNotNull(
+            com.squareup.moshi.Moshi.Builder()
+                .add(com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory())
+                .build()
+                .adapter(SearchResponse::class.java)
+                .fromJson(ServerFixtures.SEARCH_EMPTY),
+        )
+
+        assertTrue(result.isEmpty)
+        assertEquals(0, result.total)
+    }
+
+    // --- Highlight offsets -----------------------------------------------------------------------
+
+    @Test
+    fun `a plain snippet's spans pass straight through`() {
+        val hit = ParsedFixtures.search.text.items.single()
+
+        assertEquals(listOf(SnippetSpan(26, 38)), snippetSpans(hit.snippet, hit.highlights))
+        assertEquals("ashfall gate", hit.snippet.substring(26, 38))
+    }
+
+    @Test
+    fun `an emoji before the match shifts the span, and it is corrected`() {
+        // The server counts code points; Kotlin counts UTF-16 units. Without the conversion the
+        // highlight would land one unit early for every astral character ahead of it — and this is
+        // exactly the payload where "one unit early" becomes "inside a surrogate pair".
+        val snippet = "🔥 the ashfall gate"
+        val codePointStart = snippet.codePointCount(0, snippet.indexOf("ashfall"))
+
+        val spans = snippetSpans(snippet, listOf(listOf(codePointStart, codePointStart + 12)))
+
+        assertEquals("ashfall gate", snippet.substring(spans.single().start, spans.single().end))
+    }
+
+    @Test
+    fun `a span past the end of the snippet is dropped rather than thrown`() {
+        // An out-of-range index is a crash when it reaches an AnnotatedString, so a malformed
+        // payload has to cost one missing highlight, not the whole results list.
+        assertEquals(emptyList(), snippetSpans("short", listOf(listOf(40, 50))))
+    }
+
+    @Test
+    fun `a span running past the end is clamped to it`() {
+        assertEquals(listOf(SnippetSpan(2, 5)), snippetSpans("short", listOf(listOf(2, 900))))
+    }
+
+    @Test
+    fun `inverted, negative and malformed spans are dropped`() {
+        assertEquals(
+            emptyList(),
+            snippetSpans("a snippet", listOf(listOf(5, 2), listOf(-1, 3), listOf(4), emptyList())),
+        )
+    }
+
+    @Test
+    fun `no highlights and an empty snippet are both simply nothing to draw`() {
+        assertEquals(emptyList(), snippetSpans("a snippet", emptyList()))
+        assertEquals(emptyList(), snippetSpans("", listOf(listOf(0, 2))))
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/nav/AppNavigationTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/nav/AppNavigationTest.kt
@@ -171,6 +171,17 @@ class AppNavigationTest {
     }
 
     @Test
+    fun `searching twice from the library reuses one search entry`() {
+        // Search carries no query precisely so this holds: the second search re-runs against the
+        // same destination rather than stacking a second copy whose payload would then be stale.
+        var stack = rootBackStack.navigateTo(Destination.Search).navigateTo(fiction(7))
+
+        stack = stack.navigateTo(Destination.Search)
+
+        assertEquals(listOf(Destination.Library, Destination.Search), stack)
+    }
+
+    @Test
     fun `replacing the top releases the state of the screen it replaced`() {
         val dropped = mutableListOf<String>()
         val nav = NavigationState(onDestinationDropped = { dropped += it.toString() })

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SearchScreenUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SearchScreenUiTest.kt
@@ -1,0 +1,196 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.ParsedFixtures
+import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.SearchGroup
+import dk.perspektiva.ttsroad.desktop.data.SearchHit
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.Dispatchers
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * The search screen, driven by a [FakeRepository] over the real server fixture — no socket.
+ *
+ * Uses the JUnit 4 `createComposeRule()` API and therefore runs through JUnit Vintage; it needs a
+ * display, and CI runs it under Xvfb.
+ */
+class SearchScreenUiTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private fun holder(repository: FakeRepository) = SearchStateHolder(repository, Dispatchers.Main)
+
+    @Test
+    fun `a search renders a row from every group`() {
+        val search = holder(FakeRepository(searchResult = Result.success(ParsedFixtures.search)))
+        compose.setContent {
+            TtsRoadTheme {
+                SearchScreen(search, readAlongAvailable = true, onOpenFiction = {}, onOpenReader = { _, _ -> }, onBack = {})
+            }
+        }
+
+        compose.onNodeWithTag(SearchFieldTestTag).performTextInput("ashfall gate")
+        compose.onNodeWithTag(SearchSubmitTestTag).performClick()
+        compose.waitForIdle()
+
+        assertEquals(3, compose.onAllNodesWithTag(SearchHitTestTag).fetchSemanticsNodes().size)
+        compose.onNodeWithText("The Ashfall Gate").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the search action is dead until something has been typed`() {
+        val search = holder(FakeRepository(searchResult = Result.success(ParsedFixtures.search)))
+        compose.setContent {
+            TtsRoadTheme {
+                SearchScreen(search, readAlongAvailable = true, onOpenFiction = {}, onOpenReader = { _, _ -> }, onBack = {})
+            }
+        }
+
+        compose.onNodeWithTag(SearchSubmitTestTag).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `a text hit opens the reader, where its text actually is`() {
+        val search = holder(FakeRepository(searchResult = Result.success(ParsedFixtures.search)))
+        var openedChapter: Int? = null
+        var openedFiction: Int? = null
+        compose.setContent {
+            TtsRoadTheme {
+                SearchScreen(
+                    search,
+                    readAlongAvailable = true,
+                    onOpenFiction = { openedFiction = it.fictionId },
+                    onOpenReader = { chapterId, _ -> openedChapter = chapterId },
+                    onBack = {},
+                )
+            }
+        }
+        compose.onNodeWithTag(SearchFieldTestTag).performTextInput("ashfall gate")
+        compose.onNodeWithTag(SearchSubmitTestTag).performClick()
+        compose.waitForIdle()
+
+        // Index 2 is the narration-text hit: fiction, then chapter title, then text.
+        compose.onAllNodesWithTag(SearchHitTestTag)[2].performClick()
+
+        assertEquals(103, openedChapter)
+        assertNull(openedFiction)
+    }
+
+    @Test
+    fun `without a reader a chapter hit falls back to the fiction`() {
+        val search = holder(FakeRepository(searchResult = Result.success(ParsedFixtures.search)))
+        var openedChapter: Int? = null
+        var openedFiction: Int? = null
+        compose.setContent {
+            TtsRoadTheme {
+                SearchScreen(
+                    search,
+                    readAlongAvailable = false,
+                    onOpenFiction = { openedFiction = it.fictionId },
+                    onOpenReader = { chapterId, _ -> openedChapter = chapterId },
+                    onBack = {},
+                )
+            }
+        }
+        compose.onNodeWithTag(SearchFieldTestTag).performTextInput("ashfall gate")
+        compose.onNodeWithTag(SearchSubmitTestTag).performClick()
+        compose.waitForIdle()
+
+        compose.onAllNodesWithTag(SearchHitTestTag)[2].performClick()
+
+        assertEquals(7, openedFiction)
+        assertNull(openedChapter)
+    }
+
+    @Test
+    fun `a server that cannot search says so instead of showing no matches`() {
+        val search = holder(FakeRepository(searchResult = Result.success(null)))
+        compose.setContent {
+            TtsRoadTheme {
+                SearchScreen(search, readAlongAvailable = true, onOpenFiction = {}, onOpenReader = { _, _ -> }, onBack = {})
+            }
+        }
+
+        compose.onNodeWithTag(SearchFieldTestTag).performTextInput("gate")
+        compose.onNodeWithTag(SearchSubmitTestTag).performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("THIS SERVER CANNOT SEARCH").assertIsDisplayed()
+    }
+
+    // --- Pure helpers ----------------------------------------------------------------------------
+
+    @Test
+    fun `a group heading says how much of the total is on screen`() {
+        val one = SearchHit(fictionId = 7, fictionTitle = "A Test Serial")
+
+        assertEquals("Chapters — 1", groupTitle("Chapters", SearchGroup(items = listOf(one), total = 1)))
+        assertEquals(
+            "Chapters — 1 shown of 340",
+            groupTitle("Chapters", SearchGroup(items = listOf(one), total = 340)),
+        )
+        assertEquals(
+            "Chapters — 1 shown of 500+",
+            groupTitle("Chapters", SearchGroup(items = listOf(one), total = 500, capped = true)),
+        )
+    }
+
+    @Test
+    fun `a fiction the library already knows is opened with its real summary`() {
+        val known = FictionSummary(id = 7, title = "A Test Serial", totalChapters = 340, doneChapters = 300)
+        val hit = SearchHit(fictionId = 7, fictionTitle = "A Test Serial")
+
+        assertEquals(known, fictionForHit(listOf(known), hit))
+    }
+
+    @Test
+    fun `a fiction the library has not loaded still opens, from what the hit carries`() {
+        val hit = SearchHit(
+            fictionId = 9,
+            fictionTitle = "Unfollowed Serial",
+            author = "Someone",
+            fictionSlug = "unfollowed-serial",
+            tags = listOf("LitRPG"),
+        )
+
+        val summary = fictionForHit(emptyList(), hit)
+
+        assertEquals(9, summary.id)
+        assertEquals("Unfollowed Serial", summary.title)
+        assertEquals("Someone", summary.author)
+        assertEquals(listOf("LitRPG"), summary.tags)
+    }
+
+    @Test
+    fun `a chapter hit headlines the chapter and names the book underneath it`() {
+        val hit = SearchHit(
+            fictionId = 7,
+            fictionTitle = "A Test Serial",
+            chapterId = 102,
+            chapterTitle = "The Ashfall Gate",
+            playable = true,
+        )
+
+        assertEquals("The Ashfall Gate", hitTitle(hit))
+        assertEquals("A Test Serial", hitContext(hit))
+    }
+
+    @Test
+    fun `a chapter found before its audio exists says so rather than looking broken`() {
+        val hit = SearchHit(fictionId = 7, fictionTitle = "A Test Serial", chapterId = 104, chapterTitle = "New", playable = false)
+
+        assertEquals("A Test Serial  ·  No audio yet", hitContext(hit))
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SearchStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SearchStateHolderTest.kt
@@ -1,0 +1,141 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.ParsedFixtures
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * The search state machine.
+ *
+ * Every answer the screen can be in — nothing searched, results, no matches, failed, and "this
+ * server cannot search" — is decided here rather than in the composable.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SearchStateHolderTest {
+
+    private fun holder(repository: FakeRepository) =
+        SearchStateHolder(repository, UnconfinedTestDispatcher())
+
+    @Test
+    fun `nothing is asked of the server until a search is submitted`() = runTest {
+        val repository = FakeRepository(searchResult = Result.success(ParsedFixtures.search))
+        val search = holder(repository)
+
+        search.queryChanged("ashf")
+        search.queryChanged("ashfall")
+
+        assertEquals(emptyList(), repository.searchQueries)
+        assertFalse(search.state.value.hasSearched)
+    }
+
+    @Test
+    fun `a submitted search publishes the results and the query they answer`() = runTest {
+        val repository = FakeRepository(searchResult = Result.success(ParsedFixtures.search))
+        val search = holder(repository)
+
+        search.search("ashfall gate")
+
+        val state = search.state.value
+        assertEquals(listOf("ashfall gate"), repository.searchQueries)
+        assertEquals("ashfall gate", state.resultQuery)
+        assertEquals(3, state.result?.total)
+        assertFalse(state.busy)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `a blank query clears rather than asking the server for everything`() = runTest {
+        val repository = FakeRepository(searchResult = Result.success(ParsedFixtures.search))
+        val search = holder(repository)
+        search.search("gate")
+
+        search.search("   ")
+
+        assertEquals(listOf("gate"), repository.searchQueries)
+        assertNull(search.state.value.result)
+        assertEquals("", search.state.value.resultQuery)
+    }
+
+    @Test
+    fun `a server that answers 404 is unsupported, not an error the user can retry`() = runTest {
+        val repository = FakeRepository(searchResult = Result.success(null))
+        val search = holder(repository)
+
+        search.search("gate")
+
+        assertTrue(search.state.value.unsupported)
+        assertNull(search.state.value.error)
+        assertNull(search.state.value.result)
+    }
+
+    @Test
+    fun `a failed search keeps the results already on screen`() = runTest {
+        // Same rule as a failed library refresh: an error explains less than blanking the screen
+        // destroys, and the previous answer is still the best one available.
+        val repository = FakeRepository(searchResult = Result.success(ParsedFixtures.search))
+        val search = holder(repository)
+        search.search("ashfall gate")
+
+        repository.searchResult = Result.failure(java.io.IOException("connection reset"))
+        search.search("gate")
+
+        assertNotNull(search.state.value.result)
+        assertEquals("ashfall gate", search.state.value.resultQuery)
+        assertNotNull(search.state.value.error)
+        assertFalse(search.state.value.busy)
+    }
+
+    @Test
+    fun `an unsupported answer is cleared by the next successful search`() = runTest {
+        val repository = FakeRepository(searchResult = Result.success(null))
+        val search = holder(repository)
+        search.search("gate")
+
+        repository.searchResult = Result.success(ParsedFixtures.search)
+        search.search("gate")
+
+        assertFalse(search.state.value.unsupported)
+        assertEquals(3, search.state.value.result?.total)
+    }
+
+    @Test
+    fun `refresh re-runs the query the results belong to, not what is in the field`() = runTest {
+        val repository = FakeRepository(searchResult = Result.success(ParsedFixtures.search))
+        val search = holder(repository)
+        search.search("ashfall gate")
+        // The user has started typing a second query but has not submitted it.
+        search.queryChanged("something else")
+
+        search.refresh()
+
+        assertEquals(listOf("ashfall gate", "ashfall gate"), repository.searchQueries)
+    }
+
+    @Test
+    fun `refresh before any search has run does nothing`() = runTest {
+        val repository = FakeRepository(searchResult = Result.success(ParsedFixtures.search))
+
+        holder(repository).refresh()
+
+        assertEquals(emptyList(), repository.searchQueries)
+    }
+
+    @Test
+    fun `signing out drops the results, which belonged to that account`() = runTest {
+        val repository = FakeRepository(searchResult = Result.success(ParsedFixtures.search))
+        val search = holder(repository)
+        search.search("ashfall gate")
+
+        search.sessionEnded()
+
+        assertEquals(SearchUiState(), search.state.value)
+    }
+}


### PR DESCRIPTION
Closes #40. Built against real `master` (`b92a087`, v1.0.2).

## The gap

`LibraryScreen`'s "SEARCH TITLE, AUTHOR OR TAG" field filters the loaded library locally. It cannot match anything not yet fetched, and cannot match chapter text at all. The server has `GET /api/mobile/search` — a per-dialect index over fiction metadata, chapter titles and narration text, results grouped and ranked — advertised as the `search` capability. This client parsed that flag and used it to print the string `"Server search"` in Settings.

## The local filter stays

It is instant, needs no network, and keeps working against a downloaded library with the server unreachable. Removing it would be a regression for a client with a real offline mode.

Server search is a **second, explicit action**, reached from the same field: a button under it, and Enter. Enter escalating rather than re-filtering is the deliberate part — the filter has already applied itself on every keystroke, so "look further than this" is the only remaining meaning for the key. When the local filter finds nothing the row says so, which is exactly the case where the words are in a chapter rather than a title.

Hidden entirely, not disabled, where the `search` capability is false.

## Where a hit goes

- **Fiction** → the fiction detail screen. A fiction the library has not loaded (an unfollowed one, say) still opens: the summary is synthesised from the hit and replaced when the chapter list lands.
- **Chapter title / narration text** → the **reader**, which is where the words it matched are. It does not start playback: `char_offset` is a character offset into `clean_text`, not an audio timestamp, so there is no position to start at, and beginning to play a chapter somebody clicked to read is not what they asked for.
- Without the `readalong` capability there is no reader to open, so both fall back to the fiction.

`char_offset` is decoded and named in a test as *not* a position, so nobody feeds it to `seekTo`. Landing on the matched passage needs the read-along timings and is a separate piece of work.

## The bug worth copying to the other clients

The `highlights` ranges are computed over Python string indices, which count **code points**. Kotlin and JavaScript both index UTF-16 units, so one emoji anywhere ahead of the match shifts every span after it — and an out-of-range span **throws** when it reaches an `AnnotatedString` rather than merely mis-highlighting, which would take out the whole results list.

`snippetSpans` converts rather than trusting, and drops what it cannot place instead of clamping it into the middle of a surrogate pair. Same constraint applies to `jonarihen/TTSRoad-App#67`.

## Three smaller judgement calls

**A 404 is "this server cannot search", not an error.** Same distinction `SettingsStateHolder` already draws for device sessions: one is worth a retry and the other never will be, and they want different words on screen.

**A failed search keeps the results already on screen**, like a failed library refresh — the error explains less than blanking the list destroys.

**`Destination.Search` carries no query.** The query lives in the hoisted holder, so following a hit and coming back finds the results still there, and a second search from the library is not defeated by the pop-back-to-existing rule (which keeps the *older* entry's payload). Query length and limit are bounded client-side so the server's 422 is never reachable.

## Verification

`./gradlew --no-daemon check --warning-mode fail -Pttsroad.warningsAsErrors=true` passes, with 38 new tests: the wire against MockWebServer, the decode against a new fixture carrying the real three-group payload, the code-point conversion including the emoji case, every state of the holder, and the screen itself under the Compose rule.

Not exercised against a live TTSRoad server — there is no instance in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)