### PR TITLE
Follow / unfollow, and a browse-all library scope

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -328,6 +328,9 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                         search.search(query)
                                         nav.open(Destination.Search)
                                     },
+                                    // On a server without per-user libraries there is no shelf to
+                                    // distinguish from the catalogue, so there is no mode to pick.
+                                    followsAvailable = capabilities.follows,
                                 )
 
                                 Destination.Search -> SearchScreen(

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryCache.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryCache.kt
@@ -56,6 +56,18 @@ class LibraryCache(
     val library: StateFlow<Cached<LibraryResponse>> = _library.asStateFlow()
     private var libraryJob: Job? = null
 
+    /**
+     * The whole server, for finding something to follow.
+     *
+     * A second state rather than a scope on [library], and deliberately **never written to disk**:
+     * the offline namespace holds what this account chose to keep, and a catalogue of everything
+     * the server happens to host is not that. It is also why switching between the two costs no
+     * request the second time — each keeps its own answer.
+     */
+    private val _browseAll = MutableStateFlow(Cached<LibraryResponse>())
+    val browseAll: StateFlow<Cached<LibraryResponse>> = _browseAll.asStateFlow()
+    private var browseAllJob: Job? = null
+
     private val chapterStates = LinkedHashMap<Int, MutableStateFlow<Cached<ChaptersResponse>>>()
     private val chapterJobs = HashMap<Int, Job>()
     private val chapterOptions = LinkedHashMap<Int, MutableStateFlow<ChapterListOptions>>()
@@ -85,6 +97,71 @@ class LibraryCache(
             ) { repository.library() }
         }
     }
+
+    // --- Browse all --------------------------------------------------------------------------
+
+    /** Opening browse-all. Same coalescing rule as [ensureLibrary]; no disk priming. */
+    fun ensureBrowseAll() {
+        if (_browseAll.value.hasContent || browseAllJob?.isActive == true) return
+        refreshBrowseAll()
+    }
+
+    fun refreshBrowseAll() {
+        browseAllJob?.cancel()
+        _browseAll.update { it.copy(isRefreshing = true, error = null) }
+        browseAllJob = scope.launch {
+            load(state = _browseAll, fallback = "Could not load the server's fictions") {
+                repository.library(LibraryScope.All)
+            }
+        }
+    }
+
+    /**
+     * Follows or unfollows [fictionId], answering the state the **server** now holds.
+     *
+     * Not optimistic, and that is the point: the shelf is a list whose membership changes, so a
+     * guessed answer would have to add or remove a row — and undo it on failure — rather than flip
+     * a flag in place. One request, then the flag is patched from what came back and the shelf is
+     * re-asked, because following something also changes what "Continue listening" contains.
+     *
+     * Null means the server answered 404: no such fiction, or no such endpoint. Neither did
+     * anything, so neither may render as success.
+     */
+    suspend fun setFollowing(fictionId: Int, following: Boolean): Boolean? {
+        val confirmed = repository.setFollowing(fictionId, following) ?: return null
+        patchFollowing(fictionId, confirmed)
+        // Membership changed, so the shelf is a different list now — a flag patch cannot express
+        // a row appearing or disappearing.
+        refreshLibrary()
+        return confirmed
+    }
+
+    /** Patches the flag on both lists without a request. Public so a test can pin the rule. */
+    fun patchFollowing(fictionId: Int, following: Boolean) {
+        listOf(_library, _browseAll).forEach { state ->
+            state.update { cached ->
+                val library = cached.value ?: return@update cached
+                cached.copy(
+                    value = library.copy(
+                        fictions = library.fictions.map { fiction ->
+                            if (fiction.id == fictionId) fiction.copy(following = following) else fiction
+                        },
+                    ),
+                )
+            }
+        }
+    }
+
+    /**
+     * What this client believes about [fictionId]'s follow state, or null when nothing says.
+     *
+     * Reads the two library payloads and never the chapters one, which does not carry the key —
+     * see [FictionSummary.following].
+     */
+    fun followingOf(fictionId: Int): Boolean? =
+        (_library.value.value?.fictions.orEmpty() + _browseAll.value.value?.fictions.orEmpty())
+            .firstOrNull { it.id == fictionId }
+            ?.following
 
     // --- Chapters --------------------------------------------------------------------------
 
@@ -247,11 +324,14 @@ class LibraryCache(
     fun clear() {
         libraryJob?.cancel()
         libraryJob = null
+        browseAllJob?.cancel()
+        browseAllJob = null
         chapterJobs.values.forEach(Job::cancel)
         chapterJobs.clear()
         chapterStates.clear()
         chapterOptions.clear()
         _library.value = Cached()
+        _browseAll.value = Cached()
     }
 
     override fun close() {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
@@ -45,9 +45,41 @@ data class ServerInfo(
 
 data class LibraryResponse(
     @param:Json(name = "api_version") val apiVersion: Int = 1,
+    /**
+     * Which list this is: `followed` (the caller's shelf, and the default) or `all` (the whole
+     * server). Echoed by the server so a client can tell that the scope it asked for is the scope
+     * it got — an older server ignores the parameter and answers `followed` shaped content with no
+     * `scope` key at all.
+     */
+    val scope: String? = null,
     val fictions: List<FictionSummary> = emptyList(),
     @param:Json(name = "continue_listening") val continueListening: List<ChapterSummary> = emptyList(),
     @param:Json(name = "recent_chapters") val recentChapters: List<ChapterSummary> = emptyList(),
+)
+
+/**
+ * The two answers to "which fictions".
+ *
+ * `followed` is what a client that has never heard of follows gets, and it is safe because the
+ * server backfills a follow of every fiction for every existing account on upgrade.
+ */
+enum class LibraryScope(val wireValue: String) {
+    Followed("followed"),
+    All("all"),
+}
+
+/** `POST`/`DELETE /api/mobile/fictions/{id}/follow`. */
+data class FollowResponse(
+    val status: String = "",
+    @param:Json(name = "fiction_id") val fictionId: Int = 0,
+    /**
+     * The state the server now holds — **not** the state that was asked for.
+     *
+     * Read rather than assumed, so a request that did not do what it looked like cannot render as
+     * success. `created`/`removed` say whether anything actually changed and are deliberately not
+     * modelled: following something already followed is a no-op, not a failure.
+     */
+    val following: Boolean = false,
 )
 
 data class ChaptersResponse(
@@ -72,6 +104,16 @@ data class FictionSummary(
     @param:Json(name = "pending_chapters") val pendingChapters: Int = 0,
     @param:Json(name = "error_chapters") val errorChapters: Int = 0,
     @param:Json(name = "processing_chapters") val processingChapters: Int = 0,
+    /**
+     * Whether this account has the fiction on its shelf, or **null when the payload does not say**.
+     *
+     * Nullable rather than defaulted-false, because the difference is a real trap: only
+     * `/api/mobile/library` adds this key. `/api/mobile/fictions/{id}/chapters` builds its `fiction`
+     * with `_fiction_payload()`, which does not — so a detail screen that re-read follow state from
+     * its own chapters response would flip every followed book to "unfollowed" the moment the
+     * chapters arrived. Null means *ask someone else*, and false would have meant "not followed".
+     */
+    val following: Boolean? = null,
 ) {
     val readyFraction: Float
         get() = if (totalChapters > 0) (doneChapters.toFloat() / totalChapters).coerceIn(0f, 1f) else 0f

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -106,7 +106,16 @@ interface TtsRoadRepository {
      */
     suspend fun endSession(end: SessionEnd)
 
-    suspend fun library(): LibraryResponse
+    suspend fun library(scope: LibraryScope = LibraryScope.Followed): LibraryResponse
+
+    /**
+     * Follows or unfollows a fiction, answering the state **the server now holds**, or null when it
+     * answered 404.
+     *
+     * The 404 is genuinely ambiguous — no such fiction, or no such endpoint — and both mean the
+     * same thing to the caller: the toggle did not happen and must not render as though it did.
+     */
+    suspend fun setFollowing(fictionId: Int, following: Boolean): Boolean?
 
     /**
      * The signed-in account as the server sees it now, or null when the server has no `/me`.
@@ -361,7 +370,14 @@ class RetrofitTtsRoadRepository(
         synchronized(capabilityCache) { capabilityCache.remove(normalized) }
     }
 
-    override suspend fun library(): LibraryResponse = withAuthorizedApi { it.library() }
+    override suspend fun library(scope: LibraryScope): LibraryResponse =
+        withAuthorizedApi { it.library(scope.wireValue) }
+
+    override suspend fun setFollowing(fictionId: Int, following: Boolean): Boolean? =
+        ifEndpointExists {
+            // The answer is read, never assumed: a response is the only proof the shelf changed.
+            if (following) it.follow(fictionId).following else it.unfollow(fictionId).following
+        }
 
     override suspend fun currentUser(): MobileUser? = ifEndpointExists { it.me() }?.user
 

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
@@ -43,6 +43,14 @@ data class ServerCapabilities(
     val deltaSync: Boolean = false,
     val batchProgress: Boolean = false,
     val audioContentHash: Boolean = false,
+    /**
+     * Per-user libraries.
+     *
+     * False means `/api/mobile/library` is still the whole shared list on that server, so this
+     * client must not offer a follow control it cannot honour — the capability comment in
+     * `app/routers/platform.py` states exactly that consequence.
+     */
+    val follows: Boolean = false,
     val deviceManagement: Boolean = false,
     val maxChaptersPerPage: Int? = null,
     /**
@@ -72,6 +80,7 @@ data class ServerCapabilities(
             deltaSync = response.capabilities.flag("delta_sync"),
             batchProgress = response.capabilities.flag("batch_progress"),
             audioContentHash = response.capabilities.flag("audio_content_hash"),
+            follows = response.capabilities.flag("follows"),
             deviceManagement = response.capabilities.flag("device_management"),
             maxChaptersPerPage = response.limits.intLimit("max_chapters_per_page"),
             maxPlaybackSyncItems = response.limits.intLimit("max_playback_sync_items"),

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -60,8 +60,22 @@ interface TtsRoadApi {
     @POST("api/mobile/devices/revoke-others")
     suspend fun revokeOtherDevices()
 
+    /**
+     * The caller's shelf, or the whole server with `scope=all`.
+     *
+     * The parameter is always sent — an older server simply ignores an unknown query parameter and
+     * answers the shared list it always did, which is what makes browse-all safe to ask for.
+     */
     @GET("api/mobile/library")
-    suspend fun library(): LibraryResponse
+    suspend fun library(@Query("scope") scope: String = LibraryScope.Followed.wireValue): LibraryResponse
+
+    /** Puts a fiction on this account's shelf. 404 for a fiction that does not exist. */
+    @POST("api/mobile/fictions/{fiction_id}/follow")
+    suspend fun follow(@Path("fiction_id") fictionId: Int): FollowResponse
+
+    /** Takes it off. The fiction stays on the server and stays reachable through `scope=all`. */
+    @DELETE("api/mobile/fictions/{fiction_id}/follow")
+    suspend fun unfollow(@Path("fiction_id") fictionId: Int): FollowResponse
 
     /**
      * Library-wide search across fiction metadata, chapter titles and narration text.

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionDetailScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionDetailScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.Download
@@ -197,6 +199,34 @@ fun FictionDetailScreen(
     val playingChapterId = player.playingChapterIdIn(fiction.id)
     val currentRow = remember(visible, playingChapterId) { visible.indexOfChapter(playingChapterId) }
 
+    // Seeded from the library summary and mutated only by the toggle. Deliberately *not* re-read
+    // from `loaded.fiction`: the chapters endpoint builds its fiction payload without a `following`
+    // key at all, so a screen that trusted it would flip every followed book to "unfollowed" the
+    // moment its chapters arrived. See [FictionSummary.following].
+    var followOverride by remember(fiction.id) { mutableStateOf<Boolean?>(null) }
+    var followBusy by remember(fiction.id) { mutableStateOf(false) }
+    val following = followOverride ?: fiction.following ?: cache.followingOf(fiction.id)
+
+    fun toggleFollow() {
+        val target = !(following ?: false)
+        followBusy = true
+        actionError = null
+        scope.launch {
+            runCatching { cache.setFollowing(fiction.id, target) }
+                .onSuccess { confirmed ->
+                    // Null is the server's 404 — no such fiction, or no such endpoint. Nothing
+                    // changed, so nothing may render as though it had.
+                    if (confirmed == null) {
+                        actionError = "The server does not have this fiction any more"
+                    } else {
+                        followOverride = confirmed
+                    }
+                }
+                .onFailure { actionError = userFacingMessage(it, "Could not update your shelf") }
+            followBusy = false
+        }
+    }
+
     fun mark(ids: List<Int>, played: Boolean) {
         if (ids.isEmpty()) return
         actionError = null
@@ -261,7 +291,19 @@ fun FictionDetailScreen(
                     }
 
                     // `resumeTarget` is null until chapters load, so the button appears with the list.
-                    FictionHeader(header, repository, chapters = chapters, onResume = ::play)
+                    FictionHeader(
+                        header,
+                        repository,
+                        chapters = chapters,
+                        onResume = ::play,
+                        // Absent, not disabled, on a server whose library is still the whole shared
+                        // list: there is no shelf there to add anything to.
+                        follow = if (capabilities.follows) {
+                            FollowUi(following = following ?: false, busy = followBusy, onToggle = ::toggleFollow)
+                        } else {
+                            null
+                        },
+                    )
 
                     actionError?.let { message ->
                         Spacer(Modifier.height(12.dp))
@@ -503,12 +545,18 @@ private fun resumeTarget(chapters: List<ChapterSummary>): ChapterSummary? =
         ?: chapters.firstOrNull { it.hasAudio && !it.isPlayed }
         ?: chapters.firstOrNull { it.hasAudio }
 
+/** The follow control's whole state, or null where the server has no per-user library. */
+data class FollowUi(val following: Boolean, val busy: Boolean, val onToggle: () -> Unit)
+
+const val FollowToggleTestTag: String = "followToggle"
+
 @Composable
 private fun FictionHeader(
     fiction: FictionSummary,
     repository: TtsRoadRepository,
     chapters: List<ChapterSummary>,
     onResume: (ChapterSummary) -> Unit,
+    follow: FollowUi? = null,
 ) {
     Row(Modifier.fillMaxWidth()) {
         CoverImage(
@@ -578,19 +626,55 @@ private fun FictionHeader(
                 MetaText(listeningTotalsLabel(totals), color = AarisColor.Muted)
             }
             val target = remember(chapters) { resumeTarget(chapters) }
-            if (target != null) {
+            if (target != null || follow != null) {
                 Spacer(Modifier.height(16.dp))
-                Button(
-                    onClick = { onResume(target) },
-                    shape = RectangleShape,
-                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                ) {
-                    Icon(Icons.Default.PlayArrow, contentDescription = null, Modifier.size(18.dp))
-                    Spacer(Modifier.width(8.dp))
-                    Text(if (target.resolvedPositionSeconds > 0.0) "RESUME" else "START LISTENING")
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
+                    if (target != null) {
+                        Button(
+                            onClick = { onResume(target) },
+                            shape = RectangleShape,
+                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                        ) {
+                            Icon(Icons.Default.PlayArrow, contentDescription = null, Modifier.size(18.dp))
+                            Spacer(Modifier.width(8.dp))
+                            Text(if (target.resolvedPositionSeconds > 0.0) "RESUME" else "START LISTENING")
+                        }
+                    }
+                    follow?.let { FollowButton(it) }
                 }
             }
         }
+    }
+}
+
+/**
+ * Add to, or take off, this account's shelf.
+ *
+ * Labelled for the state it is *in* rather than the action it performs — "Following" with a filled
+ * bookmark, "Follow" with an outline — because the row above it is a description of the fiction,
+ * and a control there that reads as an instruction is ambiguous about which of the two it is
+ * saying. The content description carries the action for a screen reader.
+ */
+@Composable
+private fun FollowButton(follow: FollowUi) {
+    OutlinedButton(
+        onClick = follow.onToggle,
+        enabled = !follow.busy,
+        shape = RectangleShape,
+        modifier = Modifier
+            .pointerHoverIcon(PointerIcon.Hand)
+            .testTag(FollowToggleTestTag)
+            .semantics {
+                contentDescription = if (follow.following) "Unfollow this fiction" else "Follow this fiction"
+            },
+    ) {
+        Icon(
+            if (follow.following) Icons.Default.Bookmark else Icons.Default.BookmarkBorder,
+            contentDescription = null,
+            Modifier.size(18.dp),
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(if (follow.following) "FOLLOWING" else "FOLLOW")
     }
 }
 

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/LibraryScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/LibraryScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.itemsIndexed as itemsIndexedInRow
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -63,6 +64,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
@@ -116,6 +118,13 @@ fun LibraryScreen(
     serverSearchAvailable: Boolean = false,
     onSearchServer: (String) -> Unit = {},
     /**
+     * Whether the signed-in server advertises the `follows` capability.
+     *
+     * False means `/api/mobile/library` is still the whole shared list there, so there is no shelf
+     * to distinguish from a catalogue and the mode switch is absent entirely.
+     */
+    followsAvailable: Boolean = false,
+    /**
      * Local listening history, for the "Jump back in" strip. Defaulted to an in-memory store so a
      * screen test never reads or writes the real config directory.
      */
@@ -128,7 +137,15 @@ fun LibraryScreen(
     nowMillis: () -> Long = System::currentTimeMillis,
 ) {
     val scope = rememberCoroutineScope()
-    val state by cache.library.collectAsState()
+    // Retained per destination, so walking into a fiction from browse-all and back lands where the
+    // user left rather than snapping to the shelf.
+    var browsing by rememberSaveable { mutableStateOf(false) }
+    // Browse-all is unreachable on a server without follows, and staying in it after a downgrade
+    // would leave the user in a mode the server no longer honours.
+    val browseAll = browsing && followsAvailable
+    val shelf by cache.library.collectAsState()
+    val everything by cache.browseAll.collectAsState()
+    val state = if (browseAll) everything else shelf
     val snapshots by history.history.collectAsState()
     val jumpBack = remember(snapshots, historyOwnerKey) {
         PlaybackHistory.jumpBackChoices(snapshots, historyOwnerKey)
@@ -136,6 +153,9 @@ fun LibraryScreen(
     // Keyless on purpose: fires once per screen *appearance*, not per recomposition. Reuses cached
     // content and coalesces with a load already in flight, so Back into the library costs nothing.
     LaunchedEffect(Unit) { cache.ensureLibrary() }
+    // Keyed, because switching modes is what makes browse-all worth fetching at all; it coalesces
+    // the same way, so flipping back and forth costs one request each.
+    LaunchedEffect(browseAll) { if (browseAll) cache.ensureBrowseAll() }
 
     // Hoisted out of the lazy content on purpose: an item that scrolls off is disposed, and the
     // search text must not be one of the things that disposal takes with it. `rememberSaveable`
@@ -143,13 +163,21 @@ fun LibraryScreen(
     var query by rememberSaveable { mutableStateOf("") }
     val gridState = rememberLazyGridState()
 
+    // The rails — hero, jump-back, recent — always come from the shelf, in both modes. The server
+    // derives them from the followed set either way ("browse-all widens the catalogue, not what the
+    // app thinks you are in the middle of"), and reading them from the mode being browsed would
+    // blank them while browse-all is still loading.
+    val rails = shelf.value
     val library = state.value
     val error = state.error
+    fun refreshCurrent() = if (browseAll) cache.refreshBrowseAll() else cache.refreshLibrary()
     when {
-        library == null && error != null -> InitialErrorState(error) { cache.refreshLibrary() }
-        library == null -> CenterProgress()
+        rails == null && shelf.error != null -> InitialErrorState(shelf.error.orEmpty()) { cache.refreshLibrary() }
+        rails == null -> CenterProgress()
         else -> {
-            val filtered = remember(library.fictions, query) { filterFictions(library.fictions, query) }
+            val filtered = remember(library?.fictions, query) {
+                filterFictions(library?.fictions.orEmpty(), query)
+            }
             val keys = remember(filtered) { fictionKeys(filtered) }
             Box(Modifier.fillMaxSize()) {
                 LazyVerticalGrid(
@@ -171,12 +199,12 @@ fun LibraryScreen(
                                 message = error.orEmpty(),
                                 lastSuccessMillis = state.lastSuccessMillis,
                                 nowMillis = nowMillis(),
-                                onRetry = { cache.refreshLibrary() },
+                                onRetry = { refreshCurrent() },
                             )
                         }
                     }
 
-                    val continueList = library.continueListening
+                    val continueList = rails.continueListening
                     if (continueList.isNotEmpty()) {
                         val hero = continueList.first()
                         fullWidthItem("hero") {
@@ -210,7 +238,7 @@ fun LibraryScreen(
                                 JumpBackShelf(
                                     snapshots = jumpBack,
                                     onOpen = { snapshot ->
-                                        library.fictions.firstOrNull { it.id == snapshot.fictionId }
+                                        rails.fictions.firstOrNull { it.id == snapshot.fictionId }
                                             ?.let(onOpenFiction)
                                     },
                                     onDismiss = { history.dismiss(it.key) },
@@ -221,9 +249,13 @@ fun LibraryScreen(
 
                     fullWidthItem("fictions-header") {
                         Column {
-                            SectionTitle("03", "Fictions")
+                            SectionTitle("03", if (browseAll) "Every fiction" else "Fictions")
                             Spacer(Modifier.height(16.dp))
-                            if (library.fictions.isNotEmpty()) {
+                            if (followsAvailable) {
+                                LibraryScopeTabs(browseAll) { browsing = it }
+                                Spacer(Modifier.height(14.dp))
+                            }
+                            if (library != null && library.fictions.isNotEmpty()) {
                                 OutlinedTextField(
                                     value = query,
                                     onValueChange = { query = it },
@@ -253,11 +285,32 @@ fun LibraryScreen(
                     }
 
                     when {
+                        // Only the grid waits, never the rails above it: switching to browse-all
+                        // must not take the hero off screen while one request runs.
+                        library == null && error != null -> fullWidthItem("grid-error") {
+                            Box(Modifier.fillMaxWidth().height(160.dp), contentAlignment = Alignment.Center) {
+                                InlineRetry(error, ::refreshCurrent)
+                            }
+                        }
+
+                        library == null -> fullWidthItem("grid-loading") {
+                            Box(Modifier.fillMaxWidth().height(160.dp), contentAlignment = Alignment.Center) {
+                                CenterProgress()
+                            }
+                        }
+
                         library.fictions.isEmpty() -> fullWidthItem("no-fictions") {
-                            EmptyState(
-                                "Nothing here yet",
-                                "Add a fiction on the server and it will show up here.",
-                            )
+                            if (browseAll) {
+                                EmptyState(
+                                    "The server has no fictions",
+                                    "Add one on the server and it will show up here.",
+                                )
+                            } else {
+                                EmptyState(
+                                    "Your shelf is empty",
+                                    "Switch to Everything to find something to follow.",
+                                )
+                            }
                         }
 
                         filtered.isEmpty() -> fullWidthItem("no-matches") {
@@ -275,13 +328,13 @@ fun LibraryScreen(
                         }
                     }
 
-                    if (library.recentChapters.isNotEmpty()) {
+                    if (rails.recentChapters.isNotEmpty()) {
                         fullWidthItem("recent") {
                             Column {
                                 Spacer(Modifier.height(20.dp))
                                 SectionTitle("04", "Recent")
                                 Spacer(Modifier.height(16.dp))
-                                ContinueShelf(library.recentChapters, repository) { chapter ->
+                                ContinueShelf(rails.recentChapters, repository) { chapter ->
                                     scope.launch { playback.play(chapter, chapter.fiction) }
                                 }
                             }
@@ -396,6 +449,62 @@ private fun SearchServerAction(query: String, matches: Int, onSearch: () -> Unit
             Spacer(Modifier.width(12.dp))
             MetaText("Nothing here matches — the server may still find it", color = AarisColor.Dim)
         }
+    }
+}
+
+const val LibraryScopeTabTestTag: String = "libraryScopeTab"
+
+/**
+ * Shelf or catalogue.
+ *
+ * `selectable` tabs rather than a toggle, for the same reason the chapter filter uses them: a tab
+ * announces its selected state and can be reached in one Tab stop, where a button that relabels
+ * itself announces the state you would move *to*.
+ */
+@Composable
+private fun LibraryScopeTabs(browseAll: Boolean, onSelect: (Boolean) -> Unit) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+        ScopeTab("My shelf", selected = !browseAll) { onSelect(false) }
+        ScopeTab("Everything", selected = browseAll) { onSelect(true) }
+    }
+}
+
+@Composable
+private fun ScopeTab(label: String, selected: Boolean, onSelect: () -> Unit) {
+    val interaction = remember { MutableInteractionSource() }
+    val focused by interaction.collectIsFocusedAsState()
+    Box(
+        Modifier
+            .selectable(
+                selected = selected,
+                interactionSource = interaction,
+                indication = null,
+                role = Role.Tab,
+                onClick = onSelect,
+            )
+            .pointerHoverIcon(PointerIcon.Hand)
+            .background(if (selected) AarisColor.BgHover else Color.Transparent)
+            .border(1.dp, if (focused) AarisColor.Accent else Color.Transparent)
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+            .testTag(LibraryScopeTabTestTag),
+    ) {
+        MetaText(label, color = if (selected) AarisColor.Accent else AarisColor.Muted)
+    }
+}
+
+/** A failure that took out one section rather than the screen. Always carries its own retry. */
+@Composable
+private fun InlineRetry(message: String, onRetry: () -> Unit) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text(message, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.error)
+        OutlinedButton(
+            onClick = onRetry,
+            shape = RectangleShape,
+            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+        ) { Text("RETRY") }
     }
 }
 

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -41,6 +41,10 @@ open class FakeRepository(
         Result.success(null),
     /** `success(null)` is the server saying it cannot search — not "nothing matched". */
     var searchResult: Result<dk.perspektiva.ttsroad.desktop.data.SearchResponse?> = Result.success(null),
+    /** What `scope=all` answers. Defaults to the same payload the shelf gives. */
+    var browseAllResult: Result<LibraryResponse> = Result.success(LibraryResponse()),
+    /** Null means "echo what was asked". `success(null)` is the server's 404. */
+    var followResult: Result<Boolean?>? = null,
 ) : TtsRoadRepository {
     var loginCalls: Int = 0
         private set
@@ -69,6 +73,12 @@ open class FakeRepository(
     val capabilityProbes: MutableList<String> = mutableListOf()
     /** Queries the server was actually asked, in order — trimming and debouncing are observable. */
     val searchQueries: MutableList<String> = mutableListOf()
+
+    /** Scopes the library was asked for, in order — browse-all is a different request. */
+    val libraryScopes: MutableList<dk.perspektiva.ttsroad.desktop.data.LibraryScope> = mutableListOf()
+
+    /** `(fictionId, following)` pairs passed to [setFollowing], in order. */
+    val followCalls: MutableList<Pair<Int, Boolean>> = mutableListOf()
     val markedPlayed: MutableList<Pair<List<Int>, Boolean>> = mutableListOf()
     val savedProgress: MutableList<Triple<Int, Double, Boolean>> = mutableListOf()
 
@@ -109,9 +119,22 @@ open class FakeRepository(
         logoutCalls++
     }
 
-    override suspend fun library(): LibraryResponse {
+    override suspend fun library(
+        scope: dk.perspektiva.ttsroad.desktop.data.LibraryScope,
+    ): LibraryResponse {
         libraryCalls++
-        return libraryResult.getOrThrow()
+        libraryScopes += scope
+        return (if (scope == dk.perspektiva.ttsroad.desktop.data.LibraryScope.All) browseAllResult else libraryResult)
+            .getOrThrow()
+    }
+
+    override suspend fun setFollowing(fictionId: Int, following: Boolean): Boolean? {
+        followCalls += fictionId to following
+        // An *unset* `followResult` echoes what was asked, which is what a healthy server does.
+        // A set one is used as-is, null included — `success(null)` is the server's 404 and must not
+        // fall through to the echo.
+        val configured = followResult ?: return following
+        return configured.getOrThrow()
     }
 
     override suspend fun currentUser(): MobileUser? = currentUserResult.getOrThrow()

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ServerFixtures.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ServerFixtures.kt
@@ -575,6 +575,83 @@ object ServerFixtures {
           "text": {"items": [], "total": 0, "capped": false, "has_more": false}
         }
     """.trimIndent()
+
+    /** A server with per-user libraries. Only `follows` differs from [CAPABILITIES_1_4_0]. */
+    val CAPABILITIES_WITH_FOLLOWS = """
+        {
+          "api_version": 1,
+          "server": {"name": "Perspektiva TTSRoad", "version": "1.5.0", "base_url": "https://ttsroad.example.com"},
+          "capabilities": {
+            "readalong": true,
+            "follows": true,
+            "device_management": true
+          },
+          "limits": {"max_chapters_per_page": 200}
+        }
+    """.trimIndent()
+
+    /**
+     * GET /api/mobile/library?scope=all — 200, on a server with per-user libraries.
+     *
+     * Two fictions, one followed and one not, plus the `scope` echo and the `following_ids` list.
+     * The shelf payload has exactly the same shape with the unfollowed row absent.
+     */
+    val LIBRARY_BROWSE_ALL = """
+        {
+          "api_version": 1,
+          "generated_at": "2026-08-11T09:12:33.123456Z",
+          "scope": "all",
+          "server_time": "2026-08-11T09:12:33.123456Z",
+          "updated_since": null,
+          "delta": false,
+          "user": {"id": 1, "username": "admin", "is_admin": true},
+          "server": {"name": "Perspektiva TTSRoad", "version": "1.5.0", "base_url": "https://ttsroad.example.com"},
+          "fictions": [
+            {
+              "id": 7,
+              "title": "A Test Serial",
+              "author": "Someone",
+              "slug": "a-test-serial",
+              "cover_image_url": "https://cdn.royalroadcdn.com/covers/12345.jpg",
+              "tags": ["LitRPG"],
+              "total_chapters": 10,
+              "done_chapters": 6,
+              "pending_chapters": 2,
+              "error_chapters": 1,
+              "processing_chapters": 1,
+              "following": true
+            },
+            {
+              "id": 9,
+              "title": "Someone Else's Serial",
+              "author": "Another",
+              "slug": "someone-elses-serial",
+              "cover_image_url": null,
+              "tags": [],
+              "total_chapters": 4,
+              "done_chapters": 4,
+              "pending_chapters": 0,
+              "error_chapters": 0,
+              "processing_chapters": 0,
+              "following": false
+            }
+          ],
+          "following_ids": [7],
+          "deleted": [],
+          "continue_listening": [],
+          "recent_chapters": []
+        }
+    """.trimIndent()
+
+    /** POST /api/mobile/fictions/{id}/follow — 200. */
+    val FOLLOWED = """
+        {"api_version": 1, "status": "ok", "fiction_id": 7, "following": true, "created": true}
+    """.trimIndent()
+
+    /** DELETE /api/mobile/fictions/{id}/follow — 200. */
+    val UNFOLLOWED = """
+        {"api_version": 1, "status": "ok", "fiction_id": 7, "following": false, "removed": true}
+    """.trimIndent()
 }
 
 /**

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/FollowTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/FollowTest.kt
@@ -1,0 +1,187 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import dk.perspektiva.ttsroad.desktop.ServerFixtures
+import dk.perspektiva.ttsroad.desktop.authedClient
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.Headers
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import retrofit2.HttpException
+
+/** Per-user libraries: the two follow routes, the `scope` parameter, and the `following` key. */
+@OptIn(ExperimentalCoroutinesApi::class)
+class FollowTest {
+    private lateinit var server: MockWebServer
+    private lateinit var repository: RetrofitTtsRoadRepository
+
+    private val jsonHeaders = Headers.headersOf("Content-Type", "application/json")
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        val sessionStore = InMemorySessionStore(
+            SessionState(
+                serverUrl = server.url("/").toString(),
+                token = "ttsr_token",
+                username = "admin",
+                isAdmin = true,
+            ),
+        )
+        repository = RetrofitTtsRoadRepository(
+            sessionStore = sessionStore,
+            client = authedClient(sessionStore),
+            ioDispatcher = UnconfinedTestDispatcher(),
+            deviceNameProvider = { "test-host" },
+        )
+    }
+
+    @AfterEach
+    fun tearDown() = server.close()
+
+    private fun enqueue(code: Int, body: String) {
+        server.enqueue(MockResponse(code = code, headers = jsonHeaders, body = body))
+    }
+
+    // --- The scope parameter ----------------------------------------------------------------------
+
+    @Test
+    fun `the shelf is what the library asks for by default`() = runTest {
+        enqueue(200, ServerFixtures.LIBRARY)
+
+        repository.library()
+
+        assertEquals("followed", server.takeRequest().url.queryParameter("scope"))
+    }
+
+    @Test
+    fun `browse-all asks for the whole server`() = runTest {
+        enqueue(200, ServerFixtures.LIBRARY_BROWSE_ALL)
+
+        val response = repository.library(LibraryScope.All)
+
+        assertEquals("all", server.takeRequest().url.queryParameter("scope"))
+        assertEquals("all", response.scope)
+        assertEquals(2, response.fictions.size)
+    }
+
+    @Test
+    fun `an older server that ignores the parameter still decodes, with no scope`() = runTest {
+        // The 1.4.0 payload has no `scope` and no `following`. Sending the parameter is safe
+        // precisely because an unknown query parameter is ignored rather than rejected.
+        enqueue(200, ServerFixtures.LIBRARY)
+
+        val response = repository.library(LibraryScope.All)
+
+        assertNull(response.scope)
+        assertNull(response.fictions.single().following)
+    }
+
+    // --- The following key ------------------------------------------------------------------------
+
+    @Test
+    fun `the library says which fictions are on the shelf`() = runTest {
+        enqueue(200, ServerFixtures.LIBRARY_BROWSE_ALL)
+
+        val fictions = repository.library(LibraryScope.All).fictions
+
+        assertEquals(true, fictions.first { it.id == 7 }.following)
+        assertEquals(false, fictions.first { it.id == 9 }.following)
+    }
+
+    @Test
+    fun `the chapters endpoint says nothing about follow state, and null is how that reads`() = runTest {
+        // The trap: `_fiction_payload()` has no `following` key, so a screen that re-read follow
+        // state from its own chapters response would unfollow every book on screen. Null is the
+        // modelling that makes "this payload does not say" impossible to confuse with "not
+        // followed".
+        enqueue(200, ServerFixtures.CHAPTERS)
+
+        assertNull(repository.chapters(fictionId = 7).fiction.following)
+    }
+
+    // --- The two routes ---------------------------------------------------------------------------
+
+    @Test
+    fun `following posts to the follow path and reports what the server now holds`() = runTest {
+        enqueue(200, ServerFixtures.FOLLOWED)
+
+        assertEquals(true, repository.setFollowing(7, following = true))
+
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/api/mobile/fictions/7/follow", request.url.encodedPath)
+        assertEquals("Bearer ttsr_token", request.headers["Authorization"])
+    }
+
+    @Test
+    fun `unfollowing deletes on the same path`() = runTest {
+        enqueue(200, ServerFixtures.UNFOLLOWED)
+
+        assertEquals(false, repository.setFollowing(7, following = false))
+
+        val request = server.takeRequest()
+        assertEquals("DELETE", request.method)
+        assertEquals("/api/mobile/fictions/7/follow", request.url.encodedPath)
+    }
+
+    @Test
+    fun `the server's answer is read, not the request that was made`() = runTest {
+        // A follow that came back saying "not following" must render as not following. Assuming
+        // success is how a toggle ends up disagreeing with the shelf it just changed.
+        enqueue(200, ServerFixtures.UNFOLLOWED)
+
+        assertFalse(repository.setFollowing(7, following = true) == true)
+    }
+
+    @Test
+    fun `a fiction that no longer exists answers null rather than success`() = runTest {
+        enqueue(404, """{"detail": "Fiction not found"}""")
+
+        assertNull(repository.setFollowing(999, following = true))
+    }
+
+    @Test
+    fun `a 500 propagates, because the server has the endpoint and simply failed`() = runTest {
+        enqueue(500, """{"detail": "boom"}""")
+
+        assertThrows<HttpException> { repository.setFollowing(7, following = true) }
+    }
+
+    // --- The capability ---------------------------------------------------------------------------
+
+    @Test
+    fun `follows is parsed from the capability payload`() {
+        val moshi = com.squareup.moshi.Moshi.Builder()
+            .add(com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory())
+            .build()
+        val response = requireNotNull(
+            moshi.adapter(CapabilitiesResponse::class.java).fromJson(ServerFixtures.CAPABILITIES_WITH_FOLLOWS),
+        )
+
+        assertTrue(ServerCapabilities.from(response).follows)
+    }
+
+    @Test
+    fun `a server that never mentions follows is not assumed to have them`() {
+        val moshi = com.squareup.moshi.Moshi.Builder()
+            .add(com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory())
+            .build()
+        val response = requireNotNull(
+            moshi.adapter(CapabilitiesResponse::class.java).fromJson(ServerFixtures.CAPABILITIES_1_4_0),
+        )
+
+        assertFalse(ServerCapabilities.from(response).follows)
+        assertFalse(ServerCapabilities.Baseline.follows)
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryCacheTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryCacheTest.kt
@@ -111,7 +111,7 @@ class LibraryCacheTest {
         val gate = CompletableDeferred<LibraryResponse>()
         val repository = object : FakeRepository() {
             var calls = 0
-            override suspend fun library(): LibraryResponse {
+            override suspend fun library(scope: LibraryScope): LibraryResponse {
                 calls++
                 return gate.await()
             }
@@ -152,7 +152,7 @@ class LibraryCacheTest {
         val second = CompletableDeferred<LibraryResponse>()
         val repository = object : FakeRepository() {
             var calls = 0
-            override suspend fun library(): LibraryResponse {
+            override suspend fun library(scope: LibraryScope): LibraryResponse {
                 calls++
                 return if (calls == 1) first.await() else second.await()
             }
@@ -525,5 +525,152 @@ class LibraryCacheTest {
         runCurrent()
 
         assertEquals(1, repository.libraryCalls)
+    }
+
+    // --- Browse all and follows -----------------------------------------------------------------
+
+    private fun shelf(vararg titles: String) = LibraryResponse(
+        scope = "followed",
+        fictions = titles.mapIndexed { index, title ->
+            FictionSummary(id = index + 1, title = title, following = true)
+        },
+    )
+
+    private fun catalogue(vararg followed: Pair<String, Boolean>) = LibraryResponse(
+        scope = "all",
+        fictions = followed.mapIndexed { index, (title, isFollowed) ->
+            FictionSummary(id = index + 1, title = title, following = isFollowed)
+        },
+    )
+
+    @Test
+    fun `browse-all is a different request from the shelf, and neither answers for the other`() = runTest {
+        val repository = FakeRepository(
+            libraryResult = Result.success(shelf("Followed")),
+            browseAllResult = Result.success(catalogue("Followed" to true, "Not followed" to false)),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+
+        cache.ensureLibrary()
+        cache.ensureBrowseAll()
+        runCurrent()
+
+        assertEquals(listOf(LibraryScope.Followed, LibraryScope.All), repository.libraryScopes)
+        assertEquals(1, cache.library.value.value?.fictions?.size)
+        assertEquals(2, cache.browseAll.value.value?.fictions?.size)
+        cache.close()
+    }
+
+    @Test
+    fun `switching back to a mode already loaded costs no request`() = runTest {
+        val repository = FakeRepository(
+            libraryResult = Result.success(shelf("Followed")),
+            browseAllResult = Result.success(catalogue("Followed" to true)),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+
+        cache.ensureBrowseAll()
+        runCurrent()
+        cache.ensureBrowseAll()
+        cache.ensureBrowseAll()
+        runCurrent()
+
+        assertEquals(listOf(LibraryScope.All), repository.libraryScopes)
+        cache.close()
+    }
+
+    @Test
+    fun `following patches the flag in both lists and re-asks the shelf`() = runTest {
+        // The flag patch is what makes the toggle instant; the shelf re-ask is what makes the row
+        // actually appear, which a flag patch cannot express.
+        val repository = FakeRepository(
+            libraryResult = Result.success(shelf("Followed")),
+            browseAllResult = Result.success(catalogue("Followed" to true, "Not followed" to false)),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        cache.ensureLibrary()
+        cache.ensureBrowseAll()
+        runCurrent()
+
+        val confirmed = cache.setFollowing(2, following = true)
+        runCurrent()
+
+        assertEquals(true, confirmed)
+        assertEquals(listOf(2 to true), repository.followCalls)
+        assertEquals(true, cache.browseAll.value.value?.fictions?.first { it.id == 2 }?.following)
+        assertEquals(listOf(LibraryScope.Followed, LibraryScope.All, LibraryScope.Followed), repository.libraryScopes)
+        cache.close()
+    }
+
+    @Test
+    fun `the state the server reports wins over the state that was asked for`() = runTest {
+        val repository = FakeRepository(
+            libraryResult = Result.success(shelf("Followed")),
+            browseAllResult = Result.success(catalogue("Followed" to true, "Other" to false)),
+            // A server that disagrees — the client must render its answer, not its own request.
+            followResult = Result.success(false),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        cache.ensureBrowseAll()
+        runCurrent()
+
+        val confirmed = cache.setFollowing(2, following = true)
+        runCurrent()
+
+        assertEquals(false, confirmed)
+        assertEquals(false, cache.browseAll.value.value?.fictions?.first { it.id == 2 }?.following)
+        cache.close()
+    }
+
+    @Test
+    fun `a 404 changes nothing at all, and says so`() = runTest {
+        val repository = FakeRepository(
+            libraryResult = Result.success(shelf("Followed")),
+            browseAllResult = Result.success(catalogue("Followed" to true, "Deleted" to false)),
+            followResult = Result.success(null),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        cache.ensureBrowseAll()
+        runCurrent()
+
+        val confirmed = cache.setFollowing(2, following = true)
+        runCurrent()
+
+        assertNull(confirmed)
+        assertEquals(false, cache.browseAll.value.value?.fictions?.first { it.id == 2 }?.following)
+        assertEquals(emptyList(), repository.libraryScopes.filter { it == LibraryScope.Followed })
+        cache.close()
+    }
+
+    @Test
+    fun `follow state is read from the library payloads, never from the chapters one`() = runTest {
+        // The trap this exists for: the chapters endpoint's `fiction` has no `following` key, so
+        // anything that trusted it would read null and render "not followed".
+        val repository = FakeRepository(libraryResult = Result.success(shelf("Followed")))
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        cache.ensureLibrary()
+        runCurrent()
+
+        assertEquals(true, cache.followingOf(1))
+        assertNull(cache.followingOf(999), "a fiction nothing knows about answers null, not false")
+        cache.close()
+    }
+
+    @Test
+    fun `signing out drops the catalogue as well as the shelf`() = runTest {
+        val repository = FakeRepository(
+            libraryResult = Result.success(shelf("Followed")),
+            browseAllResult = Result.success(catalogue("Followed" to true)),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        cache.ensureLibrary()
+        cache.ensureBrowseAll()
+        runCurrent()
+
+        cache.clear()
+
+        assertNull(cache.library.value.value)
+        assertNull(cache.browseAll.value.value)
+        cache.close()
     }
 }

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/FollowUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/FollowUiTest.kt
@@ -1,0 +1,194 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import dk.perspektiva.ttsroad.desktop.FakePlaybackController
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.data.ChaptersResponse
+import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.LibraryCache
+import dk.perspektiva.ttsroad.desktop.data.LibraryResponse
+import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
+import dk.perspektiva.ttsroad.desktop.testLibraryCache
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * The follow control and the library's two scopes, under the Compose rule.
+ *
+ * Needs a display; CI runs it under Xvfb.
+ */
+class FollowUiTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val followed = FictionSummary(id = 7, title = "A Test Serial", totalChapters = 3, following = true)
+    private val unfollowed = FictionSummary(id = 9, title = "Someone Else's Serial", following = false)
+
+    /** What the chapters endpoint really sends: a fiction payload with **no** `following` key. */
+    private val chaptersFiction = FictionSummary(id = 7, title = "A Test Serial", totalChapters = 3)
+
+    private fun repository(follows: Boolean) = FakeRepository(
+        libraryResult = Result.success(LibraryResponse(scope = "followed", fictions = listOf(followed))),
+        browseAllResult = Result.success(
+            LibraryResponse(scope = "all", fictions = listOf(followed, unfollowed)),
+        ),
+        chaptersResult = Result.success(ChaptersResponse(fiction = chaptersFiction)),
+        capabilitiesResult = ServerCapabilities(serverVersion = "1.5.0", follows = follows),
+    ).also { repository ->
+        // The screens gate on `currentCapabilities`, which only discovery publishes.
+        runBlocking { repository.refreshCurrentCapabilities() }
+    }
+
+    private fun detail(repository: FakeRepository, seed: FictionSummary, cache: LibraryCache) {
+        compose.setContent {
+            TtsRoadTheme {
+                FictionDetailScreen(
+                    fiction = seed,
+                    cache = cache,
+                    repository = repository,
+                    playback = FakePlaybackController(),
+                    onBack = {},
+                )
+            }
+        }
+        compose.waitForIdle()
+    }
+
+    private fun library(repository: FakeRepository, follows: Boolean) {
+        val cache = testLibraryCache(repository)
+        compose.setContent {
+            TtsRoadTheme {
+                LibraryScreen(
+                    cache = cache,
+                    repository = repository,
+                    playback = FakePlaybackController(),
+                    onOpenFiction = {},
+                    onOpenPlayer = {},
+                    followsAvailable = follows,
+                )
+            }
+        }
+        compose.waitForIdle()
+    }
+
+    // --- The toggle -------------------------------------------------------------------------------
+
+    @Test
+    fun `a followed fiction says so rather than telling the user to follow it`() {
+        val repository = repository(follows = true)
+        val cache = testLibraryCache(repository)
+        runBlockingRefresh(cache)
+
+        detail(repository, followed, cache)
+
+        compose.onNodeWithText("FOLLOWING").assertExists()
+    }
+
+    @Test
+    fun `following calls the server and takes its answer`() {
+        val repository = repository(follows = true)
+        val cache = testLibraryCache(repository)
+        runBlockingRefresh(cache)
+
+        detail(repository, unfollowed, cache)
+        clickFollow()
+        compose.waitForIdle()
+
+        assertEquals(listOf(9 to true), repository.followCalls)
+        compose.onNodeWithText("FOLLOWING").assertExists()
+    }
+
+    @Test
+    fun `the chapters response arriving does not unfollow the fiction on screen`() {
+        // The regression this guards: `/fictions/{id}/chapters` builds its `fiction` payload
+        // without a `following` key, so a screen that re-read follow state from it would flip every
+        // followed book to "Follow" the moment its chapters landed.
+        val repository = repository(follows = true)
+        val cache = testLibraryCache(repository)
+        runBlockingRefresh(cache)
+
+        detail(repository, followed, cache)
+        compose.waitForIdle()
+
+        assertTrue(repository.chaptersCalls > 0, "the chapters response really did arrive")
+        compose.onNodeWithText("FOLLOWING").assertExists()
+    }
+
+    @Test
+    fun `a server without per-user libraries offers no follow control at all`() {
+        val repository = repository(follows = false)
+        val cache = testLibraryCache(repository)
+        runBlockingRefresh(cache)
+
+        detail(repository, followed, cache)
+
+        assertEquals(0, compose.onAllNodesWithTag(FollowToggleTestTag).fetchSemanticsNodes().size)
+    }
+
+    @Test
+    fun `a fiction the server no longer has says so instead of looking followed`() {
+        val repository = repository(follows = true).apply { followResult = Result.success(null) }
+        val cache = testLibraryCache(repository)
+        runBlockingRefresh(cache)
+
+        detail(repository, unfollowed, cache)
+        clickFollow()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("The server does not have this fiction any more").assertExists()
+        compose.onNodeWithText("FOLLOW").assertExists()
+    }
+
+    // --- The two scopes ---------------------------------------------------------------------------
+
+    @Test
+    fun `the shelf is what the library opens on`() {
+        val repository = repository(follows = true)
+
+        library(repository, follows = true)
+
+        assertEquals(1, compose.onAllNodesWithTag(FictionCardTestTag).fetchSemanticsNodes().size)
+        assertEquals(2, compose.onAllNodesWithTag(LibraryScopeTabTestTag).fetchSemanticsNodes().size)
+    }
+
+    @Test
+    fun `Everything widens the grid to the whole server`() {
+        val repository = repository(follows = true)
+        library(repository, follows = true)
+
+        compose.onNodeWithText("EVERYTHING").performClick()
+        compose.waitForIdle()
+
+        assertEquals(2, compose.onAllNodesWithTag(FictionCardTestTag).fetchSemanticsNodes().size)
+    }
+
+    @Test
+    fun `a server without per-user libraries has no mode to pick`() {
+        val repository = repository(follows = false)
+
+        library(repository, follows = false)
+
+        assertEquals(0, compose.onAllNodesWithTag(LibraryScopeTabTestTag).fetchSemanticsNodes().size)
+    }
+
+    /** The control lives inside the header item, which is taller than the test window. */
+    private fun clickFollow() {
+        compose.onNodeWithTag(ChapterListTestTag).performScrollToNode(hasTestTag(FollowToggleTestTag))
+        compose.onNodeWithTag(FollowToggleTestTag).performClick()
+    }
+
+    private fun runBlockingRefresh(cache: LibraryCache) {
+        cache.refreshLibrary()
+        compose.waitForIdle()
+    }
+}


### PR DESCRIPTION
Closes #39. Built against real `master` (`b92a087`, v1.0.2).

## The gap

The backend has per-user libraries — `POST`/`DELETE /api/mobile/fictions/{id}/follow`, and `?scope=all` on the library — advertised as the `follows` capability, whose comment states the consequence of ignoring it: a client that sees it false is talking to a server where `/api/mobile/library` is still the whole shared list.

This client neither offered the control nor parsed the flag: `follows` was absent from `data/ServerCapabilities.kt` entirely, unlike `search` and `bookmarks` which are at least parsed. So it rendered whatever the library returned and called it the library, and on a follows-enabled server it and the web disagreed about what "my library" means.

## The trap, made structural

`FictionSummary.following` is **nullable**.

Only `/api/mobile/library` adds that key. `/api/mobile/fictions/{id}/chapters` builds its `fiction` with `_fiction_payload()`, which does not — so a detail screen that re-read follow state from its own chapters response would flip **every followed book to "unfollowed"** the moment its chapters arrived.

Modelling it as `Boolean? = null` rather than `Boolean = false` is what makes that impossible to write by accident: null means *this payload does not say*, false means *not followed*. The state is seeded from the library summary and mutated only by the toggle. There is a UI test that loads the detail screen, asserts the chapters response really did arrive, and asserts the button still says FOLLOWING.

Worth carrying to `jonarihen/TTSRoad-App#66`, which faces the identical payload.

## Browse-all

A second cached state in `LibraryCache`, **never written to disk**. The offline namespace holds what this account chose to keep; a catalogue of everything the server happens to host is not that. Each mode keeps its own answer, so flipping between them costs one request each and nothing after.

The rails — hero, "Jump back in", "Recent" — stay bound to the **shelf** in both modes. The server derives them from the followed set either way ("browse-all widens the catalogue, not what the app thinks you are in the middle of"), and reading them from the mode being browsed would blank the hero for the duration of one request. Only the grid waits.

`scope` is always sent, including to a 1.4.0 server: an unknown query parameter is ignored rather than rejected, so an older server answers exactly what it always did, with no `scope` and no `following`. There is a test for that payload.

## Two judgement calls

**The toggle reads the server's answer, not its own request.** `{"following": …}` is what gets rendered, so a call that did not do what it looked like cannot show as success. `created`/`removed` are deliberately not modelled — following something already followed is a no-op, not a failure.

**Following is not optimistic.** The shelf is a list whose *membership* changes, so an optimistic answer would have to add or remove a row and then undo it on failure. Instead: one request, then the flag is patched from what came back and the shelf is re-asked, because following something also changes what "Continue listening" holds.

A 404 — no such fiction, or no such endpoint — answers null, and the screen says so rather than showing the toggle flipped.

## Verification

`./gradlew --no-daemon check --warning-mode fail -Pttsroad.warningsAsErrors=true` passes, with 25 new tests: both routes and the scope parameter against MockWebServer, the older-server payload, the cache's two states and the follow patch, and the screens under the Compose rule including the chapters-response regression.

Not exercised against a live TTSRoad server — there is no instance in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)