### PR TITLE
Bookmarks: capture a passage, label it, come back to it

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -59,6 +60,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.data.Bookmark
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.di.AppContainer
 import dk.perspektiva.ttsroad.desktop.nav.AppShortcut
@@ -69,6 +71,8 @@ import dk.perspektiva.ttsroad.desktop.nav.escapeAction
 import dk.perspektiva.ttsroad.desktop.nav.key
 import dk.perspektiva.ttsroad.desktop.nav.shortcutFor
 import dk.perspektiva.ttsroad.desktop.ui.AarisColor
+import dk.perspektiva.ttsroad.desktop.ui.BookmarksScreen
+import dk.perspektiva.ttsroad.desktop.ui.BookmarksStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.ContentMaxWidth
 import dk.perspektiva.ttsroad.desktop.ui.FictionDetailScreen
 import dk.perspektiva.ttsroad.desktop.ui.LibraryScreen
@@ -91,6 +95,7 @@ import dk.perspektiva.ttsroad.desktop.ui.rememberChapterDownloads
 import dk.perspektiva.ttsroad.desktop.ui.UpdateStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.rememberStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.windowSizeClassFor
+import kotlinx.coroutines.launch
 
 /**
  * Root composable. The object graph is *passed in*, not built here — see [AppContainer]. The
@@ -120,6 +125,10 @@ fun App(container: AppContainer = remember { AppContainer() }) {
     // Hoisted for the same reason: following a hit and coming back must find the results still
     // there. A search you have to run twice to use is not a search.
     val search = rememberStateHolder(repository) { SearchStateHolder(repository) }
+    // Hoisted for a sharper reason than the other two: bookmarks are *written* from the player and
+    // the reader and *read* on a destination the user may never open, so a holder owned by the
+    // bookmarks screen would give Ctrl+B nowhere to put anything.
+    val bookmarks = rememberStateHolder(repository) { BookmarksStateHolder(repository) }
 
     // Capability discovery is the only source of the server's stable advertised identity. Feed it
     // into the download namespace as soon as it arrives; using it only for feature flags would
@@ -135,13 +144,45 @@ fun App(container: AppContainer = remember { AppContainer() }) {
     val nav = remember { NavigationState(onDestinationDropped = screenState::removeState) }
     val playerState by playback.state.collectAsState()
 
+    val scope = rememberCoroutineScope()
+
     fun refreshCurrentScreen() {
         when (val destination = nav.current) {
             Destination.Library -> cache.refreshLibrary()
             is Destination.Fiction -> cache.refreshChapters(destination.fiction.id)
             Destination.Settings, Destination.Devices -> settings.refreshCurrentSection()
             Destination.Search -> search.refresh()
+            Destination.Bookmarks -> bookmarks.refresh()
             Destination.Player, is Destination.Reader -> Unit
+        }
+    }
+
+    /**
+     * Marks the spot that is playing.
+     *
+     * Takes the position from the player rather than from whatever screen is on top, so Ctrl+B in
+     * the library marks the chapter that is *playing* — the only position the app can honestly
+     * claim the user meant. The reader passes its own sentence text as a label; see below.
+     */
+    fun addBookmark(label: String? = null) {
+        val chapterId = playerState.queue.getOrNull(playerState.currentIndex)?.chapterId ?: 0
+        if (chapterId > 0) bookmarks.add(chapterId, playerState.positionMs, label)
+    }
+
+    /**
+     * Opens a mark: loads its fiction, queues it, and starts *at the mark* rather than at the
+     * chapter's saved resume position — the whole point of having clicked it.
+     *
+     * Fetched through the repository rather than the library cache because this screen has no
+     * fiction context at all: a bookmark can point at a serial the session has never opened.
+     */
+    fun openBookmark(bookmark: Bookmark) {
+        val fictionId = bookmark.fictionId ?: return
+        val chapterId = bookmark.chapterId ?: return
+        scope.launch {
+            val loaded = runCatching { repository.chapters(fictionId) }.getOrNull() ?: return@launch
+            playback.playQueue(loaded.chapters, chapterId, loaded.fiction, bookmark.positionMs)
+            nav.open(Destination.Player)
         }
     }
 
@@ -208,6 +249,15 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                 true
             }
 
+            // Both are inert on a server with no bookmark API, and report themselves unhandled so
+            // the key falls through rather than being silently swallowed by a feature that is not
+            // there.
+            AppShortcut.AddBookmark -> capabilities.bookmarks && whenPlaying { addBookmark() }
+
+            AppShortcut.OpenBookmarks -> capabilities.bookmarks.also {
+                if (it) nav.open(Destination.Bookmarks)
+            }
+
             AppShortcut.ShowShortcuts -> {
                 showShortcuts = true
                 true
@@ -232,6 +282,7 @@ fun App(container: AppContainer = remember { AppContainer() }) {
             container.readAlongCache.clear()
             settings.sessionEnded()
             search.sessionEnded()
+            bookmarks.sessionEnded()
         } else {
             // Cheap, and it is what makes optional UI correct after a restart, where login did
             // not run but a keyring-backed session was restored.
@@ -300,6 +351,9 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                         current = nav.current,
                         canGoBack = nav.canGoBack,
                         canRefresh = nav.current.isRefreshable,
+                        // Gated the way the speed and skip-silence controls are: no entry at all
+                        // where the server cannot answer, rather than one that leads to a 404.
+                        showBookmarks = capabilities.bookmarks,
                         compact = sizeClass == WindowSizeClass.Compact,
                         onBack = { nav.back() },
                         onRefresh = ::refreshCurrentScreen,
@@ -380,9 +434,17 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                     sizeClass = sizeClass,
                                     preferences = container.playbackPreferences,
                                     readAlongAvailable = capabilities.readAlong,
+                                    bookmarksAvailable = capabilities.bookmarks,
+                                    onAddBookmark = { addBookmark() },
                                     onOpenReader = { chapterId, title ->
                                         nav.open(Destination.Reader(chapterId, title))
                                     },
+                                    onBack = { nav.back() },
+                                )
+
+                                Destination.Bookmarks -> BookmarksScreen(
+                                    holder = bookmarks,
+                                    onOpen = ::openBookmark,
                                     onBack = { nav.back() },
                                 )
 
@@ -417,6 +479,14 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                     cache = container.readAlongCache,
                                     preferences = container.readerPreferences,
                                     playback = playback,
+                                    bookmarksAvailable = capabilities.bookmarks,
+                                    // The reader knows which *sentence* is being narrated, so it
+                                    // supplies both a precise position and a label made of the
+                                    // words themselves — the thing this client can do that a
+                                    // phone reaching for a transport button cannot.
+                                    onAddBookmark = { positionMs, label ->
+                                        bookmarks.add(destination.chapterId, positionMs, label)
+                                    },
                                     onBack = { nav.back() },
                                     onChapterAdvanced = { chapterId, title ->
                                         nav.replaceTop(Destination.Reader(chapterId, title))
@@ -449,7 +519,9 @@ fun App(container: AppContainer = remember { AppContainer() }) {
 /** Whether the Refresh action means anything on this destination. */
 private val Destination.isRefreshable: Boolean
     get() = when (this) {
-        Destination.Library, is Destination.Fiction, Destination.Settings, Destination.Devices -> true
+        Destination.Library, is Destination.Fiction, Destination.Settings, Destination.Devices,
+        Destination.Bookmarks,
+        -> true
         // Refresh re-runs the query the results belong to; it is dead until one has been run, but
         // enabling it is cheaper to reason about than a state-dependent header button.
         Destination.Search -> true
@@ -462,6 +534,7 @@ private fun HeaderBar(
     current: Destination,
     canGoBack: Boolean,
     canRefresh: Boolean,
+    showBookmarks: Boolean,
     compact: Boolean,
     onBack: () -> Unit,
     onRefresh: () -> Unit,
@@ -517,6 +590,11 @@ private fun HeaderBar(
                 "Library",
                 active = current == Destination.Library || current is Destination.Fiction,
             ) { onSelect(Destination.Library) }
+            if (showBookmarks) {
+                NavItem("Bookmarks", active = current == Destination.Bookmarks) {
+                    onSelect(Destination.Bookmarks)
+                }
+            }
             NavItem(
                 "Settings",
                 active = current == Destination.Settings || current == Destination.Devices,

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/BookmarkModels.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/BookmarkModels.kt
@@ -1,0 +1,115 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Json
+
+/**
+ * `GET /api/mobile/bookmarks`.
+ *
+ * The same rows and shapes as the web's `/api/bookmarks` — both routers call into
+ * `app/services/bookmarks.py`, so a mark made here is the same record the browser sees.
+ */
+data class BookmarksResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    /** The cursor to echo back as `updated_since` next time. Server time, never this machine's. */
+    @param:Json(name = "server_time") val serverTime: String? = null,
+    val bookmarks: List<Bookmark> = emptyList(),
+    /** Ids tombstoned since the cursor. Only ever populated on a delta pull. */
+    val deleted: List<Int> = emptyList(),
+)
+
+data class Bookmark(
+    val id: Int = 0,
+    /**
+     * **Nullable.** `retire_bookmarks_for_chapters` soft-deletes marks and *clears the link* when a
+     * chapter is hard-deleted, rather than letting the foreign key cascade take them silently. So a
+     * bookmark can outlive its audio, and a non-null assertion here is a crash waiting for the day
+     * someone deletes a chapter.
+     */
+    @param:Json(name = "chapter_id") val chapterId: Int? = null,
+    /** Derived server-side from the chapter, so it is null for exactly the same reason. */
+    @param:Json(name = "fiction_id") val fictionId: Int? = null,
+    @param:Json(name = "position_seconds") val positionSeconds: Double = 0.0,
+    @param:Json(name = "position_label") val positionLabel: String? = null,
+    val label: String? = null,
+    val note: String? = null,
+    val color: String? = null,
+    /**
+     * `manual` — a mark the reader chose — or `auto`, a jump-back breadcrumb recorded because
+     * playback stopped there. Anywhere the user-chosen list is rendered must filter to `manual`, or
+     * a day of listening buries the marks somebody actually made.
+     */
+    val kind: String = BookmarkKind.Manual,
+    @param:Json(name = "created_at") val createdAt: String? = null,
+    @param:Json(name = "updated_at") val updatedAt: String? = null,
+    @param:Json(name = "deleted_at") val deletedAt: String? = null,
+    @param:Json(name = "chapter_title") val chapterTitle: String? = null,
+    @param:Json(name = "chapter_number") val chapterNumber: Int? = null,
+    @param:Json(name = "fiction_title") val fictionTitle: String? = null,
+    @param:Json(name = "fiction_slug") val fictionSlug: String? = null,
+) {
+    /** Whether there is still audio to play. False once the chapter has been deleted server-side. */
+    val isPlayable: Boolean get() = (chapterId ?: 0) > 0 && (fictionId ?: 0) > 0
+
+    val positionMs: Long get() = (positionSeconds * 1000).toLong().coerceAtLeast(0L)
+
+    /** What the row is called: the reader's own label, else the chapter, else the position. */
+    val displayLabel: String
+        get() = label?.takeIf { it.isNotBlank() }
+            ?: chapterTitle?.takeIf { it.isNotBlank() }
+            ?: positionLabel?.takeIf { it.isNotBlank() }
+            ?: "Bookmark"
+}
+
+object BookmarkKind {
+    const val Manual: String = "manual"
+    const val Auto: String = "auto"
+}
+
+/** What the server will accept, mirrored so a request it would reject is never sent. */
+object BookmarkLimits {
+    const val MaxLabelChars: Int = 512
+    const val MaxNoteChars: Int = 4000
+}
+
+data class BookmarkCreateRequest(
+    @param:Json(name = "chapter_id") val chapterId: Int,
+    @param:Json(name = "position_seconds") val positionSeconds: Double,
+    val label: String? = null,
+    val note: String? = null,
+    val kind: String = BookmarkKind.Manual,
+)
+
+/**
+ * A PATCH.
+ *
+ * Every field is nullable and Moshi omits nulls, which lines up exactly with the server's rule that
+ * an **absent** key means "leave it alone". Clearing a label is expressed by sending an empty
+ * string, which `_clean_text` turns into null — so "leave alone" and "clear" stay distinguishable
+ * without needing to serialise an explicit JSON null.
+ */
+data class BookmarkPatchRequest(
+    val label: String? = null,
+    val note: String? = null,
+    @param:Json(name = "position_seconds") val positionSeconds: Double? = null,
+)
+
+data class BookmarkWriteResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    val bookmark: Bookmark? = null,
+)
+
+data class BookmarkDeleteResponse(
+    val status: String = "",
+    val id: Int = 0,
+    @param:Json(name = "deleted_at") val deletedAt: String? = null,
+)
+
+/**
+ * Newest first, and tombstones dropped.
+ *
+ * A soft-deleted row can come back in a full list as well as in a delta — the server's list query
+ * is what decides — so filtering here rather than trusting the shape is what keeps a deleted mark
+ * from reappearing after a refresh.
+ */
+fun List<Bookmark>.visibleBookmarks(): List<Bookmark> =
+    filter { it.deletedAt == null }.sortedByDescending { it.createdAt.orEmpty() }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -176,6 +176,27 @@ interface TtsRoadRepository {
     suspend fun markPlayed(chapterIds: List<Int>, played: Boolean): PlaybackMarkResponse
 
     /**
+     * This account's bookmarks, or **null when the server has no bookmark API**.
+     *
+     * Defaults to `manual` for the reason the backend documents: the same table holds the web
+     * player's jump-back breadcrumbs, and a day of listening buries the marks a reader chose under
+     * a few hundred automatic ones.
+     */
+    suspend fun bookmarks(
+        kind: String? = BookmarkKind.Manual,
+        fictionId: Int? = null,
+    ): List<Bookmark>?
+
+    /** The created bookmark, or null on a server with no bookmark API. */
+    suspend fun createBookmark(request: BookmarkCreateRequest): Bookmark?
+
+    /** The updated bookmark, or null when the server has no such bookmark (or no such API). */
+    suspend fun updateBookmark(bookmarkId: Int, request: BookmarkPatchRequest): Bookmark?
+
+    /** True once the mark is gone. A second delete is a success, not a 404 — it is idempotent. */
+    suspend fun deleteBookmark(bookmarkId: Int): Boolean
+
+    /**
      * Record a listening position and try to get it to the server.
      *
      * Queued to disk with a timestamp *before* being sent. That ordering is the fix for #36: if the
@@ -425,6 +446,38 @@ class RetrofitTtsRoadRepository(
 
     override suspend fun markPlayed(chapterIds: List<Int>, played: Boolean): PlaybackMarkResponse =
         withAuthorizedApi { it.markPlayback(PlaybackMarkRequest(chapterIds, played)) }
+
+    override suspend fun bookmarks(kind: String?, fictionId: Int?): List<Bookmark>? =
+        ifEndpointExists { it.bookmarks(kind = kind, fictionId = fictionId) }?.bookmarks
+
+    override suspend fun createBookmark(request: BookmarkCreateRequest): Bookmark? =
+        ifEndpointExists {
+            it.createBookmark(
+                request.copy(
+                    // Bounded here so an over-long label is a shorter bookmark rather than a 400:
+                    // the server truncates to exactly these limits anyway.
+                    label = request.label?.take(BookmarkLimits.MaxLabelChars),
+                    note = request.note?.take(BookmarkLimits.MaxNoteChars),
+                    positionSeconds = request.positionSeconds.coerceAtLeast(0.0),
+                ),
+            )
+        }?.bookmark
+
+    override suspend fun updateBookmark(bookmarkId: Int, request: BookmarkPatchRequest): Bookmark? =
+        ifEndpointExists {
+            it.updateBookmark(
+                bookmarkId,
+                request.copy(
+                    label = request.label?.take(BookmarkLimits.MaxLabelChars),
+                    note = request.note?.take(BookmarkLimits.MaxNoteChars),
+                ),
+            )
+        }?.bookmark
+
+    override suspend fun deleteBookmark(bookmarkId: Int): Boolean =
+        // A 404 here is "already gone or never existed", which is the outcome the caller wanted
+        // either way — the delete is idempotent by design, so it is not worth surfacing.
+        ifEndpointExists { it.deleteBookmark(bookmarkId) } != null
 
     override suspend fun saveProgress(
         fictionId: Int,

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -118,4 +118,31 @@ interface TtsRoadApi {
 
     @POST("api/mobile/playback/mark")
     suspend fun markPlayback(@Body request: PlaybackMarkRequest): PlaybackMarkResponse
+
+    /**
+     * This account's bookmarks. Advertised as the `bookmarks` capability; 404 on an older server.
+     *
+     * [kind] is not optional in practice: without `manual` the list is drowned in the jump-back
+     * breadcrumbs the web player writes as `auto`.
+     */
+    @GET("api/mobile/bookmarks")
+    suspend fun bookmarks(
+        @Query("kind") kind: String? = BookmarkKind.Manual,
+        @Query("fiction_id") fictionId: Int? = null,
+        @Query("chapter_id") chapterId: Int? = null,
+    ): BookmarksResponse
+
+    /** 201 on success; 404 for an unknown chapter, 409 once the account is at its bookmark cap. */
+    @POST("api/mobile/bookmarks")
+    suspend fun createBookmark(@Body request: BookmarkCreateRequest): BookmarkWriteResponse
+
+    @PATCH("api/mobile/bookmarks/{bookmark_id}")
+    suspend fun updateBookmark(
+        @Path("bookmark_id") bookmarkId: Int,
+        @Body request: BookmarkPatchRequest,
+    ): BookmarkWriteResponse
+
+    /** Soft delete, idempotent: a second call answers the first one's tombstone, not a 404. */
+    @DELETE("api/mobile/bookmarks/{bookmark_id}")
+    suspend fun deleteBookmark(@Path("bookmark_id") bookmarkId: Int): BookmarkDeleteResponse
 }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/nav/AppNavigation.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/nav/AppNavigation.kt
@@ -44,6 +44,15 @@ sealed interface Destination {
      */
     data object Search : Destination
 
+    /**
+     * The account's bookmarks.
+     *
+     * Carries nothing. The list lives in the hoisted bookmarks holder because the *writer* is the
+     * player or the reader — a mark made with Ctrl+B has to land somewhere whether or not this
+     * destination has ever been opened.
+     */
+    data object Bookmarks : Destination
+
     data object Settings : Destination
 
     data object Devices : Destination
@@ -64,6 +73,7 @@ val Destination.key: String
         Destination.Player -> "Player"
         is Destination.Reader -> "Reader:$chapterId"
         Destination.Search -> "Search"
+        Destination.Bookmarks -> "Bookmarks"
         Destination.Settings -> "Settings"
         Destination.Devices -> "Devices"
     }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/nav/Shortcuts.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/nav/Shortcuts.kt
@@ -42,6 +42,18 @@ enum class AppShortcut {
     /** Ctrl+comma — the platform convention for preferences. */
     OpenSettings,
 
+    /**
+     * Ctrl+B — mark the spot that is playing.
+     *
+     * Safe mid-word, and checked against the one text field that could plausibly claim it: the
+     * library's search box is a plain `OutlinedTextField`, which has no bold to toggle. So this is
+     * a combination no text field takes, and it stays live while typing like Ctrl+L and F5.
+     */
+    AddBookmark,
+
+    /** Ctrl+Shift+B — the list of them. */
+    OpenBookmarks,
+
     /** F1 or Ctrl+slash. */
     ShowShortcuts,
     ;
@@ -60,7 +72,9 @@ enum class AppShortcut {
      */
     val firesWhileTyping: Boolean
         get() = when (this) {
-            Back, Refresh, Dismiss, OpenLibrary, OpenSettings, ShowShortcuts -> true
+            Back, Refresh, Dismiss, OpenLibrary, OpenSettings, ShowShortcuts,
+            AddBookmark, OpenBookmarks,
+            -> true
             PlayPause, SeekBackward, SeekForward, PreviousChapter, NextChapter -> false
         }
 }
@@ -104,6 +118,10 @@ private fun match(key: Key, alt: Boolean, ctrl: Boolean, meta: Boolean, shift: B
         key == Key.L && accel -> AppShortcut.OpenLibrary
         key == Key.Comma && accel -> AppShortcut.OpenSettings
         key == Key.Slash && accel -> AppShortcut.ShowShortcuts
+
+        // The list is checked before the bare mark, so Ctrl+Shift+B does not also bookmark.
+        key == Key.B && accel && shift -> AppShortcut.OpenBookmarks
+        key == Key.B && accel -> AppShortcut.AddBookmark
 
         // Chapter stepping is checked before plain seeking: Ctrl+Left is a chapter, not a skip.
         key == Key.DirectionLeft && accel -> AppShortcut.PreviousChapter
@@ -171,6 +189,8 @@ val ShortcutHelpTable: List<ShortcutHelp> = listOf(
     ShortcutHelp("Ctrl+Left / Ctrl+Right", "Previous or next chapter"),
     ShortcutHelp("Alt+Left", "Back"),
     ShortcutHelp("Ctrl+L", "Library"),
+    ShortcutHelp("Ctrl+B", "Bookmark this spot"),
+    ShortcutHelp("Ctrl+Shift+B", "Your bookmarks"),
     ShortcutHelp("Ctrl+,", "Settings"),
     ShortcutHelp("F5 / Ctrl+R", "Refresh the current screen"),
     ShortcutHelp("Escape", "Close a dialog, or go back"),

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackController.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackController.kt
@@ -87,8 +87,18 @@ interface PlaybackController {
     /**
      * Play a whole fiction as a queue, starting at [startChapterId] — enables next/previous,
      * auto-advance, and the up-next list (mirrors the Android client's playQueue).
+     *
+     * [startPositionMs] overrides the chapter's saved resume position, and exists for the one
+     * caller that knows better than the server does: opening a bookmark means "start *here*", and
+     * resuming where this chapter was last left would silently ignore the mark that was clicked.
+     * Null — every other caller — keeps the saved position.
      */
-    suspend fun playQueue(chapters: List<ChapterSummary>, startChapterId: Int, fiction: FictionSummary?)
+    suspend fun playQueue(
+        chapters: List<ChapterSummary>,
+        startChapterId: Int,
+        fiction: FictionSummary?,
+        startPositionMs: Long? = null,
+    )
 
     fun togglePlayPause()
 

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
@@ -205,6 +205,7 @@ class QueuePlaybackController(
         chapters: List<ChapterSummary>,
         startChapterId: Int,
         fiction: FictionSummary?,
+        startPositionMs: Long?,
     ) {
         // Canonical reading order, never the order the screen happens to be sorted in: a listener
         // who flipped the list to newest-first still wants the serial to play forwards.
@@ -220,7 +221,13 @@ class QueuePlaybackController(
         queueFiction = fiction
         queueOwnerKey = ownerKey()
         val startIndex = playable.indexOfFirst { it.resolvedChapterId == startChapterId }.coerceAtLeast(0)
-        begin(startIndex, resumeMsOf(playable[startIndex]), leaveCurrent = false)
+        // An explicit start position only applies to the chapter that was asked for. Falling back
+        // to the saved position when the requested chapter is not in the queue is what stops a
+        // bookmark on a chapter that has since lost its audio from seeking chapter one to 41:12.
+        val requestedFound = playable[startIndex].resolvedChapterId == startChapterId
+        val startMs = startPositionMs?.takeIf { requestedFound }?.coerceAtLeast(0L)
+            ?: resumeMsOf(playable[startIndex])
+        begin(startIndex, startMs, leaveCurrent = false)
     }
 
     override fun togglePlayPause() {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/BookmarksScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/BookmarksScreen.kt
@@ -1,0 +1,340 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.data.Bookmark
+import dk.perspektiva.ttsroad.desktop.data.BookmarkLimits
+
+const val BookmarkRowTestTag: String = "bookmarkRow"
+const val BookmarkPlayTestTag: String = "bookmarkPlay"
+const val BookmarkEditTestTag: String = "bookmarkEdit"
+const val BookmarkDeleteTestTag: String = "bookmarkDelete"
+const val BookmarkConfirmDeleteTestTag: String = "bookmarkConfirmDelete"
+const val BookmarkNoticeTestTag: String = "bookmarkNotice"
+
+/**
+ * The account's marks, newest first.
+ *
+ * Rows carry the fiction and chapter titles the server sends alongside each mark, which is why this
+ * screen needs neither the library nor a request per row to render — a bookmark on a serial that
+ * was never opened in this session still reads as a sentence rather than as an id.
+ */
+@Composable
+fun BookmarksScreen(
+    holder: BookmarksStateHolder,
+    onOpen: (Bookmark) -> Unit,
+    onBack: () -> Unit,
+) {
+    val ui by holder.state.collectAsState()
+    LaunchedEffect(Unit) { holder.ensureLoaded() }
+
+    var editing by remember { mutableStateOf<Bookmark?>(null) }
+    var confirmDelete by remember { mutableStateOf<Bookmark?>(null) }
+
+    Box(Modifier.fillMaxSize()) {
+        Column(
+            Modifier.align(Alignment.TopCenter).widthIn(max = ContentMaxWidth).fillMaxSize()
+                .padding(horizontal = PageGutter, vertical = 20.dp),
+        ) {
+            BackLink("Back", onBack)
+            Spacer(Modifier.height(12.dp))
+            SectionTitle("bookmarks", "Your bookmarks")
+            RefreshingStrip(ui.loading && !ui.isEmpty)
+            ui.notice?.let {
+                Spacer(Modifier.height(12.dp))
+                BookmarkNotice(it) { holder.dismissNotice() }
+            }
+            Spacer(Modifier.height(16.dp))
+            when {
+                ui.unsupported -> EmptyState(
+                    "No bookmarks here",
+                    "This server does not have the bookmarks API.",
+                )
+
+                ui.loading && ui.isEmpty -> CenterProgress()
+
+                ui.isEmpty && ui.error != null -> InitialErrorState(ui.error.orEmpty()) { holder.refresh() }
+
+                ui.isEmpty -> EmptyState(
+                    "No bookmarks yet",
+                    "Press Ctrl+B while listening, or use the bookmark action in the player.",
+                )
+
+                else -> {
+                    ui.error?.let {
+                        Text(it, color = MaterialTheme.colorScheme.error)
+                        Spacer(Modifier.height(12.dp))
+                    }
+                    LazyColumn(Modifier.fillMaxSize()) {
+                        items(ui.bookmarks, key = { it.id }) { bookmark ->
+                            BookmarkRow(
+                                bookmark = bookmark,
+                                onOpen = { onOpen(bookmark) },
+                                onEdit = { editing = bookmark },
+                                onDelete = { confirmDelete = bookmark },
+                            )
+                            HorizontalDivider(thickness = 1.dp, color = AarisColor.LineSoft)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    editing?.let { bookmark ->
+        BookmarkEditDialog(
+            bookmark = bookmark,
+            onDismiss = { editing = null },
+            onSave = { label, note ->
+                holder.edit(bookmark.id, label, note)
+                editing = null
+            },
+        )
+    }
+
+    confirmDelete?.let { bookmark ->
+        AlertDialog(
+            onDismissRequest = { confirmDelete = null },
+            title = { Text("Remove this bookmark?") },
+            text = { Text(bookmark.displayLabel) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        holder.remove(bookmark.id)
+                        confirmDelete = null
+                    },
+                    modifier = Modifier.testTag(BookmarkConfirmDeleteTestTag),
+                ) { Text("REMOVE") }
+            },
+            dismissButton = { TextButton(onClick = { confirmDelete = null }) { Text("CANCEL") } },
+            shape = RectangleShape,
+        )
+    }
+}
+
+/**
+ * One mark.
+ *
+ * The actions are explicit rather than the row itself being clickable, because two of the three are
+ * destructive or modal and a row-wide hit target would fire them by accident. Play still shares the
+ * row's interaction source, so hovering anywhere lights up the primary action.
+ *
+ * Play appears only when there is still audio behind the mark: a chapter deleted on the server
+ * leaves its bookmarks in place with the link cleared, so a row can outlive the thing it points at.
+ * That row stays visible — the note on it is still the user's — and simply says what happened.
+ */
+@Composable
+private fun BookmarkRow(
+    bookmark: Bookmark,
+    onOpen: () -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    val focused by interaction.collectIsFocusedAsState()
+    val active = hovered || focused
+    Row(
+        Modifier
+            .testTag(BookmarkRowTestTag)
+            .fillMaxWidth()
+            .hoverable(interaction)
+            .background(if (active) AarisColor.BgHover.copy(alpha = 0.5f) else Color.Transparent)
+            .border(1.dp, if (focused) AarisColor.Accent else Color.Transparent)
+            .padding(horizontal = 8.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(
+                bookmark.displayLabel,
+                style = MaterialTheme.typography.titleMedium,
+                color = AarisColor.Ink,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(Modifier.height(4.dp))
+            MetaText(bookmarkSubtitle(bookmark), color = AarisColor.Dim)
+            bookmark.note?.takeIf { it.isNotBlank() }?.let {
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    it,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = AarisColor.Muted,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp), verticalAlignment = Alignment.CenterVertically) {
+            if (bookmark.isPlayable) {
+                RowAction("PLAY", BookmarkPlayTestTag, interaction, onOpen)
+            } else {
+                MetaText("Chapter removed", color = AarisColor.Warning)
+            }
+            RowAction("EDIT", BookmarkEditTestTag, onClick = onEdit)
+            RowAction("REMOVE", BookmarkDeleteTestTag, onClick = onDelete)
+        }
+    }
+}
+
+/**
+ * "Serial · Chapter 4 · 12:07", skipping whatever the server did not send.
+ *
+ * Pure, and total over a mark whose chapter has been deleted: every part is optional, so a bookmark
+ * with nothing left but a position still gets a subtitle rather than a row of separators.
+ */
+fun bookmarkSubtitle(bookmark: Bookmark): String = listOfNotNull(
+    bookmark.fictionTitle?.takeIf { it.isNotBlank() },
+    bookmark.chapterTitle?.takeIf { it.isNotBlank() && it != bookmark.label },
+    bookmark.positionLabel?.takeIf { it.isNotBlank() } ?: formatDuration(bookmark.positionMs),
+).joinToString(" · ")
+
+@Composable
+private fun RowAction(
+    label: String,
+    tag: String,
+    interaction: MutableInteractionSource? = null,
+    onClick: () -> Unit,
+) {
+    val own = remember { MutableInteractionSource() }
+    val source = interaction ?: own
+    val hovered by source.collectIsHoveredAsState()
+    val focused by source.collectIsFocusedAsState()
+    MetaText(
+        label,
+        color = if (hovered || focused) AarisColor.Accent else AarisColor.Muted,
+        modifier = Modifier
+            .testTag(tag)
+            .hoverable(source)
+            .clickable(
+                interactionSource = source,
+                indication = null,
+                role = Role.Button,
+                onClick = onClick,
+            )
+            .pointerHoverIcon(PointerIcon.Hand)
+            .padding(horizontal = 8.dp, vertical = 6.dp),
+    )
+}
+
+/** Transient confirmation from a write. Dismissible, because it sits above a scrolling list. */
+@Composable
+private fun BookmarkNotice(message: String, onDismiss: () -> Unit) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .background(AarisColor.BgRaise)
+            .border(1.dp, AarisColor.Line)
+            .padding(horizontal = 14.dp, vertical = 10.dp)
+            .testTag(BookmarkNoticeTestTag)
+            .semantics(mergeDescendants = true) { contentDescription = message },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(message, style = MaterialTheme.typography.bodyMedium, color = AarisColor.Ink, modifier = Modifier.weight(1f))
+        RowAction("DISMISS", "bookmarkNoticeDismiss", onClick = onDismiss)
+    }
+}
+
+/**
+ * Label and note, edited together.
+ *
+ * Both fields are sent on every save, blank included — an empty string is how the server is told to
+ * *clear* a value, where an absent key would mean "leave it alone". Editing a note to nothing and
+ * having it come back is the bug this avoids.
+ */
+@Composable
+private fun BookmarkEditDialog(
+    bookmark: Bookmark,
+    onDismiss: () -> Unit,
+    onSave: (label: String, note: String) -> Unit,
+) {
+    var label by remember(bookmark.id) { mutableStateOf(bookmark.label.orEmpty()) }
+    var note by remember(bookmark.id) { mutableStateOf(bookmark.note.orEmpty()) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Edit bookmark") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
+                MetaText(bookmarkSubtitle(bookmark), color = AarisColor.Dim)
+                OutlinedTextField(
+                    value = label,
+                    // Bounded in the field rather than at the request, so the limit is visible
+                    // while typing instead of silently truncating on save.
+                    onValueChange = { label = it.take(BookmarkLimits.MaxLabelChars) },
+                    label = { Text("LABEL") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth().testTag(BookmarkLabelFieldTestTag),
+                )
+                OutlinedTextField(
+                    value = note,
+                    onValueChange = { note = it.take(BookmarkLimits.MaxNoteChars) },
+                    label = { Text("NOTE") },
+                    minLines = 3,
+                    modifier = Modifier.fillMaxWidth().testTag(BookmarkNoteFieldTestTag),
+                )
+            }
+        },
+        confirmButton = { TextButton(onClick = { onSave(label, note) }) { Text("SAVE") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("CANCEL") } },
+        shape = RectangleShape,
+    )
+}
+
+const val BookmarkLabelFieldTestTag: String = "bookmarkLabelField"
+const val BookmarkNoteFieldTestTag: String = "bookmarkNoteField"
+
+/** The player's and reader's "mark this spot" control, drawn only where the server has the API. */
+@Composable
+fun BookmarkAction(enabled: Boolean, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    OutlinedButton(
+        onClick = onClick,
+        enabled = enabled,
+        shape = RectangleShape,
+        modifier = modifier.testTag(AddBookmarkTestTag).pointerHoverIcon(PointerIcon.Hand),
+    ) { Text("BOOKMARK") }
+}
+
+const val AddBookmarkTestTag: String = "addBookmark"

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/BookmarksStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/BookmarksStateHolder.kt
@@ -1,0 +1,222 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.data.Bookmark
+import dk.perspektiva.ttsroad.desktop.data.BookmarkCreateRequest
+import dk.perspektiva.ttsroad.desktop.data.BookmarkLimits
+import dk.perspektiva.ttsroad.desktop.data.BookmarkPatchRequest
+import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
+import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
+import dk.perspektiva.ttsroad.desktop.data.visibleBookmarks
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * What the bookmarks screen shows, and what the player and reader say after marking a spot.
+ *
+ * [notice] is the one piece of state the *other* screens read: a bookmark is made from the player
+ * or the reader, but the list it joins is somewhere else entirely, so without a word back the
+ * action looks like it did nothing. It is deliberately not an error channel — [error] is —
+ * because "saved" and "could not save" are shown in different places and different colours.
+ */
+data class BookmarksUiState(
+    val bookmarks: List<Bookmark> = emptyList(),
+    val loading: Boolean = false,
+    val error: String? = null,
+    /**
+     * The server answered 404 for the endpoint the capability advertised.
+     *
+     * Kept apart from [error] for the reason `SearchStateHolder` keeps them apart: one is worth a
+     * Retry button and the other never will be.
+     */
+    val unsupported: Boolean = false,
+    val notice: String? = null,
+    /** True once a load has completed, so "no bookmarks yet" is only said about a list that ran. */
+    val loaded: Boolean = false,
+) {
+    val isEmpty: Boolean get() = bookmarks.isEmpty()
+}
+
+/**
+ * The account's manual bookmarks, held above the screens.
+ *
+ * Hoisted like the settings, update and search holders, and for a sharper reason than any of them:
+ * the *writer* is the player or the reader and the *reader* is a destination the user may never
+ * have opened. A holder owned by the bookmarks screen would mean the Ctrl+B pressed while
+ * listening had nowhere to go.
+ *
+ * Only `manual` marks are ever requested. The same server table holds the web player's jump-back
+ * breadcrumbs as `auto`, and a day of listening writes a few hundred of those — a list that mixed
+ * them in would bury the handful of marks somebody actually chose.
+ */
+class BookmarksStateHolder(
+    private val repository: TtsRoadRepository,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : StateHolder(dispatcher) {
+    private val _state = MutableStateFlow(BookmarksUiState())
+    val state: StateFlow<BookmarksUiState> = _state.asStateFlow()
+
+    private var loadJob: Job? = null
+
+    /** Loads once. What the bookmarks screen calls on entry; a second visit costs nothing. */
+    fun ensureLoaded() {
+        if (_state.value.loaded || _state.value.loading) return
+        refresh()
+    }
+
+    fun refresh() {
+        loadJob?.cancel()
+        _state.update { it.copy(loading = true, error = null) }
+        loadJob = scope.launch {
+            val outcome = runCatching { repository.bookmarks() }
+            _state.update { current ->
+                outcome.fold(
+                    onSuccess = { list ->
+                        if (list == null) {
+                            current.copy(loading = false, loaded = true, unsupported = true, bookmarks = emptyList())
+                        } else {
+                            current.copy(
+                                loading = false,
+                                loaded = true,
+                                unsupported = false,
+                                error = null,
+                                bookmarks = list.visibleBookmarks(),
+                            )
+                        }
+                    },
+                    // The list already on screen is kept. A failed refresh is the same situation as
+                    // a failed library refresh: a banner over retained content explains more than
+                    // an empty screen does.
+                    onFailure = { failure ->
+                        current.copy(
+                            loading = false,
+                            loaded = true,
+                            error = userFacingMessage(failure, "Could not load bookmarks"),
+                        )
+                    },
+                )
+            }
+        }
+    }
+
+    /**
+     * Marks [positionMs] in [chapterId].
+     *
+     * Fire-and-forget by design: this is pressed mid-chapter, from a screen that is not the list,
+     * so it must never open a dialog or block the transport. Labelling and annotating happen later
+     * on the bookmarks screen, where there is room for them.
+     */
+    fun add(chapterId: Int, positionMs: Long, label: String? = null) {
+        if (chapterId <= 0) return
+        scope.launch {
+            val outcome = runCatching {
+                repository.createBookmark(
+                    BookmarkCreateRequest(
+                        chapterId = chapterId,
+                        positionSeconds = positionMs.coerceAtLeast(0L) / 1000.0,
+                        label = label?.trim()?.take(BookmarkLimits.MaxLabelChars)?.takeIf { it.isNotEmpty() },
+                    ),
+                )
+            }
+            _state.update { current ->
+                outcome.fold(
+                    onSuccess = { created ->
+                        if (created == null) {
+                            current.copy(unsupported = true, notice = "This server has no bookmarks")
+                        } else {
+                            current.copy(
+                                // Prepended rather than re-fetched: the list is already correct and
+                                // a round trip would make the confirmation arrive after it.
+                                bookmarks = (listOf(created) + current.bookmarks.filterNot { it.id == created.id }),
+                                notice = "Bookmarked at ${created.positionLabel ?: formatDuration(created.positionMs)}",
+                            )
+                        }
+                    },
+                    onFailure = { failure ->
+                        current.copy(notice = userFacingMessage(failure, "Could not save the bookmark"))
+                    },
+                )
+            }
+        }
+    }
+
+    /**
+     * Edits a mark's label and note.
+     *
+     * A blank string is sent as `""` rather than omitted, which is how the server distinguishes
+     * "clear this" from "leave it alone" — an absent key means the latter. See [BookmarkPatchRequest].
+     */
+    fun edit(bookmarkId: Int, label: String, note: String) {
+        scope.launch {
+            val outcome = runCatching {
+                repository.updateBookmark(bookmarkId, BookmarkPatchRequest(label = label, note = note))
+            }
+            _state.update { current ->
+                outcome.fold(
+                    onSuccess = { updated ->
+                        if (updated == null) {
+                            current.copy(notice = "That bookmark is no longer there")
+                        } else {
+                            current.copy(
+                                bookmarks = current.bookmarks.map { if (it.id == updated.id) updated else it },
+                                notice = "Bookmark saved",
+                            )
+                        }
+                    },
+                    onFailure = { failure ->
+                        current.copy(notice = userFacingMessage(failure, "Could not save the bookmark"))
+                    },
+                )
+            }
+        }
+    }
+
+    /**
+     * Deletes a mark, optimistically.
+     *
+     * The row leaves immediately and comes back only if the request fails. The server's delete is
+     * idempotent — a second one answers the first one's tombstone rather than 404 — so the retry a
+     * user makes after a dropped connection cannot produce an error about a row that is already
+     * gone.
+     */
+    fun remove(bookmarkId: Int) {
+        val removed = _state.value.bookmarks.firstOrNull { it.id == bookmarkId } ?: return
+        val index = _state.value.bookmarks.indexOf(removed)
+        _state.update { it.copy(bookmarks = it.bookmarks.filterNot { row -> row.id == bookmarkId }) }
+        scope.launch {
+            val outcome = runCatching { repository.deleteBookmark(bookmarkId) }
+            _state.update { current ->
+                val failed = outcome.getOrNull() != true
+                if (!failed) {
+                    current.copy(notice = "Bookmark removed")
+                } else {
+                    current.copy(
+                        // Put back exactly where it was, so a failed delete does not also reorder
+                        // the list under the user's cursor.
+                        bookmarks = current.bookmarks.toMutableList().apply {
+                            add(index.coerceIn(0, size), removed)
+                        },
+                        notice = outcome.exceptionOrNull()
+                            ?.let { userFacingMessage(it, "Could not remove the bookmark") }
+                            ?: "Could not remove the bookmark",
+                    )
+                }
+            }
+        }
+    }
+
+    fun dismissNotice() {
+        _state.update { it.copy(notice = null) }
+    }
+
+    /** The account's bookmarks are the account's. Dropped with the session, like the library. */
+    fun sessionEnded() {
+        loadJob?.cancel()
+        _state.value = BookmarksUiState()
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreen.kt
@@ -91,6 +91,9 @@ fun PlayerScreen(
      */
     preferences: PlaybackPreferencesStore = remember { InMemoryPlaybackPreferencesStore() },
     readAlongAvailable: Boolean = false,
+    /** Capability-gated like read-along: no control at all where the server has no bookmark API. */
+    bookmarksAvailable: Boolean = false,
+    onAddBookmark: () -> Unit = {},
     onOpenReader: (chapterId: Int, title: String) -> Unit = { _, _ -> },
     onBack: () -> Unit,
 ) {
@@ -114,6 +117,8 @@ fun PlayerScreen(
                     preferences,
                     compact = true,
                     readAlongAvailable = readAlongAvailable,
+                    bookmarksAvailable = bookmarksAvailable,
+                    onAddBookmark = onAddBookmark,
                     onOpenReader = onOpenReader,
                     modifier = Modifier.fillMaxWidth(),
                 )
@@ -131,6 +136,8 @@ fun PlayerScreen(
                         preferences,
                         compact = false,
                         readAlongAvailable = readAlongAvailable,
+                        bookmarksAvailable = bookmarksAvailable,
+                        onAddBookmark = onAddBookmark,
                         onOpenReader = onOpenReader,
                         modifier = Modifier.align(Alignment.TopCenter).widthIn(max = NarrowMaxWidth)
                             .fillMaxWidth().fillMaxHeight(),
@@ -153,6 +160,8 @@ private fun PlayerMain(
     preferences: PlaybackPreferencesStore,
     compact: Boolean,
     readAlongAvailable: Boolean,
+    bookmarksAvailable: Boolean,
+    onAddBookmark: () -> Unit,
     onOpenReader: (chapterId: Int, title: String) -> Unit,
     modifier: Modifier,
 ) {
@@ -188,16 +197,23 @@ private fun PlayerMain(
             MetaText(it)
         }
         val chapterId = s.queue.getOrNull(s.currentIndex)?.chapterId ?: 0
-        if (readAlongAvailable && chapterId > 0) {
+        if ((readAlongAvailable || bookmarksAvailable) && chapterId > 0) {
             Spacer(Modifier.height(12.dp))
-            OutlinedButton(
-                onClick = { onOpenReader(chapterId, s.title) },
-                shape = androidx.compose.ui.graphics.RectangleShape,
-                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-            ) {
-                Icon(Icons.AutoMirrored.Filled.MenuBook, contentDescription = null, Modifier.size(18.dp))
-                Spacer(Modifier.width(8.dp))
-                Text("READ ALONG")
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                if (readAlongAvailable) {
+                    OutlinedButton(
+                        onClick = { onOpenReader(chapterId, s.title) },
+                        shape = androidx.compose.ui.graphics.RectangleShape,
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.MenuBook, contentDescription = null, Modifier.size(18.dp))
+                        Spacer(Modifier.width(8.dp))
+                        Text("READ ALONG")
+                    }
+                }
+                // Enabled on loaded media rather than on "is playing": marking the spot you just
+                // paused at is the most ordinary reason to reach for this at all.
+                if (bookmarksAvailable) BookmarkAction(enabled = s.hasMedia, onClick = onAddBookmark)
             }
         }
         Spacer(Modifier.height(20.dp))

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.BookmarkAdd
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.Search
@@ -108,6 +109,7 @@ const val ReaderListTestTag: String = "readerList"
 const val ReaderFindFieldTestTag: String = "readerFindField"
 const val ReaderSettingsButtonTestTag: String = "readerSettingsButton"
 const val ReaderParagraphTestTag: String = "readerParagraph"
+const val ReaderBookmarkButtonTestTag: String = "readerBookmarkButton"
 
 data class ReaderPalette(
     val background: Color,
@@ -149,6 +151,51 @@ fun readerAutoScrollOffsetPx(viewportHeightPx: Int): Int =
 fun readerShouldPrefetch(positionMs: Long, durationMs: Long): Boolean =
     durationMs > 0L && positionMs.coerceAtLeast(0L).toDouble() / durationMs >= 0.8
 
+/** Where a bookmark made in the reader points, and what it ends up called. */
+data class ReaderBookmarkAnchor(val positionMs: Long, val label: String?)
+
+/**
+ * How long a sentence may be before it is elided into a label.
+ *
+ * A label is a row in a list, not the passage itself — the note field is where a whole paragraph
+ * belongs. Well under the server's 512-character limit on purpose: the truncation the user sees
+ * should be this one, made for readability, rather than a silent one made for a database column.
+ */
+const val ReaderBookmarkLabelChars: Int = 160
+
+/**
+ * Where a mark made from the reader points, or null when the reader cannot honestly place one.
+ *
+ * Pure, because the *judgement* is the interesting part and it has three distinct cases. Reading a
+ * chapter that is not playing, or one whose timings do not match the audio, gives no position at
+ * all — a bookmark at 0:00 on a chapter somebody was reading at leisure is worse than no bookmark,
+ * and this is the same rule that already disables highlighting.
+ *
+ * Given a position, the *sentence start* beats the millisecond the button was pressed: a listener
+ * marking a passage means the passage, not the syllable. Falling back to the raw position covers
+ * the gaps between cues, where there is no sentence to anchor to.
+ */
+fun readerBookmarkAnchor(
+    isPlayingThisChapter: Boolean,
+    timingsMatch: Boolean,
+    positionMs: Long,
+    sentenceStartSeconds: Double?,
+    sentenceText: String?,
+): ReaderBookmarkAnchor? {
+    if (!isPlayingThisChapter || !timingsMatch) return null
+    val anchored = sentenceStartSeconds
+        ?.takeIf { it.isFinite() && it >= 0.0 }
+        ?.let { (it * 1000.0).roundToLong() }
+        ?: positionMs
+    val label = sentenceText?.trim()?.replace(WhitespaceRun, " ")?.takeIf { it.isNotEmpty() }?.let {
+        if (it.length <= ReaderBookmarkLabelChars) it else it.take(ReaderBookmarkLabelChars).trimEnd() + "…"
+    }
+    return ReaderBookmarkAnchor(anchored.coerceAtLeast(0L), label)
+}
+
+/** Narration text is laid out with newlines in it; a label is one line. */
+private val WhitespaceRun = Regex("\\s+")
+
 /** Audio-linked reader that remains useful as a plain, selectable document with no playback. */
 @Composable
 fun ReaderScreen(
@@ -157,6 +204,9 @@ fun ReaderScreen(
     cache: ReadAlongCache,
     preferences: ReaderPreferencesStore,
     playback: PlaybackController,
+    /** Capability-gated like everywhere else: no control at all without the server API. */
+    bookmarksAvailable: Boolean = false,
+    onAddBookmark: (positionMs: Long, label: String?) -> Unit = { _, _ -> },
     onBack: () -> Unit,
     onChapterAdvanced: (chapterId: Int, title: String) -> Unit,
 ) {
@@ -226,6 +276,8 @@ fun ReaderScreen(
                 playback = playback,
                 prefs = prefs,
                 palette = palette,
+                bookmarksAvailable = bookmarksAvailable,
+                onAddBookmark = onAddBookmark,
                 onBack = onBack,
                 onOpenSettings = { showSettings = true },
             )
@@ -249,6 +301,8 @@ private fun ReaderDocumentPage(
     playback: PlaybackController,
     prefs: ReaderPreferences,
     palette: ReaderPalette,
+    bookmarksAvailable: Boolean,
+    onAddBookmark: (positionMs: Long, label: String?) -> Unit,
     onBack: () -> Unit,
     onOpenSettings: () -> Unit,
 ) {
@@ -264,6 +318,16 @@ private fun ReaderDocumentPage(
         else ReadAlongHighlight.None
     }
     val activeParagraph = highlight.word?.let { document.paragraphIndexAt(it.start) } ?: -1
+
+    val bookmarkAnchor = remember(document, highlight, isPlayingThisChapter, timingsMatch, player.positionMs) {
+        readerBookmarkAnchor(
+            isPlayingThisChapter = isPlayingThisChapter,
+            timingsMatch = timingsMatch,
+            positionMs = player.positionMs,
+            sentenceStartSeconds = highlight.sentence?.let { document.seekSecondsForOffset(it.start) },
+            sentenceText = highlight.sentence?.let { document.textIn(it) },
+        )
+    }
 
     LaunchedEffect(listState) {
         listState.interactionSource.interactions.collect { interaction ->
@@ -350,6 +414,13 @@ private fun ReaderDocumentPage(
             ReaderToolbar(
                 title = document.title.ifBlank { "Chapter" },
                 palette = palette,
+                // Present but inert while reading a chapter that is not playing: hiding it as the
+                // narration catches up would move the other toolbar buttons under the cursor.
+                bookmarkEnabled = bookmarksAvailable && bookmarkAnchor != null,
+                showBookmark = bookmarksAvailable,
+                onBookmark = {
+                    bookmarkAnchor?.let { onAddBookmark(it.positionMs, it.label) }
+                },
                 onBack = onBack,
                 onFind = { findOpen = !findOpen },
                 onSettings = onOpenSettings,
@@ -436,6 +507,9 @@ private fun ReaderDocumentPage(
 private fun ReaderToolbar(
     title: String,
     palette: ReaderPalette,
+    bookmarkEnabled: Boolean,
+    showBookmark: Boolean,
+    onBookmark: () -> Unit,
     onBack: () -> Unit,
     onFind: () -> Unit,
     onSettings: () -> Unit,
@@ -448,6 +522,19 @@ private fun ReaderToolbar(
             Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back", tint = palette.ink)
         }
         Text(title, color = palette.ink, maxLines = 1, modifier = Modifier.weight(1f))
+        if (showBookmark) {
+            IconButton(
+                onClick = onBookmark,
+                enabled = bookmarkEnabled,
+                modifier = Modifier.testTag(ReaderBookmarkButtonTestTag),
+            ) {
+                Icon(
+                    Icons.Default.BookmarkAdd,
+                    "Bookmark this passage",
+                    tint = if (bookmarkEnabled) palette.ink else palette.muted,
+                )
+            }
+        }
         IconButton(onClick = onFind) { Icon(Icons.Default.Search, "Find in chapter", tint = palette.ink) }
         IconButton(onClick = onSettings, modifier = Modifier.testTag(ReaderSettingsButtonTestTag)) {
             Icon(Icons.Default.Settings, "Reading settings", tint = palette.ink)

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -1,5 +1,8 @@
 package dk.perspektiva.ttsroad.desktop
 
+import dk.perspektiva.ttsroad.desktop.data.Bookmark
+import dk.perspektiva.ttsroad.desktop.data.BookmarkCreateRequest
+import dk.perspektiva.ttsroad.desktop.data.BookmarkPatchRequest
 import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
 import dk.perspektiva.ttsroad.desktop.data.ChaptersResponse
 import dk.perspektiva.ttsroad.desktop.data.DeviceSession
@@ -45,6 +48,11 @@ open class FakeRepository(
     var browseAllResult: Result<LibraryResponse> = Result.success(LibraryResponse()),
     /** Null means "echo what was asked". `success(null)` is the server's 404. */
     var followResult: Result<Boolean?>? = null,
+    /** `success(null)` is the server saying it has no bookmark API — not "no bookmarks". */
+    var bookmarksResult: Result<List<Bookmark>?> = Result.success(emptyList()),
+    var createBookmarkResult: Result<Bookmark?> = Result.success(Bookmark(id = 1)),
+    var updateBookmarkResult: Result<Bookmark?> = Result.success(Bookmark(id = 1)),
+    var deleteBookmarkResult: Result<Boolean> = Result.success(true),
 ) : TtsRoadRepository {
     var loginCalls: Int = 0
         private set
@@ -81,6 +89,12 @@ open class FakeRepository(
     val followCalls: MutableList<Pair<Int, Boolean>> = mutableListOf()
     val markedPlayed: MutableList<Pair<List<Int>, Boolean>> = mutableListOf()
     val savedProgress: MutableList<Triple<Int, Double, Boolean>> = mutableListOf()
+
+    /** Bookmark traffic, in order — the `kind` filter is part of what the tests assert. */
+    val bookmarkListCalls: MutableList<Pair<String?, Int?>> = mutableListOf()
+    val createdBookmarks: MutableList<BookmarkCreateRequest> = mutableListOf()
+    val patchedBookmarks: MutableList<Pair<Int, BookmarkPatchRequest>> = mutableListOf()
+    val deletedBookmarks: MutableList<Int> = mutableListOf()
 
     private val _currentCapabilities = MutableStateFlow(ServerCapabilities.Baseline)
     override val currentCapabilities: StateFlow<ServerCapabilities> = _currentCapabilities.asStateFlow()
@@ -192,6 +206,35 @@ open class FakeRepository(
         return PlaybackMarkResponse(status = "ok", played = played, chapterIds = chapterIds, count = chapterIds.size)
     }
 
+    override suspend fun bookmarks(kind: String?, fictionId: Int?): List<Bookmark>? {
+        bookmarkListCalls += kind to fictionId
+        return bookmarksResult.getOrThrow()
+    }
+
+    override suspend fun createBookmark(request: BookmarkCreateRequest): Bookmark? {
+        createdBookmarks += request
+        return createBookmarkResult.getOrThrow()?.copy(
+            chapterId = request.chapterId,
+            positionSeconds = request.positionSeconds,
+            label = request.label,
+            note = request.note,
+        )
+    }
+
+    override suspend fun updateBookmark(bookmarkId: Int, request: BookmarkPatchRequest): Bookmark? {
+        patchedBookmarks += bookmarkId to request
+        return updateBookmarkResult.getOrThrow()?.copy(
+            id = bookmarkId,
+            label = request.label,
+            note = request.note,
+        )
+    }
+
+    override suspend fun deleteBookmark(bookmarkId: Int): Boolean {
+        deletedBookmarks += bookmarkId
+        return deleteBookmarkResult.getOrThrow()
+    }
+
     override suspend fun saveProgress(
         fictionId: Int,
         chapterId: Int,
@@ -240,8 +283,13 @@ class FakePlaybackController(initial: PlayerUiState = PlayerUiState()) : Playbac
         chapters: List<ChapterSummary>,
         startChapterId: Int,
         fiction: FictionSummary?,
+        startPositionMs: Long?,
     ) {
-        calls += "playQueue($startChapterId)"
+        calls += if (startPositionMs == null) {
+            "playQueue($startChapterId)"
+        } else {
+            "playQueue($startChapterId@$startPositionMs)"
+        }
     }
 
     override fun togglePlayPause() {

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ServerFixtures.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ServerFixtures.kt
@@ -439,6 +439,112 @@ object ServerFixtures {
     val MARK_OK = """{"status": "ok", "played": true, "chapter_ids": [101], "count": 1}"""
 
     /**
+     * GET /api/mobile/bookmarks — 200, as `app/services/bookmarks.py` serialises it.
+     *
+     * Carries `user_id`, which this client deliberately does not model — every row already belongs
+     * to the account that asked. It also carries a tombstone the server would normally have
+     * filtered out and an `auto` breadcrumb, because the client must not depend on either being
+     * absent: the list query decides, and the jump-back marks the web player writes live in this
+     * same table.
+     */
+    val BOOKMARKS = """
+        {
+          "api_version": 1,
+          "server_time": "2027-01-01T12:00:00Z",
+          "updated_since": null,
+          "bookmarks": [
+            {
+              "id": 9,
+              "user_id": 1,
+              "chapter_id": 101,
+              "fiction_id": 7,
+              "position_seconds": 742.5,
+              "position_label": "12:22",
+              "label": "The bridge scene",
+              "note": "Come back to this for the epigraph.",
+              "color": null,
+              "kind": "manual",
+              "created_at": "2027-01-01T09:00:00Z",
+              "updated_at": "2027-01-01T09:00:00Z",
+              "deleted_at": null,
+              "chapter_title": "Chapter 3",
+              "chapter_number": 3,
+              "fiction_title": "A Test Serial",
+              "fiction_slug": "a-test-serial"
+            },
+            {
+              "id": 11,
+              "user_id": 1,
+              "chapter_id": null,
+              "fiction_id": null,
+              "position_seconds": 30.0,
+              "position_label": "0:30",
+              "label": "On a chapter that was deleted",
+              "note": null,
+              "color": null,
+              "kind": "manual",
+              "created_at": "2027-01-02T09:00:00Z",
+              "updated_at": "2027-01-02T09:00:00Z",
+              "deleted_at": null,
+              "chapter_title": null,
+              "chapter_number": null,
+              "fiction_title": null,
+              "fiction_slug": null
+            },
+            {
+              "id": 12,
+              "user_id": 1,
+              "chapter_id": 101,
+              "fiction_id": 7,
+              "position_seconds": 5.0,
+              "position_label": "0:05",
+              "label": null,
+              "note": null,
+              "color": null,
+              "kind": "manual",
+              "created_at": "2026-12-30T09:00:00Z",
+              "updated_at": "2027-01-03T09:00:00Z",
+              "deleted_at": "2027-01-03T09:00:00Z",
+              "chapter_title": "Chapter 3",
+              "chapter_number": 3,
+              "fiction_title": "A Test Serial",
+              "fiction_slug": "a-test-serial"
+            }
+          ],
+          "deleted": []
+        }
+    """.trimIndent()
+
+    /** POST /api/mobile/bookmarks — 201. */
+    val BOOKMARK_CREATED = """
+        {
+          "api_version": 1,
+          "bookmark": {
+            "id": 21,
+            "user_id": 1,
+            "chapter_id": 101,
+            "fiction_id": 7,
+            "position_seconds": 61.25,
+            "position_label": "1:01",
+            "label": null,
+            "note": null,
+            "color": null,
+            "kind": "manual",
+            "created_at": "2027-01-04T09:00:00Z",
+            "updated_at": "2027-01-04T09:00:00Z",
+            "deleted_at": null,
+            "chapter_title": "Chapter 3",
+            "chapter_number": 3,
+            "fiction_title": "A Test Serial",
+            "fiction_slug": "a-test-serial"
+          }
+        }
+    """.trimIndent()
+
+    /** DELETE /api/mobile/bookmarks/{id} — 200, and the same answer a second time. */
+    val BOOKMARK_DELETED = """{"api_version": 1, "status": "deleted", "id": 9, "deleted_at": "2027-01-04T10:00:00Z"}"""
+
+    /**
      * GET /api/mobile/search — 200, one hit in each of the three groups.
      *
      * Reproduces the shape `app/services/search.py` actually emits: one item type across all three

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/BookmarksTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/BookmarksTest.kt
@@ -1,0 +1,222 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import dk.perspektiva.ttsroad.desktop.ServerFixtures
+import dk.perspektiva.ttsroad.desktop.authedClient
+import dk.perspektiva.ttsroad.desktop.bodyText
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.Headers
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/** `/api/mobile/bookmarks`: request shape, the manual filter, and what an older server means. */
+@OptIn(ExperimentalCoroutinesApi::class)
+class BookmarksTest {
+    private lateinit var server: MockWebServer
+    private lateinit var repository: RetrofitTtsRoadRepository
+
+    private val jsonHeaders = Headers.headersOf("Content-Type", "application/json")
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        val sessionStore = InMemorySessionStore(
+            SessionState(serverUrl = server.url("/").toString(), token = "ttsr_token", username = "admin"),
+        )
+        repository = RetrofitTtsRoadRepository(
+            sessionStore = sessionStore,
+            client = authedClient(sessionStore),
+            ioDispatcher = UnconfinedTestDispatcher(),
+            deviceNameProvider = { "test-host" },
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.close()
+    }
+
+    private fun enqueue(code: Int, body: String) {
+        server.enqueue(MockResponse(code = code, headers = jsonHeaders, body = body))
+    }
+
+    @Test
+    fun `listing asks for manual marks only and sends the bearer header`() = runTest {
+        enqueue(200, ServerFixtures.BOOKMARKS)
+
+        val bookmarks = repository.bookmarks()
+
+        val request = server.takeRequest()
+        assertEquals("GET", request.method)
+        assertEquals("/api/mobile/bookmarks", request.url.encodedPath)
+        // The whole reason the default is not null: the same table holds the web player's `auto`
+        // jump-back breadcrumbs, and a day of listening writes hundreds of them.
+        assertEquals("manual", request.url.queryParameter("kind"))
+        assertEquals("Bearer ttsr_token", request.headers["Authorization"])
+        assertEquals(3, bookmarks?.size)
+    }
+
+    @Test
+    fun `a fiction filter is sent only when asked for`() = runTest {
+        enqueue(200, ServerFixtures.BOOKMARKS)
+
+        repository.bookmarks(fictionId = 7)
+
+        val request = server.takeRequest()
+        assertEquals("7", request.url.queryParameter("fiction_id"))
+    }
+
+    @Test
+    fun `unknown additive fields and a null chapter link both survive parsing`() = runTest {
+        enqueue(200, ServerFixtures.BOOKMARKS)
+
+        val bookmarks = repository.bookmarks().orEmpty()
+
+        val orphan = bookmarks.first { it.id == 11 }
+        // A chapter can be hard-deleted, and the server clears the link rather than cascading the
+        // row away. A non-null assertion anywhere on this path is a crash waiting for that day.
+        assertNull(orphan.chapterId)
+        assertNull(orphan.fictionId)
+        assertFalse(orphan.isPlayable)
+        assertTrue(bookmarks.first { it.id == 9 }.isPlayable)
+    }
+
+    @Test
+    fun `a 404 is an older server, not an error`() = runTest {
+        enqueue(404, ServerFixtures.NOT_FOUND)
+
+        // Null rather than empty: "this server has no bookmarks API" and "you have no bookmarks"
+        // are different answers and the UI shows different things for them.
+        assertNull(repository.bookmarks())
+    }
+
+    @Test
+    fun `creating sends the position in seconds and defaults to a manual mark`() = runTest {
+        enqueue(201, ServerFixtures.BOOKMARK_CREATED)
+
+        val created = repository.createBookmark(
+            BookmarkCreateRequest(chapterId = 101, positionSeconds = 61.25),
+        )
+
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/api/mobile/bookmarks", request.url.encodedPath)
+        val body = request.bodyText()
+        assertTrue(body.contains("\"chapter_id\":101"), body)
+        assertTrue(body.contains("\"position_seconds\":61.25"), body)
+        assertTrue(body.contains("\"kind\":\"manual\""), body)
+        assertEquals(21, created?.id)
+    }
+
+    @Test
+    fun `an over-long label is shortened rather than rejected`() = runTest {
+        enqueue(201, ServerFixtures.BOOKMARK_CREATED)
+
+        repository.createBookmark(
+            BookmarkCreateRequest(
+                chapterId = 101,
+                positionSeconds = 1.0,
+                label = "x".repeat(BookmarkLimits.MaxLabelChars + 50),
+            ),
+        )
+
+        // The server truncates to exactly this limit anyway, so trimming here turns what would be
+        // a rejected request into a slightly shorter bookmark.
+        val body = server.takeRequest().bodyText()
+        assertTrue(body.contains("\"label\":\"${"x".repeat(BookmarkLimits.MaxLabelChars)}\""), body)
+    }
+
+    @Test
+    fun `a negative position is clamped before it is sent`() = runTest {
+        enqueue(201, ServerFixtures.BOOKMARK_CREATED)
+
+        repository.createBookmark(BookmarkCreateRequest(chapterId = 101, positionSeconds = -12.0))
+
+        assertTrue(server.takeRequest().bodyText().contains("\"position_seconds\":0.0"))
+    }
+
+    @Test
+    fun `a patch omits the fields it was not given`() = runTest {
+        enqueue(200, ServerFixtures.BOOKMARK_CREATED)
+
+        repository.updateBookmark(9, BookmarkPatchRequest(label = "Renamed"))
+
+        val request = server.takeRequest()
+        assertEquals("PATCH", request.method)
+        assertEquals("/api/mobile/bookmarks/9", request.url.encodedPath)
+        val body = request.bodyText()
+        assertTrue(body.contains("\"label\":\"Renamed\""), body)
+        // Absent means "leave it alone" on the server, so a rename must not blank the note.
+        assertFalse(body.contains("note"), body)
+        assertFalse(body.contains("position_seconds"), body)
+    }
+
+    @Test
+    fun `an empty string is how a field is cleared`() = runTest {
+        enqueue(200, ServerFixtures.BOOKMARK_CREATED)
+
+        repository.updateBookmark(9, BookmarkPatchRequest(label = "", note = ""))
+
+        // `_clean_text` turns a blank into null server-side, which keeps "clear it" expressible
+        // without serialising an explicit JSON null that Moshi would drop.
+        val body = server.takeRequest().bodyText()
+        assertTrue(body.contains("\"label\":\"\""), body)
+        assertTrue(body.contains("\"note\":\"\""), body)
+    }
+
+    @Test
+    fun `deleting reports success, and a second delete is still a success`() = runTest {
+        enqueue(200, ServerFixtures.BOOKMARK_DELETED)
+        enqueue(200, ServerFixtures.BOOKMARK_DELETED)
+
+        assertTrue(repository.deleteBookmark(9))
+        assertEquals("DELETE", server.takeRequest().method)
+        // Idempotent by design: the server answers the first delete's tombstone rather than 404,
+        // so the retry after a dropped connection cannot error about an already-gone row.
+        assertTrue(repository.deleteBookmark(9))
+    }
+
+    @Test
+    fun `deleting on a server with no bookmark API reports failure rather than throwing`() = runTest {
+        enqueue(404, ServerFixtures.NOT_FOUND)
+
+        assertFalse(repository.deleteBookmark(9))
+    }
+
+    @Test
+    fun `the visible list drops tombstones and puts the newest first`() {
+        val rows = listOf(
+            Bookmark(id = 1, createdAt = "2027-01-01T09:00:00Z"),
+            Bookmark(id = 2, createdAt = "2027-01-03T09:00:00Z"),
+            Bookmark(id = 3, createdAt = "2027-01-02T09:00:00Z", deletedAt = "2027-01-04T09:00:00Z"),
+        )
+
+        // Filtered here rather than trusted from the shape: the server's list query decides whether
+        // a soft-deleted row comes back, and a mark that reappears after a refresh is a bug the
+        // user reads as "delete does not work".
+        assertEquals(listOf(2, 1), rows.visibleBookmarks().map { it.id })
+    }
+
+    @Test
+    fun `a row falls back through label, chapter title and position for its name`() {
+        assertEquals("Chosen", Bookmark(label = "Chosen", chapterTitle = "Chapter 3").displayLabel)
+        assertEquals("Chapter 3", Bookmark(label = "  ", chapterTitle = "Chapter 3").displayLabel)
+        assertEquals("12:22", Bookmark(positionLabel = "12:22").displayLabel)
+        assertEquals("Bookmark", Bookmark().displayLabel)
+    }
+
+    @Test
+    fun `position converts to whole milliseconds and never goes negative`() {
+        assertEquals(742_500L, Bookmark(positionSeconds = 742.5).positionMs)
+        assertEquals(0L, Bookmark(positionSeconds = -1.0).positionMs)
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/nav/AppNavigationTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/nav/AppNavigationTest.kt
@@ -40,10 +40,22 @@ class AppNavigationTest {
             fiction(7),
             Destination.Player,
             Destination.Reader(101, "Chapter 3"),
+            Destination.Bookmarks,
             Destination.Settings,
             Destination.Devices,
         )
         assertEquals(destinations.size, destinations.map { it.key }.toSet().size)
+    }
+
+    @Test
+    fun `opening bookmarks twice reuses the one entry`() {
+        // Bookmarks carries no payload — the list lives in the hoisted holder — so re-opening it
+        // from the header after following a mark pops back rather than stacking a second copy.
+        var stack = rootBackStack.navigateTo(Destination.Bookmarks).navigateTo(Destination.Player)
+
+        stack = stack.navigateTo(Destination.Bookmarks)
+
+        assertEquals(listOf(Destination.Library, Destination.Bookmarks), stack)
     }
 
     // --- Push / pop ------------------------------------------------------------------------

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/nav/ShortcutsTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/nav/ShortcutsTest.kt
@@ -155,6 +155,42 @@ class ShortcutsTest {
         }
     }
 
+    // --- Bookmarks ----------------------------------------------------------------------------
+
+    @Test
+    fun `Ctrl-B marks the spot and Ctrl-Shift-B opens the list`() {
+        assertEquals(AppShortcut.AddBookmark, shortcutFor(Key.B, KeyEventType.KeyDown, ctrl = true))
+        // Checked before the bare mark, so the list shortcut does not also bookmark on its way past.
+        assertEquals(
+            AppShortcut.OpenBookmarks,
+            shortcutFor(Key.B, KeyEventType.KeyDown, ctrl = true, shift = true),
+        )
+    }
+
+    @Test
+    fun `Cmd-B marks the spot, for the mac build`() {
+        assertEquals(AppShortcut.AddBookmark, shortcutFor(Key.B, KeyEventType.KeyDown, meta = true))
+    }
+
+    @Test
+    fun `an unmodified B is a letter, not a shortcut`() {
+        assertNull(shortcutFor(Key.B, KeyEventType.KeyDown))
+    }
+
+    @Test
+    fun `both bookmark shortcuts stay live while typing`() {
+        // Checked against the one text field that could plausibly claim Ctrl+B: the library's
+        // search box is a plain text field with no bold to toggle, so nothing consumes it.
+        assertEquals(
+            AppShortcut.AddBookmark,
+            shortcutFor(Key.B, KeyEventType.KeyDown, ctrl = true, textInputFocused = true),
+        )
+        assertEquals(
+            AppShortcut.OpenBookmarks,
+            shortcutFor(Key.B, KeyEventType.KeyDown, ctrl = true, shift = true, textInputFocused = true),
+        )
+    }
+
     @Test
     fun `the help table is not empty and every row is filled in`() {
         assertTrue(ShortcutHelpTable.isNotEmpty())

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackControllerTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackControllerTest.kt
@@ -159,6 +159,43 @@ class QueuePlaybackControllerTest {
     }
 
     @Test
+    fun `opening a bookmark starts at the mark rather than at the saved position`() = runBlocking {
+        val engine = FakePlaybackEngine(completeOnPlay = true)
+        val controller = controllerFor(engine)
+
+        controller.playQueue(
+            listOf(chapter(101, "Chapter 3", durationSeconds = 900.0, position = 30.0)),
+            startChapterId = 101,
+            fiction = FictionSummary(id = 7, title = "A Test Serial"),
+            startPositionMs = 742_500L,
+        )
+        controller.await("playback to finish", ::finished)
+
+        // Resuming at 0:30 here would silently ignore the mark the user just clicked.
+        assertEquals(listOf(742_500L), engine.preparedPositions.toList())
+        controller.release()
+    }
+
+    @Test
+    fun `a bookmark on a chapter that is no longer playable falls back to the saved position`() = runBlocking {
+        val engine = FakePlaybackEngine(completeOnPlay = true)
+        val controller = controllerFor(engine)
+
+        controller.playQueue(
+            listOf(chapter(101, "Chapter 3", durationSeconds = 900.0, position = 30.0)),
+            // The chapter the mark points at has lost its audio, so the queue starts elsewhere —
+            // and seeking *that* chapter to the missing one's offset would be nonsense.
+            startChapterId = 999,
+            fiction = FictionSummary(id = 7, title = "A Test Serial"),
+            startPositionMs = 742_500L,
+        )
+        controller.await("playback to finish", ::finished)
+
+        assertEquals(listOf(30_000L), engine.preparedPositions.toList())
+        controller.release()
+    }
+
+    @Test
     fun `a chapter with no audio at all reports a clear error instead of playing`() = runBlocking {
         val controller = controllerFor(FakePlaybackEngine())
 

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/BookmarksScreenUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/BookmarksScreenUiTest.kt
@@ -146,6 +146,9 @@ class BookmarksScreenUiTest {
 
         compose.onNodeWithTag(BookmarkDeleteTestTag).performClick()
         compose.onNodeWithTag(BookmarkConfirmDeleteTestTag).performClick()
+        // The holder does the delete in a coroutine, and a click only guarantees the *dispatch*.
+        // Asserting straight after the press is what made this test flaky.
+        compose.waitUntil(5_000) { repository.deletedBookmarks.isNotEmpty() }
         assertEquals(listOf(1), repository.deletedBookmarks)
     }
 
@@ -163,6 +166,8 @@ class BookmarksScreenUiTest {
         compose.onNodeWithTag(BookmarkLabelFieldTestTag).performTextInput("!")
         compose.onNodeWithText("SAVE").performClick()
 
+        // Same reason as the delete test: the PATCH is launched, not performed, by the press.
+        compose.waitUntil(5_000) { repository.patchedBookmarks.isNotEmpty() }
         val (id, patch) = repository.patchedBookmarks.single()
         assertEquals(1, id)
         assertTrue(patch.label.orEmpty().contains("bridge"))

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/BookmarksScreenUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/BookmarksScreenUiTest.kt
@@ -1,0 +1,232 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.FakePlaybackController
+import dk.perspektiva.ttsroad.desktop.data.Bookmark
+import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
+import dk.perspektiva.ttsroad.desktop.player.PlayerUiState
+import dk.perspektiva.ttsroad.desktop.player.QueueItem
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * The bookmarks screen as a user meets it.
+ *
+ * The state machine is covered in [BookmarksStateHolderTest]; what is asserted here is what the
+ * rows render, that removing is behind a confirmation, and that a mark whose chapter is gone still
+ * shows without offering to play audio that no longer exists.
+ */
+@OptIn(ExperimentalTestApi::class, ExperimentalCoroutinesApi::class)
+class BookmarksScreenUiTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private fun bookmark(
+        id: Int,
+        label: String? = "The bridge scene",
+        chapterId: Int? = 101,
+        fictionId: Int? = 7,
+    ) = Bookmark(
+        id = id,
+        chapterId = chapterId,
+        fictionId = fictionId,
+        positionSeconds = 742.5,
+        positionLabel = "12:22",
+        label = label,
+        note = "Come back to this.",
+        createdAt = "2027-01-0${id}T09:00:00Z",
+        chapterTitle = "Chapter 3",
+        fictionTitle = "A Test Serial",
+    )
+
+    private fun holderFor(repository: FakeRepository) =
+        BookmarksStateHolder(repository, Dispatchers.Main.immediate)
+
+    @Test
+    fun `a mark renders its label, where it came from, and its note`() {
+        val repository = FakeRepository(bookmarksResult = Result.success(listOf(bookmark(1))))
+
+        compose.setContent {
+            BookmarksScreen(holder = holderFor(repository), onOpen = {}, onBack = {})
+        }
+
+        compose.onNodeWithText("The bridge scene").assertIsDisplayed()
+        compose.onNodeWithText("Come back to this.").assertIsDisplayed()
+        // The server sends the titles alongside each mark, which is why this screen needs neither
+        // the library nor a request per row.
+        compose.onNodeWithText("A TEST SERIAL · CHAPTER 3 · 12:22").assertIsDisplayed()
+    }
+
+    @Test
+    fun `an empty list says so rather than looking broken`() {
+        compose.setContent {
+            BookmarksScreen(
+                holder = holderFor(FakeRepository(bookmarksResult = Result.success(emptyList()))),
+                onOpen = {},
+                onBack = {},
+            )
+        }
+
+        compose.onNodeWithText("NO BOOKMARKS YET").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a server with no bookmark API is distinguished from an empty list`() {
+        compose.setContent {
+            BookmarksScreen(
+                holder = holderFor(FakeRepository(bookmarksResult = Result.success(null))),
+                onOpen = {},
+                onBack = {},
+            )
+        }
+
+        compose.onNodeWithText("NO BOOKMARKS HERE").assertIsDisplayed()
+    }
+
+    @Test
+    fun `opening a mark hands the whole bookmark back`() {
+        val opened = mutableListOf<Bookmark>()
+        val repository = FakeRepository(bookmarksResult = Result.success(listOf(bookmark(1))))
+
+        compose.setContent {
+            BookmarksScreen(holder = holderFor(repository), onOpen = { opened += it }, onBack = {})
+        }
+        compose.onNodeWithTag(BookmarkPlayTestTag).performClick()
+
+        assertEquals(listOf(1), opened.map { it.id })
+        assertEquals(742_500L, opened.single().positionMs)
+    }
+
+    @Test
+    fun `a mark whose chapter was deleted stays listed but cannot be played`() {
+        val repository = FakeRepository(
+            bookmarksResult = Result.success(
+                listOf(bookmark(1, label = "Orphan", chapterId = null, fictionId = null)),
+            ),
+        )
+
+        compose.setContent {
+            BookmarksScreen(holder = holderFor(repository), onOpen = {}, onBack = {})
+        }
+
+        // The note on it is still the user's, so the row survives — it simply says what happened.
+        compose.onNodeWithText("Orphan").assertIsDisplayed()
+        compose.onNodeWithText("CHAPTER REMOVED").assertIsDisplayed()
+        compose.onAllNodesWithTag(BookmarkPlayTestTag).assertCountEquals(0)
+    }
+
+    @Test
+    fun `removing is behind a confirmation`() {
+        val repository = FakeRepository(bookmarksResult = Result.success(listOf(bookmark(1))))
+
+        compose.setContent {
+            BookmarksScreen(holder = holderFor(repository), onOpen = {}, onBack = {})
+        }
+        compose.onNodeWithTag(BookmarkDeleteTestTag).performClick()
+
+        assertTrue(repository.deletedBookmarks.isEmpty(), "nothing is deleted before confirming")
+        compose.onNodeWithText("CANCEL").performClick()
+        assertTrue(repository.deletedBookmarks.isEmpty(), "cancelling deletes nothing")
+
+        compose.onNodeWithTag(BookmarkDeleteTestTag).performClick()
+        compose.onNodeWithTag(BookmarkConfirmDeleteTestTag).performClick()
+        assertEquals(listOf(1), repository.deletedBookmarks)
+    }
+
+    @Test
+    fun `editing sends both fields, so a note can be cleared`() {
+        val repository = FakeRepository(
+            bookmarksResult = Result.success(listOf(bookmark(1))),
+            updateBookmarkResult = Result.success(Bookmark(id = 1)),
+        )
+
+        compose.setContent {
+            BookmarksScreen(holder = holderFor(repository), onOpen = {}, onBack = {})
+        }
+        compose.onNodeWithTag(BookmarkEditTestTag).performClick()
+        compose.onNodeWithTag(BookmarkLabelFieldTestTag).performTextInput("!")
+        compose.onNodeWithText("SAVE").performClick()
+
+        val (id, patch) = repository.patchedBookmarks.single()
+        assertEquals(1, id)
+        assertTrue(patch.label.orEmpty().contains("bridge"))
+        // Present and empty rather than absent: absent would mean "leave the note alone".
+        assertEquals("Come back to this.", patch.note)
+    }
+
+    // --- the player's own control ---------------------------------------------------------------
+
+    @Test
+    fun `the player draws no bookmark control where the server has no bookmark API`() {
+        compose.setContent {
+            PlayerScreen(
+                playback = playerWithMedia(),
+                preferences = InMemoryPlaybackPreferencesStore(),
+                bookmarksAvailable = false,
+                onBack = {},
+            )
+        }
+
+        compose.onAllNodesWithTag(AddBookmarkTestTag).assertCountEquals(0)
+    }
+
+    @Test
+    fun `the player's bookmark control reports the press`() {
+        var presses = 0
+
+        compose.setContent {
+            PlayerScreen(
+                playback = playerWithMedia(),
+                preferences = InMemoryPlaybackPreferencesStore(),
+                bookmarksAvailable = true,
+                onAddBookmark = { presses++ },
+                onBack = {},
+            )
+        }
+        compose.onNodeWithTag(AddBookmarkTestTag).assertIsEnabled().performClick()
+
+        assertEquals(1, presses)
+    }
+
+    @Test
+    fun `the player's bookmark control is inert with nothing loaded`() {
+        compose.setContent {
+            PlayerScreen(
+                playback = FakePlaybackController(
+                    PlayerUiState(hasMedia = false, queue = listOf(QueueItem(101, "Chapter 3"))),
+                ),
+                preferences = InMemoryPlaybackPreferencesStore(),
+                bookmarksAvailable = true,
+                onBack = {},
+            )
+        }
+
+        compose.onNodeWithTag(AddBookmarkTestTag).assertIsNotEnabled()
+    }
+
+    private fun playerWithMedia() = FakePlaybackController(
+        PlayerUiState(
+            title = "Chapter 3",
+            hasMedia = true,
+            positionMs = 61_400,
+            durationMs = 900_000,
+            queue = listOf(QueueItem(101, "Chapter 3")),
+        ),
+    )
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/BookmarksStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/BookmarksStateHolderTest.kt
@@ -1,0 +1,218 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.data.Bookmark
+import dk.perspektiva.ttsroad.desktop.data.BookmarkKind
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * The bookmark state machine.
+ *
+ * Everything the screens rely on is decided here — the manual-only filter, "no API" versus "no
+ * bookmarks", the optimistic delete and its rollback — so none of it needs a display to assert.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class BookmarksStateHolderTest {
+
+    private fun holder(repository: FakeRepository) =
+        BookmarksStateHolder(repository, UnconfinedTestDispatcher())
+
+    private fun bookmark(id: Int, createdAt: String = "2027-01-0${id}T09:00:00Z") =
+        Bookmark(id = id, chapterId = 100 + id, fictionId = 7, createdAt = createdAt)
+
+    @Test
+    fun `loading asks only for manual marks`() = runTest {
+        val repository = FakeRepository(bookmarksResult = Result.success(listOf(bookmark(1))))
+
+        holder(repository).refresh()
+
+        // The web player's jump-back breadcrumbs share this table as `auto`; a list that mixed
+        // them in would bury the handful of marks somebody actually chose.
+        assertEquals(listOf<Pair<String?, Int?>>(BookmarkKind.Manual to null), repository.bookmarkListCalls)
+    }
+
+    @Test
+    fun `ensureLoaded loads once and a second visit costs nothing`() = runTest {
+        val repository = FakeRepository(bookmarksResult = Result.success(listOf(bookmark(1))))
+        val holder = holder(repository)
+
+        holder.ensureLoaded()
+        holder.ensureLoaded()
+
+        assertEquals(1, repository.bookmarkListCalls.size)
+    }
+
+    @Test
+    fun `tombstones are dropped and the newest mark is first`() = runTest {
+        val repository = FakeRepository(
+            bookmarksResult = Result.success(
+                listOf(
+                    bookmark(1, "2027-01-01T09:00:00Z"),
+                    bookmark(2, "2027-01-03T09:00:00Z"),
+                    bookmark(3, "2027-01-02T09:00:00Z").copy(deletedAt = "2027-01-04T09:00:00Z"),
+                ),
+            ),
+        )
+        val holder = holder(repository)
+
+        holder.refresh()
+
+        assertEquals(listOf(2, 1), holder.state.value.bookmarks.map { it.id })
+    }
+
+    @Test
+    fun `a null answer is an older server rather than an empty list`() = runTest {
+        val holder = holder(FakeRepository(bookmarksResult = Result.success(null)))
+
+        holder.refresh()
+
+        val state = holder.state.value
+        assertTrue(state.unsupported)
+        // Kept out of `error` on purpose: a Retry button on this would never succeed.
+        assertNull(state.error)
+        assertTrue(state.loaded)
+    }
+
+    @Test
+    fun `a failed refresh keeps the list already on screen`() = runTest {
+        val repository = FakeRepository(bookmarksResult = Result.success(listOf(bookmark(1))))
+        val holder = holder(repository)
+        holder.refresh()
+
+        repository.bookmarksResult = Result.failure(java.io.IOException("offline"))
+        holder.refresh()
+
+        val state = holder.state.value
+        assertNotNull(state.error)
+        // Same rule as a failed library refresh: a banner over retained content explains more than
+        // a screen that has been blanked.
+        assertEquals(listOf(1), state.bookmarks.map { it.id })
+    }
+
+    @Test
+    fun `adding sends the position in seconds and prepends the result`() = runTest {
+        val repository = FakeRepository(
+            bookmarksResult = Result.success(listOf(bookmark(1))),
+            createBookmarkResult = Result.success(Bookmark(id = 50, positionLabel = "1:01")),
+        )
+        val holder = holder(repository)
+        holder.refresh()
+
+        holder.add(chapterId = 101, positionMs = 61_250L, label = "  A passage  ")
+
+        val request = repository.createdBookmarks.single()
+        assertEquals(101, request.chapterId)
+        assertEquals(61.25, request.positionSeconds)
+        assertEquals("A passage", request.label)
+        assertEquals(BookmarkKind.Manual, request.kind)
+        val state = holder.state.value
+        // Prepended rather than re-fetched: the list is already right, and a round trip would make
+        // the confirmation arrive after it.
+        assertEquals(listOf(50, 1), state.bookmarks.map { it.id })
+        assertEquals("Bookmarked at 1:01", state.notice)
+    }
+
+    @Test
+    fun `a blank label is sent as no label at all`() = runTest {
+        val repository = FakeRepository()
+
+        holder(repository).add(chapterId = 101, positionMs = 1_000L, label = "   ")
+
+        // Null, not "": an empty string is the server's instruction to *clear* a value, which is a
+        // different thing from never having set one.
+        assertNull(repository.createdBookmarks.single().label)
+    }
+
+    @Test
+    fun `adding does nothing without a chapter`() = runTest {
+        val repository = FakeRepository()
+
+        holder(repository).add(chapterId = 0, positionMs = 1_000L)
+
+        assertTrue(repository.createdBookmarks.isEmpty())
+    }
+
+    @Test
+    fun `a failed add says so instead of pretending it saved`() = runTest {
+        val repository = FakeRepository(createBookmarkResult = Result.failure(java.io.IOException("offline")))
+        val holder = holder(repository)
+
+        holder.add(chapterId = 101, positionMs = 1_000L)
+
+        assertTrue(holder.state.value.bookmarks.isEmpty())
+        assertNotNull(holder.state.value.notice)
+    }
+
+    @Test
+    fun `editing sends both fields so a cleared note stays cleared`() = runTest {
+        val repository = FakeRepository(
+            bookmarksResult = Result.success(listOf(bookmark(1))),
+            updateBookmarkResult = Result.success(Bookmark(id = 1)),
+        )
+        val holder = holder(repository)
+        holder.refresh()
+
+        holder.edit(bookmarkId = 1, label = "Renamed", note = "")
+
+        val (id, patch) = repository.patchedBookmarks.single()
+        assertEquals(1, id)
+        assertEquals("Renamed", patch.label)
+        // Present-and-empty, never absent: absent means "leave it alone" on the server, so a note
+        // edited to nothing would come straight back.
+        assertEquals("", patch.note)
+        assertEquals("Renamed", holder.state.value.bookmarks.single().label)
+    }
+
+    @Test
+    fun `removing takes the row out immediately`() = runTest {
+        val repository = FakeRepository(bookmarksResult = Result.success(listOf(bookmark(1), bookmark(2))))
+        val holder = holder(repository)
+        holder.refresh()
+
+        holder.remove(1)
+
+        assertEquals(listOf(2), holder.state.value.bookmarks.map { it.id })
+        assertEquals(listOf(1), repository.deletedBookmarks)
+        assertEquals("Bookmark removed", holder.state.value.notice)
+    }
+
+    @Test
+    fun `a failed remove puts the row back where it was`() = runTest {
+        val repository = FakeRepository(
+            bookmarksResult = Result.success(listOf(bookmark(3), bookmark(2), bookmark(1))),
+            deleteBookmarkResult = Result.failure(java.io.IOException("offline")),
+        )
+        val holder = holder(repository)
+        holder.refresh()
+
+        holder.remove(2)
+
+        // Back in its own place, not appended: a failed delete must not also reorder the list
+        // under the user's cursor.
+        assertEquals(listOf(3, 2, 1), holder.state.value.bookmarks.map { it.id })
+        assertNotNull(holder.state.value.notice)
+    }
+
+    @Test
+    fun `signing out drops the account's marks`() = runTest {
+        val repository = FakeRepository(bookmarksResult = Result.success(listOf(bookmark(1))))
+        val holder = holder(repository)
+        holder.refresh()
+
+        holder.sessionEnded()
+
+        val state = holder.state.value
+        assertTrue(state.bookmarks.isEmpty())
+        // Not "loaded and empty" — the next account to sign in on this desktop must trigger a load
+        // rather than be shown the previous one's empty state.
+        assertFalse(state.loaded)
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderBehaviourTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderBehaviourTest.kt
@@ -3,6 +3,7 @@ package dk.perspektiva.ttsroad.desktop.ui
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ReaderBehaviourTest {
@@ -27,5 +28,89 @@ class ReaderBehaviourTest {
         assertFalse(readerShouldPrefetch(79_999, 100_000))
         assertTrue(readerShouldPrefetch(80_000, 100_000))
         assertFalse(readerShouldPrefetch(1, 0))
+    }
+
+    // --- Bookmark anchoring -------------------------------------------------------------------
+
+    @Test
+    fun `a mark from the reader is anchored to the sentence, not to the button press`() {
+        val anchor = readerBookmarkAnchor(
+            isPlayingThisChapter = true,
+            timingsMatch = true,
+            positionMs = 61_400,
+            sentenceStartSeconds = 58.25,
+            sentenceText = "The bridge came apart under them.",
+        )
+
+        // A listener marking a passage means the passage, not the syllable that happened to be
+        // sounding when their hand reached the key.
+        assertEquals(58_250L, anchor?.positionMs)
+        assertEquals("The bridge came apart under them.", anchor?.label)
+    }
+
+    @Test
+    fun `between cues it falls back to the playing position`() {
+        val anchor = readerBookmarkAnchor(
+            isPlayingThisChapter = true,
+            timingsMatch = true,
+            positionMs = 61_400,
+            sentenceStartSeconds = null,
+            sentenceText = null,
+        )
+
+        assertEquals(61_400L, anchor?.positionMs)
+        assertNull(anchor?.label)
+    }
+
+    @Test
+    fun `reading a chapter that is not playing places no mark at all`() {
+        // The same rule that already disables highlighting: with no audio position there is no
+        // honest one to record, and a bookmark at 0:00 is worse than none.
+        assertNull(
+            readerBookmarkAnchor(
+                isPlayingThisChapter = false,
+                timingsMatch = true,
+                positionMs = 0,
+                sentenceStartSeconds = 12.0,
+                sentenceText = "Whatever this says.",
+            ),
+        )
+        assertNull(
+            readerBookmarkAnchor(
+                isPlayingThisChapter = true,
+                timingsMatch = false,
+                positionMs = 61_400,
+                sentenceStartSeconds = 12.0,
+                sentenceText = "Whatever this says.",
+            ),
+        )
+    }
+
+    @Test
+    fun `a long sentence is elided into a label`() {
+        val sentence = "word ".repeat(200).trim()
+
+        val anchor = readerBookmarkAnchor(true, true, 0, 0.0, sentence)
+
+        // The ellipsis is the only thing allowed past the limit, and the cut never leaves the
+        // trailing space it landed on.
+        val label = requireNotNull(anchor?.label)
+        assertTrue(label.length <= ReaderBookmarkLabelChars + 1, "was ${label.length}")
+        assertTrue(label.endsWith("d…"), label.takeLast(8))
+    }
+
+    @Test
+    fun `narration line breaks are flattened out of a label`() {
+        val anchor = readerBookmarkAnchor(true, true, 0, 0.0, "  The bridge\n  came apart.  ")
+
+        assertEquals("The bridge came apart.", anchor?.label)
+    }
+
+    @Test
+    fun `a nonsense sentence time is ignored rather than trusted`() {
+        // `seekSecondsForOffset` answers from parsed server data; a malformed row must not become
+        // a negative or infinite seek.
+        assertEquals(61_400L, readerBookmarkAnchor(true, true, 61_400, -3.0, "x")?.positionMs)
+        assertEquals(61_400L, readerBookmarkAnchor(true, true, 61_400, Double.NaN, "x")?.positionMs)
     }
 }

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderScreenUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderScreenUiTest.kt
@@ -3,6 +3,7 @@ package dk.perspektiva.ttsroad.desktop.ui
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -59,6 +60,8 @@ class ReaderScreenUiTest {
         player: FakePlaybackController = FakePlaybackController(),
         preferences: InMemoryReaderPreferencesStore = InMemoryReaderPreferencesStore(),
         onAdvanced: (Int, String) -> Unit = { _, _ -> },
+        bookmarksAvailable: Boolean = false,
+        onAddBookmark: (Long, String?) -> Unit = { _, _ -> },
     ) {
         val repository = FakeRepository(
             readAlongResult = Result.success(ReadAlongFetchResult.Modified(response, "\"etag\"")),
@@ -71,12 +74,58 @@ class ReaderScreenUiTest {
                     cache = ReadAlongCache(repository),
                     preferences = preferences,
                     playback = player,
+                    bookmarksAvailable = bookmarksAvailable,
+                    onAddBookmark = onAddBookmark,
                     onBack = {},
                     onChapterAdvanced = onAdvanced,
                 )
             }
         }
         compose.waitForIdle()
+    }
+
+    /** Playing this chapter, at a position inside the second cue. */
+    private fun playingThisChapter(positionMs: Long = 6_000) = FakePlaybackController(
+        PlayerUiState(
+            title = "Chapter One",
+            hasMedia = true,
+            positionMs = positionMs,
+            durationMs = 60_000,
+            queue = listOf(QueueItem(10, "Chapter One")),
+        ),
+    )
+
+    @Test
+    fun `no bookmark control at all where the server has no bookmark API`() {
+        screen(player = playingThisChapter(), bookmarksAvailable = false)
+
+        compose.onAllNodesWithTag(ReaderBookmarkButtonTestTag).assertCountEquals(0)
+    }
+
+    @Test
+    fun `bookmarking a passage sends the sentence start and the sentence itself`() {
+        var marked: Pair<Long, String?>? = null
+        screen(
+            player = playingThisChapter(positionMs = 6_000),
+            bookmarksAvailable = true,
+            onAddBookmark = { position, label -> marked = position to label },
+        )
+
+        compose.onNodeWithTag(ReaderBookmarkButtonTestTag).performClick()
+
+        // The cue at 6s starts at 5s and belongs to the first sentence, which starts at 0s. A mark
+        // means the passage, not the syllable that was sounding — and it names itself with the
+        // words, which is the thing this client can do that a phone's transport button cannot.
+        assertEquals(0L to "Snow fell softly.", marked)
+    }
+
+    @Test
+    fun `the bookmark control is inert while reading a chapter that is not playing`() {
+        // Nothing is playing, so there is no honest position — the same rule that already disables
+        // highlighting. The control stays put rather than appearing later and moving its neighbours.
+        screen(player = FakePlaybackController(), bookmarksAvailable = true)
+
+        compose.onNodeWithTag(ReaderBookmarkButtonTestTag).assertIsNotEnabled()
     }
 
     @Test


### PR DESCRIPTION
Fixes #37.

The backend has shipped full bookmark CRUD on `/api/mobile/bookmarks` since 1.4.0 — `GET`, `POST` (201), `PATCH /{id}`, `DELETE /{id}`, backed by `app/services/bookmarks.py` and sharing rows and shapes with the web's `/api/bookmarks`. This client parsed the `bookmarks` capability and used it for exactly one thing: adding the string `"Bookmarks"` to a list in `SettingsScreen.kt`.

## What landed

**Data layer** (`data/BookmarkModels.kt`, `TtsRoadApi.kt`, `Repository.kt`) — the four routes, DTOs alongside the rest.

- Only `manual` marks are ever requested. The same table holds the web player's jump-back breadcrumbs as `auto`, and a day of listening buries the handful of marks somebody actually chose.
- A `404` is an older server and answers `null` — a different thing from an empty list, and the UI shows different things for the two.
- `chapter_id`/`fiction_id` are **nullable**. `retire_bookmarks_for_chapters` soft-deletes marks and *clears the link* when a chapter is hard-deleted rather than letting the FK cascade take them silently, so a bookmark can outlive its audio.
- Label/note lengths and negative positions are bounded client-side, so an over-long label is a shorter bookmark rather than a 400.
- A PATCH omits what it was not given (absent = "leave it alone") and sends `""` to clear, which is how the server keeps those two distinguishable without an explicit JSON null.
- Delete is idempotent by the server's design, so the retry after a dropped connection cannot error about a row that is already gone.

**`ui/BookmarksStateHolder.kt`** — hoisted in `App` next to the settings, update and search holders, for a sharper reason than any of them: bookmarks are *written* from the player and the reader and *read* on a destination the user may never open. A holder owned by the bookmarks screen would leave Ctrl+B nowhere to put anything. Delete is optimistic and rolls back into the row's original index.

**`ui/BookmarksScreen.kt`** + `Destination.Bookmarks` — the list, newest first, rendered from the titles the server sends alongside each mark, so it needs neither the library nor a request per row. Inline edit of label and note; delete behind a confirmation. A mark whose chapter was deleted stays listed (the note on it is still the user's) but offers no Play.

**Player** — a `BOOKMARK` control next to `READ ALONG`, enabled on loaded media rather than on "is playing", since marking the spot you just paused at is the most ordinary reason to reach for it.

**Reader** — a toolbar action that anchors the mark to the **sentence being narrated** rather than to the millisecond the button was pressed, and labels it with the words themselves. That is the thing this client can do that a phone cannot, and it is what issue #37 points at. Reading a chapter that is *not* playing places no mark at all — the same rule that already disables highlighting, because a bookmark at 0:00 is worse than none.

**Shortcuts** — `Ctrl+B` marks the spot, `Ctrl+Shift+B` opens the list. Both are classified `firesWhileTyping = true` and go on the preview handler, checked against the one text field that could plausibly claim `Ctrl+B`: the library's search box is a plain `OutlinedTextField` with no bold to toggle.

**`playQueue` gains an optional `startPositionMs`** so opening a mark starts *there* rather than at the chapter's saved resume position — which would silently ignore the mark that was clicked. It applies only when the requested chapter is actually in the queue, so a mark on a chapter that has since lost its audio cannot seek chapter one to 41:12.

Everything is capability-gated the way the speed and skip-silence controls are: no header entry, no player control, no reader button, and two inert shortcuts where the server has no bookmark API.

## Not in scope

Bookmarks ride along in `GET /api/mobile/sync` with a `deleted` id list. As #37 notes, that is worth wiring with #36 (PR #50) rather than polling — this PR uses the dedicated endpoint and leaves delta sync to that branch.

## Verification

`./gradlew clean check --warning-mode fail -Pttsroad.warningsAsErrors=true` passes (the two skips are the Windows-only credential-store tests).

New coverage: `BookmarksTest` (wire shape, the manual filter, 404-as-null, truncation, PATCH semantics, idempotent delete), `BookmarksStateHolderTest` (the state machine, optimistic delete and rollback), `BookmarksScreenUiTest`, reader anchoring in `ReaderBehaviourTest`/`ReaderScreenUiTest`, plus additions to `ShortcutsTest`, `AppNavigationTest` and `QueuePlaybackControllerTest`.

Android has the same gap — jonarihen/TTSRoad-App#64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)