### PR TITLE
Share jump-back history across clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to TTSRoad Desktop are recorded here. The format follows
 
 ### Added
 
+- Cross-device jump-back history through the server's `kind=auto` bookmarks. The desktop writes a
+  breadcrumb every five minutes of playback and at its existing transition points, merges moments
+  recorded by other clients into the Jump back shelf, and retains the bounded local copy offline.
 - The account's cross-library queue, shared with the web client, as a browsable surface of its own.
   Chapter rows gain "Play next" and "Add to queue", the chapter list gains "Queue unplayed", and the
   queue screen can reorder, remove and clear. Shown only on a server that advertises the capability.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,10 +117,12 @@ apply to audio.
   criterion. Fade gain is published as a multiplier and combined with the volume boost in one place,
   so cancelling a fade restores the boost rather than unity. End-of-chapter is checked *before* the
   auto-advance and disarms itself.
-- `data/PlaybackHistory.kt` — bounded to 60 entries, one per chapter. The snapshot type has **no URL
-  field of any kind**; covers are re-resolved from the library cache by fiction id. Dismissal is
-  per snapshot and is *inherited* when the same chapter is re-recorded, or the next progress save
-  would undo it. History is written at transitions only, never on the progress tick.
+- `data/PlaybackHistory.kt` — a bounded local-first fallback, 60 entries and one per chapter;
+  `SyncedPlaybackHistoryStore` writes the same `kind=auto` bookmarks as the web and merges a full
+  server pull without replacing newer offline work. The controller records at transitions and
+  every five minutes of active playback, never on the ten-second progress tick. The snapshot type
+  has **no URL field of any kind**; covers are re-resolved from the library cache by fiction id.
+  Dismissal stays machine-local and is inherited across both local records and remote refreshes.
 
 ### Offline storage
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Built with Compose for Desktop — real Skia-rendered UI, real OS installers, no
 | Device sessions — list, mark current, revoke one / revoke all others | ✅ |
 | Playback preferences — speed, skip interval, skip silence, volume boost | ✅ |
 | Sleep timer — 5/15/30/45/60 min or end of chapter, with a fade and "+5 min" | ✅ |
-| Local listening history — "Jump back in", dismissible per snapshot | ✅ |
+| Cross-device listening history — local-first "Jump back in", dismissible per snapshot | ✅ |
 | MPRIS over D-Bus — Cinnamon applet, lock screen, hardware media keys | ✅ Linux |
 | App shortcuts — Space, arrows, Ctrl+arrows, Ctrl+L, Ctrl+, plus an F1 list | ✅ |
 | Offline downloads — per chapter, next 10, restart-safe queue, storage controls | ✅ |
@@ -167,7 +167,7 @@ The back stack, the repository-backed cache, lazy lists and the adaptive breakpo
 [`docs/adr/0004-stateful-adaptive-navigation.md`](docs/adr/0004-stateful-adaptive-navigation.md).
 Chapter filtering and ordering, bulk marking, optimistic rollback and current-chapter resolution are in
 [`docs/adr/0005-chapter-browsing-and-bulk-controls.md`](docs/adr/0005-chapter-browsing-and-bulk-controls.md).
-Listening preferences, the sleep timer, local history, MPRIS and the shortcut table are in
+Listening preferences, the sleep timer, local-first cross-device history, MPRIS and the shortcut table are in
 [`docs/adr/0006-listening-preferences-and-desktop-integration.md`](docs/adr/0006-listening-preferences-and-desktop-integration.md).
 Offline namespaces, resumable downloads, streamed-audio retention and disk metadata are in
 [`docs/adr/0007-offline-downloads-and-streaming-cache.md`](docs/adr/0007-offline-downloads-and-streaming-cache.md).
@@ -291,6 +291,7 @@ src/main/kotlin/dk/perspektiva/ttsroad/desktop/
 │   ├── Models.kt                 mobile API models (Moshi)
 │   ├── PlaybackPreferences.kt    speed/skip/silence/boost, machine-local, migrating on read
 │   ├── PlaybackHistory.kt        bounded local snapshots, last-heard and jump-back selection
+│   ├── SyncedPlaybackHistoryStore.kt  cross-device auto-bookmark reconciliation
 │   ├── Cached.kt                 value + error + isRefreshing + last success, independently
 │   ├── LibraryCache.kt           library/chapter state held above the screens
 │   ├── LibraryDiskCache.kt       account-scoped rebuildable metadata for offline browsing
@@ -476,10 +477,13 @@ The **sleep timer** offers 5/15/30/45/60 minutes or the end of the current chapt
 None of that is timed by a scheduler: the timer is a state machine ticked by the playback loop over
 an injected clock, so a test steps an hour in one line.
 
-**Local history** (`history.json`, 60 entries, one per chapter) backs the "Jump back in" strip. It
-holds ids and titles and *no URL of any kind* — covers are re-resolved from the live library cache.
-Dismissing an entry hides that snapshot, not the day: a later chapter of the same serial comes back
-on its own, and a progress save for a dismissed chapter does not resurrect it.
+**Listening history** is local-first: `history.json` keeps 60 entries, one per chapter, while
+`kind=auto` server bookmarks share the same moments with the web and other native clients. The
+desktop records at playback transitions and every five minutes of active listening, then merges a
+server refresh without replacing newer offline work. The local file holds ids and titles and *no
+URL of any kind* — covers are re-resolved from the live library cache. Dismissing an entry hides
+that snapshot on this machine, not the day: a later chapter of the same serial comes back on its
+own, and a later refresh or progress save does not resurrect the dismissed chapter.
 
 On Linux the player appears on the session bus over **MPRIS**, so Cinnamon's media applet, the lock
 screen and hardware media keys show the right metadata and control playback. It is pure Java —

--- a/docs/adr/0006-listening-preferences-and-desktop-integration.md
+++ b/docs/adr/0006-listening-preferences-and-desktop-integration.md
@@ -188,11 +188,18 @@ With no focus they go to the desktop, which routes them over MPRIS — the same 
 other door. **No global hotkeys are installed**, per the issue: grabbing keys system-wide without an
 explicit opt-in is hostile.
 
-### History is bounded by construction
+### History is local-first and shared through automatic bookmarks
 
-`history.json`, at most 60 entries, one per chapter, newest first. It is written on every pause and
-chapter change for the life of the install, so an unbounded list would be a slow leak that only
-shows up on the machines of the people who use the app most.
+`history.json`, at most 60 entries, one per chapter, newest first, remains the offline fallback.
+`SyncedPlaybackHistoryStore` also writes each observation as a `kind=auto` bookmark and merges the
+account's live automatic bookmarks when the library opens. Those rows are the server-side home the
+web client also uses, so a moment recorded on one device is discoverable on another without putting
+the network in the path of playback or startup.
+
+The controller records on pause and chapter change and once every five minutes of active playback,
+matching the web cadence. The ten-second progress tick does not write history. A suspended laptop
+counts as no listening time, and failed background writes are silent: progress sync still owns the
+resumable position, while the local snapshot survives for the next offline launch.
 
 Two decisions worth recording:
 
@@ -204,9 +211,13 @@ Two decisions worth recording:
   position for a chapter that is already dismissed *inherits* the dismissal — otherwise the next
   progress save would undo a dismissal within a tick of the user making it. A different chapter is a
   different snapshot and appears normally.
+- **Remote merge never replaces newer offline work.** The newest observation for a chapter wins,
+  but a duration already resolved locally and a local dismissal survive because neither exists in
+  the bookmark contract. The server's rolling window owns remote retention; the desktop's 60-row
+  bound still owns its local file.
 
-History is recorded at transitions — pause, chapter change, sleep, stop, shutdown — and deliberately
-not on the ten-second progress tick, which would be write amplification for no extra information.
+This amends the original local-only decision after the shared bookmark contract landed. Keeping a
+local fallback was retained rather than replacing it because offline playback is a first-class path.
 
 ## Consequences
 

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackHistory.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackHistory.kt
@@ -104,6 +104,38 @@ object PlaybackHistory {
             .take(MaxEntries)
     }
 
+    /**
+     * Reconciles snapshots learned from another client with this machine's local fallback.
+     *
+     * A remote full pull can contain several breadcrumbs for the same chapter, while the desktop
+     * intentionally keeps one snapshot per chapter. The newest observation wins, except for the
+     * two facts only this machine can know: a local dismissal and a duration resolved by its player.
+     */
+    fun merge(
+        existing: List<PlaybackSnapshot>,
+        incoming: List<PlaybackSnapshot>,
+    ): List<PlaybackSnapshot> = (existing + incoming)
+        .groupBy(PlaybackSnapshot::key)
+        .values
+        .map { versions ->
+            val newest = versions.maxBy { it.recordedAtMs }
+            newest.copy(
+                fictionTitle = newest.fictionTitle.ifBlank {
+                    versions.filter { it.fictionTitle.isNotBlank() }
+                        .maxByOrNull { it.recordedAtMs }?.fictionTitle.orEmpty()
+                },
+                chapterTitle = newest.chapterTitle.ifBlank {
+                    versions.filter { it.chapterTitle.isNotBlank() }
+                        .maxByOrNull { it.recordedAtMs }?.chapterTitle.orEmpty()
+                },
+                durationSeconds = newest.durationSeconds.takeIf { it > 0.0 }
+                    ?: versions.maxOf { it.durationSeconds },
+                dismissed = versions.any { it.dismissed },
+            )
+        }
+        .sortedByDescending { it.recordedAtMs }
+        .take(MaxEntries)
+
     /** Marks one chapter's snapshot dismissed. A later snapshot of a *different* chapter is unaffected. */
     fun dismiss(existing: List<PlaybackSnapshot>, key: String): List<PlaybackSnapshot> =
         existing.map { if (it.key == key) it.copy(dismissed = true) else it }
@@ -189,14 +221,22 @@ object PlaybackHistory {
 }
 
 /** Seam so tests never touch the real user config directory. */
-interface PlaybackHistoryStore {
+interface PlaybackHistoryStore : AutoCloseable {
     val history: StateFlow<List<PlaybackSnapshot>>
 
     fun record(snapshot: PlaybackSnapshot)
 
+    /** Merge snapshots learned from the server without replacing newer offline work. */
+    fun merge(snapshots: List<PlaybackSnapshot>)
+
     fun dismiss(key: String)
 
     fun clear()
+
+    /** Refreshes cross-device breadcrumbs where this store has a server-backed implementation. */
+    suspend fun refresh(ownerKey: String) = Unit
+
+    override fun close() = Unit
 }
 
 /** In-memory store for tests and for a session with nowhere safe to write. */
@@ -209,6 +249,11 @@ class InMemoryPlaybackHistoryStore(
     @Synchronized
     override fun record(snapshot: PlaybackSnapshot) {
         _history.value = PlaybackHistory.record(_history.value, snapshot)
+    }
+
+    @Synchronized
+    override fun merge(snapshots: List<PlaybackSnapshot>) {
+        _history.value = PlaybackHistory.merge(_history.value, snapshots)
     }
 
     @Synchronized
@@ -253,6 +298,11 @@ class FilePlaybackHistoryStore(
     @Synchronized
     override fun record(snapshot: PlaybackSnapshot) {
         write(PlaybackHistory.record(_history.value, snapshot))
+    }
+
+    @Synchronized
+    override fun merge(snapshots: List<PlaybackSnapshot>) {
+        write(PlaybackHistory.merge(_history.value, snapshots))
     }
 
     @Synchronized

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/SyncedPlaybackHistoryStore.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/SyncedPlaybackHistoryStore.kt
@@ -1,0 +1,123 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import java.time.Instant
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Local-first playback history with account-wide `kind=auto` bookmark synchronization.
+ *
+ * The local store remains authoritative while offline and keeps dismissals machine-local. Server
+ * breadcrumbs add the cross-device half: a pause on this desktop can be found in the browser, and
+ * a moment recorded in the browser appears in this desktop's Jump back shelf after a refresh.
+ */
+class SyncedPlaybackHistoryStore(
+    private val local: PlaybackHistoryStore,
+    private val repository: TtsRoadRepository,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val currentOwnerKey: () -> String,
+) : PlaybackHistoryStore {
+    private val job = SupervisorJob()
+    private val scope = CoroutineScope(job + dispatcher)
+    private val submittedPositions = mutableMapOf<String, Double>()
+
+    override val history = local.history
+
+    override fun record(snapshot: PlaybackSnapshot) {
+        local.record(snapshot)
+
+        // A snapshot captured for the session being left must never be filed under whichever
+        // account happens to have signed in while the asynchronous request was waiting to run.
+        if (snapshot.ownerKey.isBlank() || snapshot.ownerKey != currentOwnerKey()) return
+        if (snapshot.positionSeconds < MinServerPositionSeconds) return
+
+        val shouldSubmit = synchronized(submittedPositions) {
+            val previous = submittedPositions[snapshot.key]
+            if (previous == snapshot.positionSeconds) {
+                false
+            } else {
+                submittedPositions[snapshot.key] = snapshot.positionSeconds
+                if (submittedPositions.size > MaxRememberedSubmissions) {
+                    submittedPositions.remove(submittedPositions.keys.first())
+                }
+                true
+            }
+        }
+        if (!shouldSubmit) return
+
+        scope.launch {
+            if (snapshot.ownerKey != currentOwnerKey()) return@launch
+            // Best effort by design. Progress sync still owns the resumable position, and an
+            // offline breadcrumb is preserved locally; surfacing an error every five minutes
+            // would turn a background convenience into an alert storm.
+            runCatching {
+                repository.createBookmark(
+                    BookmarkCreateRequest(
+                        chapterId = snapshot.chapterId,
+                        positionSeconds = snapshot.positionSeconds,
+                        kind = BookmarkKind.Auto,
+                    ),
+                )
+            }
+        }
+    }
+
+    override fun merge(snapshots: List<PlaybackSnapshot>) = local.merge(snapshots)
+
+    override fun dismiss(key: String) = local.dismiss(key)
+
+    override fun clear() = local.clear()
+
+    override suspend fun refresh(ownerKey: String) {
+        if (ownerKey.isBlank() || ownerKey != currentOwnerKey()) return
+        val bookmarks = runCatching { repository.bookmarks(kind = BookmarkKind.Auto) }.getOrNull() ?: return
+
+        // A request started for account A can finish after account B signs in. Drop it rather than
+        // persisting A's chapter titles under B's local owner key.
+        if (ownerKey != currentOwnerKey()) return
+        local.merge(bookmarks.mapNotNull { it.toSnapshot(ownerKey) })
+    }
+
+    override fun close() {
+        // Playback records once more during release. Give that final request a short chance to
+        // finish, then leave promptly even when the server disappeared while the window closed.
+        runBlocking {
+            withTimeoutOrNull(CloseTimeoutMs) { job.children.toList().joinAll() }
+        }
+        scope.cancel()
+        local.close()
+    }
+
+    private fun Bookmark.toSnapshot(ownerKey: String): PlaybackSnapshot? {
+        val chapter = chapterId?.takeIf { it > 0 } ?: return null
+        val fiction = fictionId?.takeIf { it > 0 } ?: return null
+        val recordedAt = createdAt?.let { value ->
+            runCatching { Instant.parse(value).toEpochMilli() }.getOrNull()
+        } ?: return null
+        return PlaybackSnapshot(
+            fictionId = fiction,
+            chapterId = chapter,
+            fictionTitle = fictionTitle.orEmpty(),
+            chapterTitle = chapterTitle.orEmpty(),
+            positionSeconds = positionSeconds.coerceAtLeast(0.0),
+            // The bookmark contract has no duration. PlaybackHistory.merge preserves a local one
+            // when this machine has played the same chapter; a remote-only row simply has no bar.
+            durationSeconds = 0.0,
+            recordedAtMs = recordedAt,
+            ownerKey = ownerKey,
+        )
+    }
+
+    private companion object {
+        const val MinServerPositionSeconds: Double = 30.0
+        const val MaxRememberedSubmissions: Int = 240
+        const val CloseTimeoutMs: Long = 3_000L
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/di/AppContainer.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/di/AppContainer.kt
@@ -16,6 +16,7 @@ import dk.perspektiva.ttsroad.desktop.data.RetrofitTtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.download.DownloadCoordinator
 import dk.perspektiva.ttsroad.desktop.download.OfflineFirstMediaSourceFactory
 import dk.perspektiva.ttsroad.desktop.data.SessionStore
+import dk.perspektiva.ttsroad.desktop.data.SyncedPlaybackHistoryStore
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadAuthInterceptor
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.data.WindowPreferencesStore
@@ -94,7 +95,9 @@ class AppContainer(
      * test never writes into the user's config directory.
      */
     val playbackPreferences: PlaybackPreferencesStore = FilePlaybackPreferencesStore(),
-    val playbackHistory: PlaybackHistoryStore = FilePlaybackHistoryStore(),
+    // Null selects the production local-plus-server store. Supplying a store keeps UI tests wholly
+    // in memory and avoids making a fake repository call just because the library was composed.
+    playbackHistory: PlaybackHistoryStore? = null,
     playbackFactory: (
         TtsRoadRepository,
         MediaSourceFactory,
@@ -162,13 +165,21 @@ class AppContainer(
         if (session.serverUrl.isBlank()) "" else PlaybackHistory.ownerKeyFor(session.serverUrl, session.username)
     }
 
+    /** Local fallback plus the account-wide `kind=auto` bookmark store shared with the web. */
+    val playbackHistory: PlaybackHistoryStore = playbackHistory ?: SyncedPlaybackHistoryStore(
+        local = FilePlaybackHistoryStore(),
+        repository = repository,
+        dispatcher = dispatchers.io,
+        currentOwnerKey = historyOwnerKey,
+    )
+
     val playback: PlaybackController = playbackFactory(
         repository,
         mediaSources,
         audioEngine,
         dispatchers,
         playbackPreferences,
-        playbackHistory,
+        this.playbackHistory,
         historyOwnerKey,
     )
 
@@ -249,6 +260,7 @@ class AppContainer(
         mprisScope.cancel()
         runCatching { downloads.close() }
         playback.release()
+        this.playbackHistory.close()
         libraryCache.close()
         readAlongCache.clear()
         readerPreferences.close()

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
@@ -82,6 +82,7 @@ class QueuePlaybackController(
     private val retryDelaysMs: List<Long> = listOf(2_000, 5_000, 15_000),
     private val tickIntervalMs: Long = 250,
     private val progressIntervalMs: Long = 10_000,
+    private val historyRecordIntervalMs: Long = 5 * 60_000L,
 ) : PlaybackController {
 
     private val _state = MutableStateFlow(emptyState())
@@ -111,6 +112,9 @@ class QueuePlaybackController(
     @Volatile private var lastKnownPositionMs = 0L
 
     @Volatile private var speed = preferencesStore.preferences.value.speed
+
+    /** Playing time since the last cross-device jump-back breadcrumb. Pauses add nothing. */
+    private var playedSinceHistoryRecordMs = 0L
 
     /**
      * Engine events, queued for the attempt loop to consume.
@@ -553,6 +557,17 @@ class QueuePlaybackController(
             if (position > 0) lastKnownPositionMs = position
             val duration = engine.durationMs().takeIf { it > 0 } ?: _state.value.durationMs
             _state.update { it.copy(positionMs = lastKnownPositionMs, durationMs = duration) }
+
+            // The web client writes the same `kind=auto` breadcrumb every five minutes of actual
+            // playback. Counting active ticks avoids treating a suspended laptop as five hours of
+            // listening when its coroutine resumes after sleep.
+            if (_state.value.isPlaying) {
+                playedSinceHistoryRecordMs += tickIntervalMs
+                if (playedSinceHistoryRecordMs >= historyRecordIntervalMs) {
+                    playedSinceHistoryRecordMs = 0L
+                    recordHistory()
+                }
+            }
 
             if (lastKnownPositionMs - lastSavedMs >= progressIntervalMs) {
                 lastSavedMs = lastKnownPositionMs

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/LibraryScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/LibraryScreen.kt
@@ -153,6 +153,10 @@ fun LibraryScreen(
     // Keyless on purpose: fires once per screen *appearance*, not per recomposition. Reuses cached
     // content and coalesces with a load already in flight, so Back into the library costs nothing.
     LaunchedEffect(Unit) { cache.ensureLibrary() }
+    // Local history paints immediately; the account-wide auto bookmarks merge underneath it when
+    // reachable, so opening the library after listening in the browser adds those moments without
+    // blanking the offline fallback.
+    LaunchedEffect(history, historyOwnerKey) { history.refresh(historyOwnerKey) }
     // Keyed, because switching modes is what makes browse-all worth fetching at all; it coalesces
     // the same way, so flipping back and forth costs one request each.
     LaunchedEffect(browseAll) { if (browseAll) cache.ensureBrowseAll() }
@@ -226,9 +230,9 @@ fun LibraryScreen(
                         }
                     }
 
-                    // Local, and therefore true even when the server's own continue-listening is
-                    // stale or unreachable: this is what *this machine* was playing. Dismissing an
-                    // entry hides that snapshot, not "today" — see PlaybackHistory.
+                    // Local-first and cross-device: the server's `auto` bookmarks merge into the
+                    // same bounded list, while this machine's copy survives an offline start.
+                    // Dismissing an entry hides that snapshot locally, not "today".
                     if (jumpBack.isNotEmpty()) {
                         fullWidthItem("jump-back") {
                             Column {

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackHistoryTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackHistoryTest.kt
@@ -167,6 +167,40 @@ class PlaybackHistoryTest {
     }
 
     @Test
+    fun `a remote breadcrumb cannot replace a newer local position or undo its dismissal`() {
+        val local = snapshot(
+            chapterId = 7,
+            positionSeconds = 300.0,
+            durationSeconds = 900.0,
+            recordedAtMs = 2_000,
+            dismissed = true,
+        )
+        val olderRemote = snapshot(
+            chapterId = 7,
+            positionSeconds = 120.0,
+            durationSeconds = 0.0,
+            recordedAtMs = 1_000,
+        )
+
+        val merged = PlaybackHistory.merge(listOf(local), listOf(olderRemote)).single()
+
+        assertEquals(300.0, merged.positionSeconds)
+        assertEquals(900.0, merged.durationSeconds)
+        assertTrue(merged.dismissed)
+    }
+
+    @Test
+    fun `a newer remote position keeps the duration this machine already resolved`() {
+        val local = snapshot(chapterId = 7, positionSeconds = 120.0, durationSeconds = 900.0, recordedAtMs = 1_000)
+        val remote = snapshot(chapterId = 7, positionSeconds = 300.0, durationSeconds = 0.0, recordedAtMs = 2_000)
+
+        val merged = PlaybackHistory.merge(listOf(local), listOf(remote)).single()
+
+        assertEquals(300.0, merged.positionSeconds)
+        assertEquals(900.0, merged.durationSeconds)
+    }
+
+    @Test
     fun `progress is bounded to zero and one`() {
         assertEquals(0f, snapshot(positionSeconds = -5.0).progress)
         assertEquals(1f, snapshot(positionSeconds = 9_999.0, durationSeconds = 600.0).progress)

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/SyncedPlaybackHistoryStoreTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/SyncedPlaybackHistoryStoreTest.kt
@@ -1,0 +1,129 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SyncedPlaybackHistoryStoreTest {
+
+    private val owner = PlaybackHistory.ownerKeyFor("https://ttsroad.example", "alice")
+
+    private fun snapshot(
+        positionSeconds: Double = 60.0,
+        recordedAtMs: Long = 1_000L,
+        ownerKey: String = owner,
+    ) = PlaybackSnapshot(
+        fictionId = 7,
+        chapterId = 101,
+        fictionTitle = "A Test Serial",
+        chapterTitle = "Chapter 3",
+        positionSeconds = positionSeconds,
+        durationSeconds = 600.0,
+        recordedAtMs = recordedAtMs,
+        ownerKey = ownerKey,
+    )
+
+    @Test
+    fun `recording stays local first and sends an auto bookmark`() = runTest {
+        val repository = FakeRepository()
+        val local = InMemoryPlaybackHistoryStore()
+        val store = SyncedPlaybackHistoryStore(
+            local,
+            repository,
+            UnconfinedTestDispatcher(testScheduler),
+        ) { owner }
+
+        store.record(snapshot(positionSeconds = 61.25))
+
+        assertEquals(61.25, local.history.value.single().positionSeconds)
+        val request = repository.createdBookmarks.single()
+        assertEquals(101, request.chapterId)
+        assertEquals(61.25, request.positionSeconds)
+        assertEquals(BookmarkKind.Auto, request.kind)
+    }
+
+    @Test
+    fun `a barely started chapter remains local without spending a server breadcrumb`() = runTest {
+        val repository = FakeRepository()
+        val local = InMemoryPlaybackHistoryStore()
+        val store = SyncedPlaybackHistoryStore(
+            local,
+            repository,
+            UnconfinedTestDispatcher(testScheduler),
+        ) { owner }
+
+        store.record(snapshot(positionSeconds = 12.0))
+
+        assertEquals(12.0, local.history.value.single().positionSeconds)
+        assertTrue(repository.createdBookmarks.isEmpty())
+    }
+
+    @Test
+    fun `refresh asks for auto bookmarks and merges another device's newest position`() = runTest {
+        val repository = FakeRepository(
+            bookmarksResult = Result.success(
+                listOf(
+                    Bookmark(
+                        id = 9,
+                        chapterId = 101,
+                        fictionId = 7,
+                        positionSeconds = 240.0,
+                        kind = BookmarkKind.Auto,
+                        createdAt = "2026-08-14T10:15:30Z",
+                        chapterTitle = "Chapter 3",
+                        fictionTitle = "A Test Serial",
+                    ),
+                ),
+            ),
+        )
+        val local = InMemoryPlaybackHistoryStore(listOf(snapshot(positionSeconds = 60.0, recordedAtMs = 1_000)))
+        val store = SyncedPlaybackHistoryStore(
+            local,
+            repository,
+            UnconfinedTestDispatcher(testScheduler),
+        ) { owner }
+
+        store.refresh(owner)
+
+        assertEquals(listOf<Pair<String?, Int?>>(BookmarkKind.Auto to null), repository.bookmarkListCalls)
+        val merged = local.history.value.single()
+        assertEquals(240.0, merged.positionSeconds)
+        assertEquals(600.0, merged.durationSeconds, "the server has no duration, so the local one survives")
+    }
+
+    @Test
+    fun `a result for an account that has since signed out is discarded`() = runTest {
+        var current = owner
+        val repository = FakeRepository(
+            bookmarksResult = Result.success(
+                listOf(
+                    Bookmark(
+                        id = 9,
+                        chapterId = 101,
+                        fictionId = 7,
+                        positionSeconds = 240.0,
+                        kind = BookmarkKind.Auto,
+                        createdAt = "2026-08-14T10:15:30Z",
+                    ),
+                ),
+            ),
+        )
+        val local = InMemoryPlaybackHistoryStore()
+        val store = SyncedPlaybackHistoryStore(
+            local,
+            repository,
+            UnconfinedTestDispatcher(testScheduler),
+        ) { current }
+
+        current = ""
+        store.refresh(owner)
+
+        assertTrue(repository.bookmarkListCalls.isEmpty())
+        assertTrue(local.history.value.isEmpty())
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackControllerTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackControllerTest.kt
@@ -5,6 +5,7 @@ import dk.perspektiva.ttsroad.desktop.data.AudioInfo
 import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
 import dk.perspektiva.ttsroad.desktop.data.ChaptersResponse
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackHistoryStore
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -40,13 +41,19 @@ class QueuePlaybackControllerTest {
         sources: FakeMediaSourceFactory = FakeMediaSourceFactory(),
         repository: FakeRepository = FakeRepository(),
         retryDelaysMs: List<Long> = emptyList(),
+        history: InMemoryPlaybackHistoryStore = InMemoryPlaybackHistoryStore(),
+        ownerKey: () -> String = { "" },
+        historyRecordIntervalMs: Long = 5 * 60_000L,
     ) = QueuePlaybackController(
         repository = repository,
         sources = sources,
         engine = engine,
         ioDispatcher = Dispatchers.Default,
+        historyStore = history,
+        ownerKey = ownerKey,
         retryDelaysMs = retryDelaysMs,
         tickIntervalMs = 10,
+        historyRecordIntervalMs = historyRecordIntervalMs,
     )
 
     private suspend fun PlaybackController.await(
@@ -342,6 +349,32 @@ class QueuePlaybackControllerTest {
         awaitCondition("a save on pause at the reported position") {
             repository.savedProgress.any { it.first == 101 && it.second == 42.0 && !it.third }
         }
+        controller.release()
+    }
+
+    @Test
+    fun `playing continuously records a jump-back breadcrumb every five minutes`() = runBlocking {
+        val engine = FakePlaybackEngine()
+        engine.durationOnPrepare = 600_000
+        val history = InMemoryPlaybackHistoryStore()
+        val controller = controllerFor(
+            engine = engine,
+            history = history,
+            ownerKey = { "owner" },
+            // Thirty milliseconds in the test represents the production five-minute cadence.
+            historyRecordIntervalMs = 30,
+        )
+
+        controller.play(chapter(101, "Chapter 3", 600.0), FictionSummary(id = 7, title = "A Test Serial"))
+        controller.await("playback to start") { it.isPlaying }
+        engine.setPosition(45_000)
+
+        awaitCondition("a periodic history record while playback continues") { history.history.value.isNotEmpty() }
+
+        val snapshot = history.history.value.single()
+        assertEquals(101, snapshot.chapterId)
+        assertEquals(45.0, snapshot.positionSeconds)
+        assertEquals("owner", snapshot.ownerKey)
         controller.release()
     }
 


### PR DESCRIPTION
Fixes #49.

The desktop now uses the server's `kind=auto` bookmarks as the shared home for jump-back breadcrumbs while retaining `history.json` as an immediate offline fallback.

- records locally at transitions and every five minutes of active playback
- sends best-effort automatic bookmarks without surfacing background offline failures
- merges full server pulls into the bounded local list without replacing newer offline positions
- preserves machine-local dismissals and locally known durations
- rejects stale cross-account results during session changes
- keeps manual bookmark lists filtered to `kind=manual` as implemented in #56

Validation:

```
xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail -Pttsroad.warningsAsErrors=true
```

`BUILD SUCCESSFUL`.