### PR TITLE
Use timestamped delta sync for cached metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to TTSRoad Desktop are recorded here. The format follows
 
 ### Added
 
+- Timestamp-based metadata refresh for the library and chapter lists. Servers that advertise the
+  delta-sync contract now receive one small change-index request followed only by the sparse data
+  that changed; older servers continue to receive ordinary full refreshes.
 - Cross-device jump-back history through the server's `kind=auto` bookmarks. The desktop writes a
   breadcrumb every five minutes of playback and at its existing transition points, merges moments
   recorded by other clients into the Jump back shelf, and retains the bounded local copy offline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,8 +144,11 @@ apply to audio.
   above 1 GiB. Never surface streaming cache as a requested Offline download.
 - `LibraryDiskCache` holds owner-only rebuildable metadata under the same identity. It strips
   server-local paths/errors, publishes cached content with the original last-refresh time, and
-  refreshes underneath. Settings measures real files, groups downloads by fiction, and keeps
-  confirmed Delete all downloads separate from Clear streaming cache.
+  refreshes underneath. A snapshot's server cursor drives `/api/mobile/sync`; unchanged resources
+  advance that cursor without downloading their payload, while changed resources merge sparse
+  rows and tombstones through `data/DeltaSync.kt`. Missing/old delta endpoints fall back to a full
+  refresh. Settings measures real files, groups downloads by fiction, and keeps confirmed Delete
+  all downloads separate from Clear streaming cache.
 
 ### Read-along
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Built with Compose for Desktop — real Skia-rendered UI, real OS installers, no
 | App shortcuts — Space, arrows, Ctrl+arrows, Ctrl+L, Ctrl+, plus an F1 list | ✅ |
 | Offline downloads — per chapter, next 10, restart-safe queue, storage controls | ✅ |
 | Bounded streaming cache and previously loaded library browsing while offline | ✅ |
+| Timestamped delta refresh for cached library and chapter metadata | ✅ |
 | Audio-synchronized read-along — offline text, word seek, find, themes and zoom | ✅ |
 | Streaming playback — audio starts before the chapter has downloaded | ✅ Linux |
 | Seeking without decoding from the start of the chapter | ✅ Linux |
@@ -295,6 +296,7 @@ src/main/kotlin/dk/perspektiva/ttsroad/desktop/
 │   ├── Cached.kt                 value + error + isRefreshing + last success, independently
 │   ├── LibraryCache.kt           library/chapter state held above the screens
 │   ├── LibraryDiskCache.kt       account-scoped rebuildable metadata for offline browsing
+│   ├── DeltaSync.kt              sparse metadata merge + deletion/cursor rules
 │   ├── ReadAlongModels.kt        compact text/cue and account-preference API models
 │   ├── ReadAlongDocument.kt      validated spans + binary highlight/seek/find lookup
 │   ├── ReadAlongSentences.kt     paragraph-bounded sentence segmentation

--- a/docs/adr/0007-offline-downloads-and-streaming-cache.md
+++ b/docs/adr/0007-offline-downloads-and-streaming-cache.md
@@ -91,6 +91,18 @@ On first open after restart, `LibraryCache` publishes the disk snapshot immediat
 last-success time, then refreshes. A network failure appears above retained content, which remains
 clearly dated. Stored models remove backend error text and server-local audio filename/path fields.
 
+When a cached response carries a server timestamp, refresh first asks the timestamped sync index
+which resource changed. An unchanged resource advances to the index's pre-query `server_time`
+without transferring the full payload; a changed resource requests its sparse delta and merges rows
+and explicit tombstones. Chapter display/player positions are recomputed from the merged whole so an
+insert cannot leave derived ordering stale. A missing endpoint, a non-delta response, or a snapshot
+from an older server safely falls back to the full resource request.
+
+Follow membership is checked from the library delta's complete `following_ids` even when the current
+server's index reports no library change. An unknown newly followed id triggers a full library pull.
+This compatibility request can disappear once the server's index treats follow-table mutations as
+library changes; until then it prevents a quiet index from hiding cross-client follows and unfollows.
+
 Signing out deletes none of these roots, but `DownloadCoordinator` closes the live stack unless a
 real bearer credential is present. Retained login hints are not authority to enumerate another
 account's index or fiction titles. Signing the same account back in resolves the same namespace.

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/DeltaSync.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/DeltaSync.kt
@@ -1,0 +1,152 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Json
+
+/** The cheap `/api/mobile/sync` index that says which resource deltas are worth pulling. */
+data class DeltaSyncResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    @param:Json(name = "server_time") val serverTime: String? = null,
+    @param:Json(name = "updated_since") val updatedSince: String? = null,
+    val delta: Boolean = false,
+    val limits: DeltaSyncLimits = DeltaSyncLimits(),
+    val endpoints: DeltaSyncEndpoints = DeltaSyncEndpoints(),
+    val changed: DeltaSyncChanged = DeltaSyncChanged(),
+    val deleted: DeltaSyncDeleted = DeltaSyncDeleted(),
+) {
+    /** The library payload's rows or always-complete listening rails may have changed. */
+    val changesLibrary: Boolean
+        get() = changed.fictions.isNotEmpty() || changed.playback > 0 || deleted.fictions.isNotEmpty()
+
+    fun changesFiction(fictionId: Int): Boolean =
+        fictionId > 0 && changed.fictions.any { it.fictionId == fictionId }
+}
+
+data class DeltaSyncLimits(
+    @param:Json(name = "max_chapters_per_page") val maxChaptersPerPage: Int? = null,
+    @param:Json(name = "max_playback_sync_items") val maxPlaybackSyncItems: Int? = null,
+)
+
+data class DeltaSyncEndpoints(
+    val library: String? = null,
+    val chapters: String? = null,
+    val bookmarks: String? = null,
+    @param:Json(name = "playback_sync") val playbackSync: String? = null,
+)
+
+data class DeltaSyncChanged(
+    val fictions: List<DeltaSyncFiction> = emptyList(),
+    val playback: Int = 0,
+    val bookmarks: Int = 0,
+)
+
+data class DeltaSyncFiction(
+    @param:Json(name = "fiction_id") val fictionId: Int = 0,
+    val slug: String? = null,
+    val title: String? = null,
+    @param:Json(name = "updated_at") val updatedAt: String? = null,
+    @param:Json(name = "changed_chapters") val changedChapters: Int = 0,
+    @param:Json(name = "deleted_chapters") val deletedChapters: Int = 0,
+    @param:Json(name = "changed_playback") val changedPlayback: Int = 0,
+)
+
+data class DeltaSyncDeleted(
+    val fictions: List<Int> = emptyList(),
+    val chapters: List<Int> = emptyList(),
+    val bookmarks: List<Int> = emptyList(),
+)
+
+/**
+ * Applies a library delta to the full local view.
+ *
+ * Listening rails are complete even on a delta, so they come from [delta] outright. Fiction rows
+ * are keyed merges and tombstones are consumed. A server that ignored `updated_since` answers a
+ * full response (`delta=false`), which is already a safe replacement.
+ */
+fun LibraryResponse.mergedWith(delta: LibraryResponse): LibraryResponse {
+    if (!delta.delta) return delta
+    require(scope == null || delta.scope == null || scope == delta.scope) {
+        "library delta scope did not match the cached library"
+    }
+    val deletedIds = delta.deleted.toSet()
+    val followedIds = delta.followingIds?.toSet().takeIf { delta.scope == LibraryScope.Followed.wireValue }
+    val changedById = delta.fictions.filter { it.id > 0 }.associateBy { it.id }
+    val retained = fictions.mapNotNull { fiction ->
+        when {
+            fiction.id in deletedIds -> null
+            followedIds != null && fiction.id !in followedIds -> null
+            changedById.containsKey(fiction.id) -> changedById.getValue(fiction.id)
+            else -> fiction
+        }
+    }
+    val knownIds = retained.mapTo(HashSet()) { it.id }
+    val added = delta.fictions.filter {
+        it.id > 0 && it.id !in knownIds && it.id !in deletedIds && (followedIds == null || it.id in followedIds)
+    }
+    return delta.copy(
+        scope = delta.scope ?: scope,
+        delta = false,
+        updatedSince = null,
+        deleted = emptyList(),
+        fictions = retained + added,
+    )
+}
+
+/**
+ * A newly followed fiction can be named by `following_ids` without appearing in the changed rows:
+ * the follow moved, not the fiction. The delta cannot materialize a row it did not send, so that
+ * one case requires a full shelf pull.
+ */
+fun LibraryResponse.deltaNeedsFullFollowPull(delta: LibraryResponse): Boolean {
+    if (delta.scope != LibraryScope.Followed.wireValue) return false
+    val followed = delta.followingIds ?: return false
+    val available = (fictions + delta.fictions).mapTo(HashSet()) { it.id }
+    return followed.any { it !in available }
+}
+
+/** Applies one fiction's changed rows and tombstones to its full cached chapter list. */
+fun ChaptersResponse.mergedWith(delta: ChaptersResponse): ChaptersResponse {
+    if (!delta.delta) return delta
+    require(fiction.id == delta.fiction.id) { "chapter delta belonged to another fiction" }
+    val deletedIds = delta.deleted.toSet()
+    val changedById = delta.chapters.filter { it.resolvedChapterId > 0 }
+        .associateBy { it.resolvedChapterId }
+    val retained = chapters.mapNotNull { chapter ->
+        val id = chapter.resolvedChapterId
+        when {
+            id in deletedIds -> null
+            changedById.containsKey(id) -> changedById.getValue(id)
+            else -> chapter
+        }
+    }
+    val knownIds = retained.mapTo(HashSet()) { it.resolvedChapterId }
+    val added = delta.chapters.filter {
+        val id = it.resolvedChapterId
+        id > 0 && id !in knownIds && id !in deletedIds
+    }
+    // `display_number` and `player_index` are derived from the whole fiction. Excluding or
+    // inserting one row shifts every later value even though those chapter rows did not change,
+    // so accepting the sparse values verbatim would leave duplicate numbers in the merged cache.
+    var nextPlayerIndex = 0
+    val merged = (retained + added)
+        .sortedWith(compareBy<ChapterSummary> { it.chapterNumber ?: Int.MAX_VALUE }.thenBy { it.resolvedChapterId })
+        .mapIndexed { index, chapter ->
+            chapter.copy(
+                displayNumber = (index + 1).toDouble(),
+                playerIndex = if (chapter.hasAudio) nextPlayerIndex++ else null,
+            )
+        }
+    return delta.copy(
+        delta = false,
+        updatedSince = null,
+        deleted = emptyList(),
+        total = merged.size,
+        chapters = merged,
+    )
+}
+
+/** Advances a fully materialized resource after the index proves nothing in it changed. */
+fun LibraryResponse.withSyncCursor(serverTime: String): LibraryResponse =
+    copy(serverTime = serverTime, updatedSince = null, delta = false, deleted = emptyList())
+
+fun ChaptersResponse.withSyncCursor(serverTime: String): ChaptersResponse =
+    copy(serverTime = serverTime, updatedSince = null, delta = false, deleted = emptyList())

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryCache.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryCache.kt
@@ -84,17 +84,18 @@ class LibraryCache(
     }
 
     /** The explicit Refresh action. Always re-asks, cancelling any load already running. */
-    fun refreshLibrary() {
+    fun refreshLibrary(forceFull: Boolean = false) {
         libraryJob?.cancel()
         if (!_library.value.hasContent) primeLibraryFromDisk()
         _library.update { it.copy(isRefreshing = true, error = null) }
         val persistent = diskCache()
         libraryJob = scope.launch {
+            val current = _library.value.value
             load(
                 state = _library,
                 fallback = "Could not load library",
                 onLoaded = { value, savedAt -> persistent?.storeLibrary(value, savedAt) },
-            ) { repository.library() }
+            ) { refreshLibraryValue(current, forceFull) }
         }
     }
 
@@ -132,7 +133,7 @@ class LibraryCache(
         patchFollowing(fictionId, confirmed)
         // Membership changed, so the shelf is a different list now — a flag patch cannot express
         // a row appearing or disappearing.
-        refreshLibrary()
+        refreshLibrary(forceFull = true)
         return confirmed
     }
 
@@ -182,11 +183,12 @@ class LibraryCache(
         state.update { it.copy(isRefreshing = true, error = null) }
         val persistent = diskCache()
         chapterJobs[fictionId] = scope.launch {
+            val current = state.value.value
             load(
                 state = state,
                 fallback = "Could not load chapters",
                 onLoaded = { value, savedAt -> persistent?.storeChapters(fictionId, value, savedAt) },
-            ) { repository.chapters(fictionId) }
+            ) { refreshChaptersValue(fictionId, current) }
         }
     }
 
@@ -360,6 +362,40 @@ class LibraryCache(
         val stored = diskCache()?.loadChapters(fictionId) ?: return
         if (state.value.hasContent) return
         state.value = Cached(value = stored.value, lastSuccessMillis = stored.savedAtMillis)
+    }
+
+    /** One index call, then only the shelf bytes that actually changed. */
+    private suspend fun refreshLibraryValue(
+        current: LibraryResponse?,
+        forceFull: Boolean,
+    ): LibraryResponse {
+        if (forceFull) return repository.library()
+        val cursor = current?.serverTime?.takeIf { it.isNotBlank() } ?: return repository.library()
+        val index = repository.deltaSync(cursor) ?: return repository.library()
+        val nextCursor = index.serverTime?.takeIf { it.isNotBlank() } ?: return repository.library()
+        if (!index.delta) return repository.library()
+        // The current backend's sync index does not count follow-table changes. A follows-aware
+        // response therefore gets one cheap library delta even when the index is otherwise quiet;
+        // its complete `following_ids` detects removals and the rare new-row case below.
+        val checksMembership = current.scope == LibraryScope.Followed.wireValue && current.followingIds != null
+        if (!index.changesLibrary && !checksMembership) return current.withSyncCursor(nextCursor)
+        val delta = repository.libraryDelta(cursor)
+        if (current.deltaNeedsFullFollowPull(delta)) return repository.library()
+        return current.mergedWith(delta)
+    }
+
+    /** One index call, then one small per-fiction delta only when that fiction moved. */
+    private suspend fun refreshChaptersValue(
+        fictionId: Int,
+        current: ChaptersResponse?,
+    ): ChaptersResponse {
+        val cursor = current?.serverTime?.takeIf { it.isNotBlank() } ?: return repository.chapters(fictionId)
+        val index = repository.deltaSync(cursor) ?: return repository.chapters(fictionId)
+        val nextCursor = index.serverTime?.takeIf { it.isNotBlank() } ?: return repository.chapters(fictionId)
+        if (!index.delta) return repository.chapters(fictionId)
+        check(fictionId !in index.deleted.fictions) { "This fiction was deleted on the server" }
+        if (!index.changesFiction(fictionId)) return current.withSyncCursor(nextCursor)
+        return current.mergedWith(repository.chaptersDelta(fictionId, cursor))
     }
 
     private suspend fun <T> load(

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
@@ -52,7 +52,15 @@ data class LibraryResponse(
      * `scope` key at all.
      */
     val scope: String? = null,
+    /** Server-issued cursor, echoed as `updated_since` on the next delta pull. */
+    @param:Json(name = "server_time") val serverTime: String? = null,
+    @param:Json(name = "updated_since") val updatedSince: String? = null,
+    val delta: Boolean = false,
+    /** Fiction ids removed since [updatedSince]. Empty on a full response. */
+    val deleted: List<Int> = emptyList(),
     val fictions: List<FictionSummary> = emptyList(),
+    /** Complete account membership even on a delta; absent on pre-follows servers. */
+    @param:Json(name = "following_ids") val followingIds: List<Int>? = null,
     @param:Json(name = "continue_listening") val continueListening: List<ChapterSummary> = emptyList(),
     @param:Json(name = "recent_chapters") val recentChapters: List<ChapterSummary> = emptyList(),
 )
@@ -85,6 +93,12 @@ data class FollowResponse(
 data class ChaptersResponse(
     @param:Json(name = "api_version") val apiVersion: Int = 1,
     val fiction: FictionSummary,
+    /** Server-issued cursor, echoed as `updated_since` on the next delta pull. */
+    @param:Json(name = "server_time") val serverTime: String? = null,
+    @param:Json(name = "updated_since") val updatedSince: String? = null,
+    val delta: Boolean = false,
+    /** Deleted or newly excluded chapter ids since [updatedSince]. */
+    val deleted: List<Int> = emptyList(),
     val total: Int = 0,
     val chapters: List<ChapterSummary> = emptyList(),
 )
@@ -214,6 +228,10 @@ data class PlaybackInfo(
     @param:Json(name = "remaining_seconds") val remainingSeconds: Double? = null,
     /** ISO-8601 UTC; null until the chapter has actually been listened to. */
     @param:Json(name = "last_listened_at") val lastListenedAt: String? = null,
+    /** Server write clock used by `updated_since` filtering. */
+    @param:Json(name = "updated_at") val updatedAt: String? = null,
+    /** Device clock that resolves conflicts between offline writes. */
+    @param:Json(name = "client_updated_at") val clientUpdatedAt: String? = null,
 )
 
 data class PlaybackProgressRequest(

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -108,6 +108,12 @@ interface TtsRoadRepository {
 
     suspend fun library(scope: LibraryScope = LibraryScope.Followed): LibraryResponse
 
+    /** The changed shelf rows and complete listening rails since a server-issued cursor. */
+    suspend fun libraryDelta(updatedSince: String): LibraryResponse = library()
+
+    /** The cheap delta index, or null when this server predates it. */
+    suspend fun deltaSync(updatedSince: String): DeltaSyncResponse? = null
+
     /**
      * Follows or unfollows a fiction, answering the state **the server now holds**, or null when it
      * answered 404.
@@ -149,6 +155,9 @@ interface TtsRoadRepository {
     suspend fun revokeOtherDevices(): Boolean
 
     suspend fun chapters(fictionId: Int, playableOnly: Boolean = false): ChaptersResponse
+
+    /** Changed/deleted chapter rows for one fiction since a server-issued cursor. */
+    suspend fun chaptersDelta(fictionId: Int, updatedSince: String): ChaptersResponse = chapters(fictionId)
 
     /**
      * Server-side search, or **null when this server has no search endpoint**.
@@ -406,6 +415,12 @@ class RetrofitTtsRoadRepository(
     override suspend fun library(scope: LibraryScope): LibraryResponse =
         withAuthorizedApi { it.library(scope.wireValue) }
 
+    override suspend fun libraryDelta(updatedSince: String): LibraryResponse =
+        withAuthorizedApi { it.library(LibraryScope.Followed.wireValue, updatedSince) }
+
+    override suspend fun deltaSync(updatedSince: String): DeltaSyncResponse? =
+        ifEndpointExists { it.deltaSync(updatedSince) }
+
     override suspend fun setFollowing(fictionId: Int, following: Boolean): Boolean? =
         ifEndpointExists {
             // The answer is read, never assumed: a response is the only proof the shelf changed.
@@ -424,6 +439,9 @@ class RetrofitTtsRoadRepository(
 
     override suspend fun chapters(fictionId: Int, playableOnly: Boolean): ChaptersResponse =
         withAuthorizedApi { it.chapters(fictionId = fictionId, playableOnly = playableOnly) }
+
+    override suspend fun chaptersDelta(fictionId: Int, updatedSince: String): ChaptersResponse =
+        withAuthorizedApi { it.chapters(fictionId = fictionId, updatedSince = updatedSince) }
 
     override suspend fun search(query: String, limit: Int, offset: Int): SearchResponse? =
         ifEndpointExists {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -67,7 +67,14 @@ interface TtsRoadApi {
      * answers the shared list it always did, which is what makes browse-all safe to ask for.
      */
     @GET("api/mobile/library")
-    suspend fun library(@Query("scope") scope: String = LibraryScope.Followed.wireValue): LibraryResponse
+    suspend fun library(
+        @Query("scope") scope: String = LibraryScope.Followed.wireValue,
+        @Query("updated_since") updatedSince: String? = null,
+    ): LibraryResponse
+
+    /** Cheap index before resource-specific delta pulls. 404 on a pre-delta server. */
+    @GET("api/mobile/sync")
+    suspend fun deltaSync(@Query("updated_since") updatedSince: String): DeltaSyncResponse
 
     /** Puts a fiction on this account's shelf. 404 for a fiction that does not exist. */
     @POST("api/mobile/fictions/{fiction_id}/follow")
@@ -95,6 +102,7 @@ interface TtsRoadApi {
         @Path("fiction_id") fictionId: Int,
         @Query("playable_only") playableOnly: Boolean = false,
         @Query("include_excluded") includeExcluded: Boolean = false,
+        @Query("updated_since") updatedSince: String? = null,
     ): ChaptersResponse
 
     /** Raw response exposes both the ETag and the normal 304 revalidation path. */

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -6,6 +6,7 @@ import dk.perspektiva.ttsroad.desktop.data.BookmarkPatchRequest
 import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
 import dk.perspektiva.ttsroad.desktop.data.ChaptersResponse
 import dk.perspektiva.ttsroad.desktop.data.DeviceSession
+import dk.perspektiva.ttsroad.desktop.data.DeltaSyncResponse
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
 import dk.perspektiva.ttsroad.desktop.data.LibraryResponse
 import dk.perspektiva.ttsroad.desktop.data.LoginResult
@@ -33,6 +34,12 @@ open class FakeRepository(
     var loginResult: LoginResult = LoginResult.Success,
     var libraryResult: Result<LibraryResponse> = Result.success(LibraryResponse()),
     var chaptersResult: Result<ChaptersResponse> = Result.success(ChaptersResponse(fiction = FictionSummary())),
+    /** Null means use [libraryResult], which models an older endpoint returning a full response. */
+    var libraryDeltaResult: Result<LibraryResponse>? = null,
+    /** Null means use [chaptersResult], which models an older endpoint returning a full response. */
+    var chaptersDeltaResult: Result<ChaptersResponse>? = null,
+    /** `success(null)` is the server saying it has no delta index. */
+    var deltaSyncResult: Result<DeltaSyncResponse?> = Result.success(null),
     var serverUrl: String = "https://ttsroad.example.com/",
     var capabilitiesResult: ServerCapabilities = ServerCapabilities.Baseline,
     /** `success(null)` is the server saying it has no device API — not "no devices". */
@@ -68,6 +75,9 @@ open class FakeRepository(
         private set
     var chaptersCalls: Int = 0
         private set
+    val libraryDeltaCursors: MutableList<String> = mutableListOf()
+    val chapterDeltaCalls: MutableList<Pair<Int, String>> = mutableListOf()
+    val deltaSyncCursors: MutableList<String> = mutableListOf()
     var devicesCalls: Int = 0
         private set
     var revokeOtherDevicesCalls: Int = 0
@@ -151,6 +161,16 @@ open class FakeRepository(
             .getOrThrow()
     }
 
+    override suspend fun libraryDelta(updatedSince: String): LibraryResponse {
+        libraryDeltaCursors += updatedSince
+        return (libraryDeltaResult ?: libraryResult).getOrThrow()
+    }
+
+    override suspend fun deltaSync(updatedSince: String): DeltaSyncResponse? {
+        deltaSyncCursors += updatedSince
+        return deltaSyncResult.getOrThrow()
+    }
+
     override suspend fun setFollowing(fictionId: Int, following: Boolean): Boolean? {
         followCalls += fictionId to following
         // An *unset* `followResult` echoes what was asked, which is what a healthy server does.
@@ -180,6 +200,11 @@ open class FakeRepository(
     override suspend fun chapters(fictionId: Int, playableOnly: Boolean): ChaptersResponse {
         chaptersCalls++
         return chaptersResult.getOrThrow()
+    }
+
+    override suspend fun chaptersDelta(fictionId: Int, updatedSince: String): ChaptersResponse {
+        chapterDeltaCalls += fictionId to updatedSince
+        return (chaptersDeltaResult ?: chaptersResult).getOrThrow()
     }
 
     override suspend fun search(

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/DeltaSyncTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/DeltaSyncTest.kt
@@ -1,0 +1,114 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class DeltaSyncTest {
+
+    @Test
+    fun `a library delta replaces changed rows consumes tombstones and replaces the complete rails`() {
+        val before = LibraryResponse(
+            scope = "followed",
+            serverTime = "2026-08-14T10:00:00Z",
+            fictions = listOf(FictionSummary(id = 1, title = "Delete me"), FictionSummary(id = 2, title = "Old")),
+            continueListening = listOf(ChapterSummary(id = 10)),
+        )
+        val delta = LibraryResponse(
+            scope = "followed",
+            serverTime = "2026-08-14T11:00:00Z",
+            updatedSince = before.serverTime,
+            delta = true,
+            deleted = listOf(1),
+            fictions = listOf(FictionSummary(id = 2, title = "Updated"), FictionSummary(id = 3, title = "Added")),
+            continueListening = listOf(ChapterSummary(id = 30)),
+        )
+
+        val merged = before.mergedWith(delta)
+
+        assertEquals(listOf(2, 3), merged.fictions.map { it.id })
+        assertEquals("Updated", merged.fictions.first().title)
+        assertEquals(listOf(30), merged.continueListening.map { it.id })
+        assertEquals("2026-08-14T11:00:00Z", merged.serverTime)
+        assertFalse(merged.delta)
+        assertTrue(merged.deleted.isEmpty())
+    }
+
+    @Test
+    fun `a full response from an older library endpoint replaces rather than merges`() {
+        val before = LibraryResponse(fictions = listOf(FictionSummary(id = 1)))
+        val full = LibraryResponse(fictions = listOf(FictionSummary(id = 9)))
+
+        assertEquals(listOf(9), before.mergedWith(full).fictions.map { it.id })
+    }
+
+    @Test
+    fun `complete follow membership removes an unfollowed row and detects a newly followed unknown row`() {
+        val before = LibraryResponse(
+            scope = "followed",
+            followingIds = listOf(1, 2),
+            fictions = listOf(FictionSummary(id = 1), FictionSummary(id = 2)),
+        )
+        val unfollow = LibraryResponse(scope = "followed", delta = true, followingIds = listOf(1))
+        val newFollow = LibraryResponse(scope = "followed", delta = true, followingIds = listOf(1, 2, 3))
+
+        assertEquals(listOf(1), before.mergedWith(unfollow).fictions.map { it.id })
+        assertFalse(before.deltaNeedsFullFollowPull(unfollow))
+        assertTrue(before.deltaNeedsFullFollowPull(newFollow))
+    }
+
+    @Test
+    fun `a chapter delta replaces adds deletes and keeps canonical reading order`() {
+        val fiction = FictionSummary(id = 7, title = "Serial")
+        val before = ChaptersResponse(
+            fiction = fiction,
+            serverTime = "2026-08-14T10:00:00Z",
+            total = 3,
+            chapters = listOf(
+                ChapterSummary(id = 101, fictionId = 7, title = "One", displayNumber = 1.0),
+                ChapterSummary(id = 102, fictionId = 7, title = "Old two", displayNumber = 2.0),
+                ChapterSummary(id = 103, fictionId = 7, title = "Delete", displayNumber = 3.0),
+            ),
+        )
+        val delta = ChaptersResponse(
+            fiction = fiction.copy(title = "Renamed serial"),
+            serverTime = "2026-08-14T11:00:00Z",
+            updatedSince = before.serverTime,
+            delta = true,
+            deleted = listOf(103),
+            total = 2,
+            chapters = listOf(
+                ChapterSummary(id = 102, fictionId = 7, title = "New two", displayNumber = 2.0),
+                ChapterSummary(id = 104, fictionId = 7, title = "Four", displayNumber = 4.0),
+            ),
+        )
+
+        val merged = before.mergedWith(delta)
+
+        assertEquals(listOf(101, 102, 104), merged.chapters.map { it.id })
+        assertEquals("New two", merged.chapters[1].title)
+        assertEquals("Renamed serial", merged.fiction.title)
+        assertEquals(3, merged.total)
+        assertFalse(merged.delta)
+        assertTrue(merged.deleted.isEmpty())
+    }
+
+    @Test
+    fun `a chapter delta for another fiction is rejected instead of corrupting the cache`() {
+        val before = ChaptersResponse(fiction = FictionSummary(id = 7))
+        val wrong = ChaptersResponse(fiction = FictionSummary(id = 8), delta = true)
+
+        assertThrows<IllegalArgumentException> { before.mergedWith(wrong) }
+    }
+
+    @Test
+    fun `the index distinguishes bookmark-only work from library work`() {
+        val bookmarks = DeltaSyncResponse(delta = true, changed = DeltaSyncChanged(bookmarks = 1))
+        val playback = DeltaSyncResponse(delta = true, changed = DeltaSyncChanged(playback = 1))
+
+        assertFalse(bookmarks.changesLibrary)
+        assertTrue(playback.changesLibrary)
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryCacheTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryCacheTest.kt
@@ -32,6 +32,19 @@ class LibraryCacheTest {
         fictions = titles.mapIndexed { index, title -> FictionSummary(id = index + 1, title = title) },
     )
 
+    private fun syncIndex(
+        serverTime: String,
+        fictions: List<DeltaSyncFiction> = emptyList(),
+        playback: Int = 0,
+        deletedFictions: List<Int> = emptyList(),
+    ) = DeltaSyncResponse(
+        serverTime = serverTime,
+        updatedSince = "cursor",
+        delta = true,
+        changed = DeltaSyncChanged(fictions = fictions, playback = playback),
+        deleted = DeltaSyncDeleted(fictions = deletedFictions),
+    )
+
     // --- Library ------------------------------------------------------------------------------
 
     @Test
@@ -103,6 +116,120 @@ class LibraryCacheTest {
         assertEquals("Cached chapter", cache.chapters(7).value.value?.chapters?.single()?.title)
         assertEquals(2_000L, cache.chapters(7).value.lastSuccessMillis)
         assertEquals("server offline", cache.chapters(7).value.error)
+        cache.close()
+    }
+
+    @Test
+    fun `a cached library with no indexed changes advances its cursor without a full pull`() = runTest {
+        val disk = LibraryDiskCache(File(tempDir, "metadata-no-change"))
+        disk.storeLibrary(
+            LibraryResponse(
+                serverTime = "2026-08-14T10:00:00Z",
+                fictions = listOf(FictionSummary(id = 7, title = "Cached")),
+            ),
+            1_000,
+        )
+        val repository = FakeRepository(
+            deltaSyncResult = Result.success(syncIndex("2026-08-14T11:00:00Z")),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler)) { 2_000L }
+            .attachDiskCache { disk }
+
+        cache.ensureLibrary()
+        runCurrent()
+
+        assertEquals(listOf("2026-08-14T10:00:00Z"), repository.deltaSyncCursors)
+        assertEquals(0, repository.libraryCalls)
+        assertTrue(repository.libraryDeltaCursors.isEmpty())
+        assertEquals("Cached", cache.library.value.value?.fictions?.single()?.title)
+        assertEquals("2026-08-14T11:00:00Z", disk.loadLibrary()?.value?.serverTime)
+        assertEquals(2_000L, cache.library.value.lastSuccessMillis)
+        cache.close()
+    }
+
+    @Test
+    fun `a cached library pulls and merges only the indexed delta`() = runTest {
+        val disk = LibraryDiskCache(File(tempDir, "metadata-library-delta"))
+        disk.storeLibrary(
+            LibraryResponse(
+                scope = "followed",
+                serverTime = "2026-08-14T10:00:00Z",
+                fictions = listOf(
+                    FictionSummary(id = 7, title = "Old title"),
+                    FictionSummary(id = 8, title = "Deleted"),
+                ),
+                continueListening = listOf(ChapterSummary(id = 101)),
+            ),
+            1_000,
+        )
+        val repository = FakeRepository(
+            deltaSyncResult = Result.success(
+                syncIndex(
+                    "2026-08-14T10:30:00Z",
+                    fictions = listOf(DeltaSyncFiction(fictionId = 7, changedChapters = 1)),
+                    deletedFictions = listOf(8),
+                ),
+            ),
+            libraryDeltaResult = Result.success(
+                LibraryResponse(
+                    scope = "followed",
+                    serverTime = "2026-08-14T10:31:00Z",
+                    updatedSince = "2026-08-14T10:00:00Z",
+                    delta = true,
+                    deleted = listOf(8),
+                    fictions = listOf(FictionSummary(id = 7, title = "New title")),
+                    continueListening = listOf(ChapterSummary(id = 102)),
+                ),
+            ),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+            .attachDiskCache { disk }
+
+        cache.ensureLibrary()
+        runCurrent()
+
+        val merged = cache.library.value.value!!
+        assertEquals(listOf(7), merged.fictions.map { it.id })
+        assertEquals("New title", merged.fictions.single().title)
+        assertEquals(listOf(102), merged.continueListening.map { it.id })
+        assertEquals(listOf("2026-08-14T10:00:00Z"), repository.libraryDeltaCursors)
+        assertEquals(0, repository.libraryCalls)
+        assertEquals("2026-08-14T10:31:00Z", disk.loadLibrary()?.value?.serverTime)
+        cache.close()
+    }
+
+    @Test
+    fun `a follows-aware shelf checks complete membership even when the sync index is quiet`() = runTest {
+        val disk = LibraryDiskCache(File(tempDir, "metadata-follow-delta"))
+        disk.storeLibrary(
+            LibraryResponse(
+                scope = "followed",
+                serverTime = "2026-08-14T10:00:00Z",
+                followingIds = listOf(7, 8),
+                fictions = listOf(FictionSummary(id = 7), FictionSummary(id = 8)),
+            ),
+            1_000,
+        )
+        val repository = FakeRepository(
+            deltaSyncResult = Result.success(syncIndex("2026-08-14T10:30:00Z")),
+            libraryDeltaResult = Result.success(
+                LibraryResponse(
+                    scope = "followed",
+                    serverTime = "2026-08-14T10:31:00Z",
+                    delta = true,
+                    followingIds = listOf(7),
+                ),
+            ),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+            .attachDiskCache { disk }
+
+        cache.ensureLibrary()
+        runCurrent()
+
+        assertEquals(listOf(7), cache.library.value.value?.fictions?.map { it.id })
+        assertEquals(listOf("2026-08-14T10:00:00Z"), repository.libraryDeltaCursors)
+        assertEquals(0, repository.libraryCalls)
         cache.close()
     }
 
@@ -244,6 +371,59 @@ class LibraryCacheTest {
 
         assertEquals(2, repository.chaptersCalls, "one request per fiction, not per visit")
         assertEquals(1, cache.chapters(7).value.value?.chapters?.size)
+        cache.close()
+    }
+
+    @Test
+    fun `a cached chapter list pulls only its changed rows`() = runTest {
+        val fiction = FictionSummary(id = 7, title = "Serial")
+        val disk = LibraryDiskCache(File(tempDir, "metadata-chapter-delta"))
+        disk.storeChapters(
+            7,
+            ChaptersResponse(
+                fiction = fiction,
+                serverTime = "2026-08-14T10:00:00Z",
+                total = 2,
+                chapters = listOf(
+                    ChapterSummary(id = 101, fictionId = 7, title = "Old", displayNumber = 1.0),
+                    ChapterSummary(id = 102, fictionId = 7, title = "Delete", displayNumber = 2.0),
+                ),
+            ),
+            1_000,
+        )
+        val repository = FakeRepository(
+            deltaSyncResult = Result.success(
+                syncIndex(
+                    "2026-08-14T10:30:00Z",
+                    fictions = listOf(DeltaSyncFiction(fictionId = 7, changedChapters = 1, deletedChapters = 1)),
+                ),
+            ),
+            chaptersDeltaResult = Result.success(
+                ChaptersResponse(
+                    fiction = fiction,
+                    serverTime = "2026-08-14T10:31:00Z",
+                    updatedSince = "2026-08-14T10:00:00Z",
+                    delta = true,
+                    deleted = listOf(102),
+                    total = 1,
+                    chapters = listOf(
+                        ChapterSummary(id = 101, fictionId = 7, title = "Updated", displayNumber = 1.0),
+                    ),
+                ),
+            ),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+            .attachDiskCache { disk }
+
+        cache.ensureChapters(7)
+        runCurrent()
+
+        val merged = cache.chapters(7).value.value!!
+        assertEquals(listOf(101), merged.chapters.map { it.id })
+        assertEquals("Updated", merged.chapters.single().title)
+        assertEquals(listOf(7 to "2026-08-14T10:00:00Z"), repository.chapterDeltaCalls)
+        assertEquals(0, repository.chaptersCalls)
+        assertEquals("2026-08-14T10:31:00Z", disk.loadChapters(7)?.value?.serverTime)
         cache.close()
     }
 

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/RepositoryTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/RepositoryTest.kt
@@ -86,6 +86,58 @@ class RepositoryTest {
     }
 
     @Test
+    fun `delta index and resource pulls echo the server cursor`() = runTest {
+        enqueue(
+            200,
+            """
+            {"api_version":1,"server_time":"2026-08-14T11:00:00Z",
+             "updated_since":"2026-08-14T10:00:00Z","delta":true,
+             "changed":{"fictions":[{"fiction_id":7,"changed_chapters":1,
+               "deleted_chapters":0,"changed_playback":1}],"playback":1,"bookmarks":0},
+             "deleted":{"fictions":[],"chapters":[],"bookmarks":[]}}
+            """.trimIndent(),
+        )
+        val index = requireNotNull(repository.deltaSync("2026-08-14T10:00:00Z"))
+        assertTrue(index.changesFiction(7))
+        assertEquals(1, index.changed.playback)
+        var request = server.takeRequest()
+        assertEquals("/api/mobile/sync", request.url.encodedPath)
+        assertEquals("2026-08-14T10:00:00Z", request.url.queryParameter("updated_since"))
+
+        enqueue(
+            200,
+            """{"scope":"followed","server_time":"2026-08-14T11:01:00Z",
+                "updated_since":"2026-08-14T10:00:00Z","delta":true,
+                "deleted":[],"fictions":[],"continue_listening":[],"recent_chapters":[]}""",
+        )
+        assertTrue(repository.libraryDelta("2026-08-14T10:00:00Z").delta)
+        request = server.takeRequest()
+        assertEquals("/api/mobile/library", request.url.encodedPath)
+        assertEquals("followed", request.url.queryParameter("scope"))
+        assertEquals("2026-08-14T10:00:00Z", request.url.queryParameter("updated_since"))
+
+        enqueue(
+            200,
+            """{"fiction":{"id":7},"server_time":"2026-08-14T11:02:00Z",
+                "updated_since":"2026-08-14T10:00:00Z","delta":true,
+                "deleted":[101],"total":0,"chapters":[]}""",
+        )
+        assertEquals(listOf(101), repository.chaptersDelta(7, "2026-08-14T10:00:00Z").deleted)
+        request = server.takeRequest()
+        assertEquals("/api/mobile/fictions/7/chapters", request.url.encodedPath)
+        assertEquals("2026-08-14T10:00:00Z", request.url.queryParameter("updated_since"))
+    }
+
+    @Test
+    fun `a missing delta index falls back without ending the session`() = runTest {
+        enqueue(404, """{"detail":"Not found"}""")
+
+        assertNull(repository.deltaSync("2026-08-14T10:00:00Z"))
+        assertTrue(sessionStore.current().isLoggedIn)
+        assertNull(repository.sessionEnd.value)
+    }
+
+    @Test
     fun `read-along sends its ETag and exposes a normal 304`() = runTest {
         server.enqueue(MockResponse(code = 304))
 


### PR DESCRIPTION
Fixes #36

## Summary
- query `/api/mobile/sync` from the server-issued cursor before refreshing cached library and chapter metadata
- merge sparse changed rows and tombstones while replacing the server-complete listening rails
- advance unchanged cursors without downloading full resources, with safe full-refresh fallback for older servers
- preserve correct derived chapter ordering after sparse insertions/deletions
- account for the current server follow-index gap by checking complete `following_ids` and falling back to a full shelf pull for a newly followed unknown row

## Validation
- `xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail -Pttsroad.warningsAsErrors=true`