### PR TITLE
Add admin fiction management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to TTSRoad Desktop are recorded here. The format follows
 - Cross-device jump-back history through the server's `kind=auto` bookmarks. The desktop writes a
   breadcrumb every five minutes of playback and at its existing transition points, merges moments
   recorded by other clients into the Jump back shelf, and retains the bounded local copy offline.
+- Capability- and admin-gated fiction management: add a Royal Road fiction by URL/id, edit its
+  title/author/voice, and delete it behind a warning that the shared chapters and every account's
+  progress will be destroyed.
 - The account's cross-library queue, shared with the web client, as a browsable surface of its own.
   Chapter rows gain "Play next" and "Add to queue", the chapter list gains "Queue unplayed", and the
   queue screen can reorder, remove and clear. Shown only on a server that advertises the capability.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,12 @@ release with no asset for this platform/architecture is announced *without* a do
 feature; unknown keys are ignored; `404` means baseline and is cached; a transient failure keeps the
 last known answer rather than downgrading; `api_version` is never a proxy for a feature.
 
+`fiction_management` says only that the admin add/edit/delete routes exist. The UI separately asks
+`/api/mobile/me` and offers controls only for its current `is_admin=true`; never trust the role
+cached at login for this gate. `FictionManagementStateHolder` owns the forms, destructive delete
+confirmation and refreshes. Delete must evict the fiction's cached chapter metadata. Do not call
+the web-only EPUB route: the stable multipart mobile contract is tracked in TTSRoad #122.
+
 ### Linux package and operational diagnostics
 
 The Debian identity and installation directory are lowercase `ttsroad` (`/opt/ttsroad`); the display
@@ -332,6 +338,7 @@ preferences / sleep timer / MPRIS / shortcuts (0006). Read the relevant one befo
 the invariants above; offline storage and caching are in 0007, read-along is in 0008, and Debian
 packaging/operations are in 0009, and releases/update checking are in 0010. They exist because
 the alternative was tried or measured. The cross-library server queue is in 0011.
+Admin fiction management and its two independent gates are in 0012.
 
 ## CI
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Built with Compose for Desktop — real Skia-rendered UI, real OS installers, no
 | Remembered window size, position and maximised state | ✅ |
 | Async cover images (cached) | ✅ |
 | Dedicated fiction-detail screen | ✅ |
+| Admin fiction management — add by URL/id, edit metadata, confirmed delete | ✅ except [EPUB](https://github.com/jonarihen/TTSRoad/issues/122) |
 | Chapter list — All/Unplayed/Ready filter, oldest/newest sort, visible counts | ✅ |
 | Highlight + auto-scroll to the playing chapter, "Jump to current" | ✅ |
 | Bulk marks — all played / all unplayed / all previous, in one request | ✅ |
@@ -347,6 +348,8 @@ src/main/kotlin/dk/perspektiva/ttsroad/desktop/
     ├── WindowLayout.kt           supported minimum size + the three width classes
     ├── LoginStateHolder.kt       login submit + result mapping
     ├── SettingsStateHolder.kt    settings panes, device sessions, confirmations
+    ├── FictionManagementStateHolder.kt capability + current-admin gate and mutation state
+    ├── FictionManagementDialogs.kt add/edit forms and destructive shared-delete warning
     ├── LibraryScreen.kt          LazyVerticalGrid: hero, shelves, search, fictions
     ├── FictionDetailScreen.kt    LazyColumn: one header item, then chapter rows + bulk controls
     ├── ReaderScreen.kt           lazy selectable reader, follow/find/zoom/theme controls
@@ -620,6 +623,13 @@ none of that: an outage is not a revocation.
 - a transient failure keeps the last known answer instead of downgrading;
 - results are cached in memory for six hours, and forcibly refreshed after login;
 - `api_version` is never used as a proxy for a feature.
+
+Global fiction mutations use two independent gates: the server must advertise
+`fiction_management`, then authenticated `/api/mobile/me` must still say this account is an admin.
+The server enforces the same rule on every request. Add accepts a Royal Road URL or bare id; edit
+is deliberately limited to title, author and voice; delete warns that chapters and every user's
+progress disappear. EPUB remains absent until the server publishes a stable multipart mobile
+contract ([TTSRoad #122](https://github.com/jonarihen/TTSRoad/issues/122)).
 
 The discovered server name and version appear under the URL field **before** any credential is
 sent, so a typo'd hostname is visible rather than password-shaped.

--- a/docs/adr/0012-admin-fiction-management.md
+++ b/docs/adr/0012-admin-fiction-management.md
@@ -1,0 +1,46 @@
+# ADR 0012: Admin fiction management uses the mobile contract and two gates
+
+- Status: Accepted
+- Date: 2026-08-14
+- Issue: [#52](https://github.com/jonarihen/TTSRoad-Desktop/issues/52)
+- Server dependency: [TTSRoad #122](https://github.com/jonarihen/TTSRoad/issues/122)
+
+## Context
+
+The desktop could browse and play the shared library but could not add, correct or remove its
+fictions. The server now mirrors add-by-URL/id, edit and delete under `/api/mobile/fictions`, with a
+`fiction_management` capability. These mutations are global: a delete cascades through chapters
+and every account's progress. The session's login-time role can also become stale while it remains
+valid.
+
+EPUB import is different. It is still a multipart web route with no mobile payload/capability
+contract. A native file picker makes desktop the right eventual client, but not a reason to bind a
+released application to a route explicitly owned by the web UI.
+
+## Decision
+
+`FictionManagementStateHolder` is hoisted above navigation and owns one editor or destructive
+confirmation at a time. Controls exist only when both conditions hold:
+
+1. discovery advertises the literal `fiction_management: true` flag; and
+2. a current authenticated `/api/mobile/me` response says `is_admin: true`.
+
+The server remains authoritative on every write. Add sends a Royal Road URL or bare id and an
+optional voice. Edit exposes title, author and voice but never the slug, because the slug names the
+existing audio directory. Delete uses the shared safe-focus confirmation dialog and says plainly
+that it removes every user's progress, not merely the caller's shelf entry.
+
+Successful mutations patch visible metadata immediately and refresh the shelf/catalogue. Delete
+also cancels the fiction's cache work, removes its in-memory rows and its account-scoped chapter
+snapshot, then navigates away from the now-invalid detail destination. A mismatched or false delete
+acknowledgement is not success.
+
+EPUB upload remains unavailable until TTSRoad #122 supplies a separately advertised mobile
+multipart contract. The desktop does not call `/api/fictions/upload-epub` as a fallback.
+
+## Consequences
+
+Older servers and non-admin accounts see no dead controls. A stale admin claim cannot expose the
+surface after an administrator revokes the role. Adds and edits remain within the stable mobile API,
+and destructive state does not survive locally after the server confirms deletion. Issue #52 stays
+open only for the explicit EPUB dependency rather than silently claiming the full scope is done.

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -75,6 +75,8 @@ import dk.perspektiva.ttsroad.desktop.ui.BookmarksScreen
 import dk.perspektiva.ttsroad.desktop.ui.BookmarksStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.ContentMaxWidth
 import dk.perspektiva.ttsroad.desktop.ui.FictionDetailScreen
+import dk.perspektiva.ttsroad.desktop.ui.FictionManagementDialogs
+import dk.perspektiva.ttsroad.desktop.ui.FictionManagementStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.LibraryScreen
 import dk.perspektiva.ttsroad.desktop.ui.LoginStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.MetaText
@@ -137,6 +139,10 @@ fun App(container: AppContainer = remember { AppContainer() }) {
     val serverQueue = rememberStateHolder(repository, playback) {
         ServerQueueStateHolder(repository, playback)
     }
+    val fictionManagement = rememberStateHolder(repository, cache) {
+        FictionManagementStateHolder(repository, cache)
+    }
+    val fictionManagementState by fictionManagement.state.collectAsState()
 
     // Capability discovery is the only source of the server's stable advertised identity. Feed it
     // into the download namespace as soon as it arrives; using it only for feature flags would
@@ -154,10 +160,27 @@ fun App(container: AppContainer = remember { AppContainer() }) {
 
     val scope = rememberCoroutineScope()
 
+    LaunchedEffect(session.isLoggedIn, capabilities.fictionManagement) {
+        if (session.isLoggedIn) fictionManagement.ensureAccess(capabilities.fictionManagement)
+    }
+
+    LaunchedEffect(fictionManagementState.deletedFictionId) {
+        val deleted = fictionManagementState.deletedFictionId ?: return@LaunchedEffect
+        val current = nav.current
+        if (current is Destination.Fiction && current.fiction.id == deleted) nav.back()
+        fictionManagement.consumeDeletedFiction()
+    }
+
     fun refreshCurrentScreen() {
         when (val destination = nav.current) {
-            Destination.Library -> cache.refreshLibrary()
-            is Destination.Fiction -> cache.refreshChapters(destination.fiction.id)
+            Destination.Library -> {
+                cache.refreshLibrary()
+                fictionManagement.ensureAccess(capabilities.fictionManagement, forceRefresh = true)
+            }
+            is Destination.Fiction -> {
+                cache.refreshChapters(destination.fiction.id)
+                fictionManagement.ensureAccess(capabilities.fictionManagement, forceRefresh = true)
+            }
             Destination.Settings, Destination.Devices -> settings.refreshCurrentSection()
             Destination.Search -> search.refresh()
             Destination.Bookmarks -> bookmarks.refresh()
@@ -212,6 +235,10 @@ fun App(container: AppContainer = remember { AppContainer() }) {
         // Escape closes — ahead of a settings confirmation that may also be open behind it.
         if (showShortcuts) {
             showShortcuts = false
+            return true
+        }
+        if (fictionManagementState.hasOpenOverlay) {
+            fictionManagement.dismissOverlay()
             return true
         }
         val ownsOverlay = nav.current == Destination.Settings || nav.current == Destination.Devices
@@ -293,6 +320,7 @@ fun App(container: AppContainer = remember { AppContainer() }) {
             search.sessionEnded()
             bookmarks.sessionEnded()
             serverQueue.sessionEnded()
+            fictionManagement.sessionEnded()
         } else {
             // Cheap, and it is what makes optional UI correct after a restart, where login did
             // not run but a keyring-backed session was restored.
@@ -396,6 +424,8 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                     // On a server without per-user libraries there is no shelf to
                                     // distinguish from the catalogue, so there is no mode to pick.
                                     followsAvailable = capabilities.follows,
+                                    fictionManagement = fictionManagementState,
+                                    onAddFiction = fictionManagement::openAdd,
                                 )
 
                                 Destination.Search -> SearchScreen(
@@ -443,6 +473,9 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                         available = capabilities.queue,
                                         fictionId = destination.fiction.id,
                                     ),
+                                    fictionManagement = fictionManagementState,
+                                    onEditFiction = fictionManagement::openEdit,
+                                    onDeleteFiction = fictionManagement::askDelete,
                                 )
 
                                 Destination.Player -> PlayerScreen(
@@ -539,6 +572,7 @@ fun App(container: AppContainer = remember { AppContainer() }) {
     // Outside the login branch on purpose: F1 is a reasonable thing to press on the sign-in
     // screen, and the list is useful there too.
     if (showShortcuts) ShortcutsDialog(onDismiss = { showShortcuts = false })
+    if (session.isLoggedIn) FictionManagementDialogs(fictionManagement)
 
     // The Devices destination is a deep link into the settings screen: entering it selects the
     // pane, so a future "manage sessions" link from anywhere lands on the right place.

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryCache.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryCache.kt
@@ -153,6 +153,71 @@ class LibraryCache(
         }
     }
 
+    /** Drops every in-memory/disk metadata reference after a confirmed server-side delete. */
+    fun forgetFiction(fictionId: Int) {
+        chapterJobs.remove(fictionId)?.cancel()
+        chapterStates.remove(fictionId)
+        chapterOptions.remove(fictionId)
+        listOf(_library, _browseAll).forEach { state ->
+            state.update { cached ->
+                val library = cached.value ?: return@update cached
+                cached.copy(
+                    value = library.copy(
+                        fictions = library.fictions.filterNot { it.id == fictionId },
+                        continueListening = library.continueListening.filterNot {
+                            it.resolvedFictionId == fictionId
+                        },
+                        recentChapters = library.recentChapters.filterNot {
+                            it.resolvedFictionId == fictionId
+                        },
+                    ),
+                )
+            }
+        }
+        diskCache()?.removeChapters(fictionId)
+    }
+
+    /** Publishes the server-returned metadata immediately while the full refresh runs underneath. */
+    fun patchFiction(fiction: FictionSummary) {
+        fun ChapterSummary.patch(): ChapterSummary =
+            if (resolvedFictionId == fiction.id) {
+                copy(
+                    fiction = this.fiction?.let { fiction },
+                    fictionTitle = fiction.title,
+                    fictionAuthor = fiction.author,
+                    coverImageUrl = fiction.coverImageUrl,
+                )
+            } else {
+                this
+            }
+
+        listOf(_library, _browseAll).forEach { state ->
+            state.update { cached ->
+                val library = cached.value ?: return@update cached
+                cached.copy(
+                    value = library.copy(
+                        fictions = library.fictions.map { current ->
+                            if (current.id == fiction.id) {
+                                // Mutation payloads are global fiction shapes, so they do not
+                                // carry this account's shelf membership. Preserve what the
+                                // library knew until its refresh returns the scoped row.
+                                fiction.copy(following = fiction.following ?: current.following)
+                            } else {
+                                current
+                            }
+                        },
+                        continueListening = library.continueListening.map(ChapterSummary::patch),
+                        recentChapters = library.recentChapters.map(ChapterSummary::patch),
+                    ),
+                )
+            }
+        }
+        chapterStates[fiction.id]?.update { cached ->
+            val chapters = cached.value ?: return@update cached
+            cached.copy(value = chapters.copy(fiction = fiction))
+        }
+    }
+
     /**
      * What this client believes about [fictionId]'s follow state, or null when nothing says.
      *

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryDiskCache.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryDiskCache.kt
@@ -69,6 +69,12 @@ class LibraryDiskCache(
         )
     }
 
+    /** Removes metadata for a fiction the server has confirmed no longer exists. */
+    fun removeChapters(fictionId: Int) {
+        runCatching { Files.deleteIfExists(chapterFile(fictionId).toPath()) }
+            .onFailure { AppLog.warn("could not remove cached chapter metadata", it) }
+    }
+
     private fun write(file: File, json: String) {
         runCatching {
             prepare()

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
@@ -107,6 +107,8 @@ data class FictionSummary(
     val id: Int = 0,
     val title: String = "Untitled",
     val author: String? = null,
+    /** Narration voice; present on management/detail payloads and optional on older library rows. */
+    val voice: String? = null,
     val slug: String? = null,
     @param:Json(name = "cover_image_url") val coverImageUrl: String? = null,
     val description: String? = null,
@@ -132,6 +134,32 @@ data class FictionSummary(
     val readyFraction: Float
         get() = if (totalChapters > 0) (doneChapters.toFloat() / totalChapters).coerceIn(0f, 1f) else 0f
 }
+
+/** Admin-only `POST /api/mobile/fictions`. A bare Royal Road id is accepted by the server. */
+data class FictionCreateRequest(
+    @param:Json(name = "fiction_url") val fictionUrl: String,
+    val voice: String? = null,
+)
+
+/** Admin-only fields intentionally exposed by the desktop editor. */
+data class FictionUpdateRequest(
+    val title: String? = null,
+    val author: String? = null,
+    val voice: String? = null,
+)
+
+data class FictionMutationResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    val status: String = "",
+    val fiction: FictionSummary,
+)
+
+data class FictionDeleteResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    val status: String = "",
+    @param:Json(name = "fiction_id") val fictionId: Int = 0,
+    val deleted: Boolean = false,
+)
 
 data class ChapterSummary(
     val id: Int = 0,

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -114,6 +114,14 @@ interface TtsRoadRepository {
     /** The cheap delta index, or null when this server predates it. */
     suspend fun deltaSync(updatedSince: String): DeltaSyncResponse? = null
 
+    suspend fun createFiction(request: FictionCreateRequest): FictionSummary =
+        error("fiction management is not implemented")
+
+    suspend fun updateFiction(fictionId: Int, request: FictionUpdateRequest): FictionSummary =
+        error("fiction management is not implemented")
+
+    suspend fun deleteFiction(fictionId: Int): Boolean = false
+
     /**
      * Follows or unfollows a fiction, answering the state **the server now holds**, or null when it
      * answered 404.
@@ -420,6 +428,15 @@ class RetrofitTtsRoadRepository(
 
     override suspend fun deltaSync(updatedSince: String): DeltaSyncResponse? =
         ifEndpointExists { it.deltaSync(updatedSince) }
+
+    override suspend fun createFiction(request: FictionCreateRequest): FictionSummary =
+        withAuthorizedApi { it.createFiction(request).fiction }
+
+    override suspend fun updateFiction(fictionId: Int, request: FictionUpdateRequest): FictionSummary =
+        withAuthorizedApi { it.updateFiction(fictionId, request).fiction }
+
+    override suspend fun deleteFiction(fictionId: Int): Boolean =
+        withAuthorizedApi { it.deleteFiction(fictionId) }.let { it.deleted && it.fictionId == fictionId }
 
     override suspend fun setFollowing(fictionId: Int, following: Boolean): Boolean? =
         ifEndpointExists {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
@@ -43,6 +43,8 @@ data class ServerCapabilities(
     val deltaSync: Boolean = false,
     val batchProgress: Boolean = false,
     val audioContentHash: Boolean = false,
+    /** Admin add/edit/delete routes. Account permission is verified separately through `/me`. */
+    val fictionManagement: Boolean = false,
     /**
      * Per-user libraries.
      *
@@ -88,6 +90,7 @@ data class ServerCapabilities(
             deltaSync = response.capabilities.flag("delta_sync"),
             batchProgress = response.capabilities.flag("batch_progress"),
             audioContentHash = response.capabilities.flag("audio_content_hash"),
+            fictionManagement = response.capabilities.flag("fiction_management"),
             follows = response.capabilities.flag("follows"),
             deviceManagement = response.capabilities.flag("device_management"),
             queue = response.capabilities.flag("queue"),

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -76,6 +76,21 @@ interface TtsRoadApi {
     @GET("api/mobile/sync")
     suspend fun deltaSync(@Query("updated_since") updatedSince: String): DeltaSyncResponse
 
+    /** Adds one shared fiction. Advertised by `fiction_management` and admin-gated by the server. */
+    @POST("api/mobile/fictions")
+    suspend fun createFiction(@Body request: FictionCreateRequest): FictionMutationResponse
+
+    /** Edits shared fiction metadata. The slug is deliberately not part of the request model. */
+    @PATCH("api/mobile/fictions/{fiction_id}")
+    suspend fun updateFiction(
+        @Path("fiction_id") fictionId: Int,
+        @Body request: FictionUpdateRequest,
+    ): FictionMutationResponse
+
+    /** Deletes the shared fiction and every account's dependent progress. */
+    @DELETE("api/mobile/fictions/{fiction_id}")
+    suspend fun deleteFiction(@Path("fiction_id") fictionId: Int): FictionDeleteResponse
+
     /** Puts a fiction on this account's shelf. 404 for a fiction that does not exist. */
     @POST("api/mobile/fictions/{fiction_id}/follow")
     suspend fun follow(@Path("fiction_id") fictionId: Int): FollowResponse

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/Components.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/Components.kt
@@ -122,8 +122,8 @@ fun RowIconAction(
 }
 
 @Composable
-fun SectionTitle(kicker: String, title: String) {
-    Column(Modifier.fillMaxWidth()) {
+fun SectionTitle(kicker: String, title: String, modifier: Modifier = Modifier) {
+    Column(modifier.fillMaxWidth()) {
         MetaText(text = "§ $kicker", color = AarisColor.Accent)
         Text(title.uppercase(), style = MaterialTheme.typography.titleLarge, color = AarisColor.Ink)
         Spacer(Modifier.height(8.dp))

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionDetailScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionDetailScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material.icons.filled.OfflinePin
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -191,6 +192,9 @@ fun FictionDetailScreen(
     onOpenReader: (ChapterSummary) -> Unit = {},
     downloads: ChapterDownloadsUi = ChapterDownloadsUi(),
     queue: ChapterQueueUi = ChapterQueueUi(),
+    fictionManagement: FictionManagementUiState = FictionManagementUiState(),
+    onEditFiction: (FictionSummary) -> Unit = {},
+    onDeleteFiction: (FictionSummary) -> Unit = {},
     nowMillis: () -> Long = System::currentTimeMillis,
 ) {
     val scope = rememberCoroutineScope()
@@ -325,11 +329,30 @@ fun FictionDetailScreen(
                         } else {
                             null
                         },
+                        management = if (fictionManagement.canManage) {
+                            FictionManagementActions(
+                                busy = fictionManagement.isBusy,
+                                onEdit = { onEditFiction(header) },
+                                onDelete = { onDeleteFiction(header) },
+                            )
+                        } else {
+                            null
+                        },
                     )
 
                     actionError?.let { message ->
                         Spacer(Modifier.height(12.dp))
                         Text(message, color = MaterialTheme.colorScheme.error)
+                    }
+                    fictionManagement.notice?.let { message ->
+                        Spacer(Modifier.height(12.dp))
+                        MetaText(message, color = AarisColor.Ok)
+                    }
+                    if (fictionManagement.editor == null) {
+                        fictionManagement.error?.let { message ->
+                            Spacer(Modifier.height(12.dp))
+                            Text(message, color = MaterialTheme.colorScheme.error)
+                        }
                     }
                     queue.error?.let { message ->
                         Spacer(Modifier.height(12.dp))
@@ -570,7 +593,15 @@ private fun resumeTarget(chapters: List<ChapterSummary>): ChapterSummary? =
 /** The follow control's whole state, or null where the server has no per-user library. */
 data class FollowUi(val following: Boolean, val busy: Boolean, val onToggle: () -> Unit)
 
+data class FictionManagementActions(
+    val busy: Boolean,
+    val onEdit: () -> Unit,
+    val onDelete: () -> Unit,
+)
+
 const val FollowToggleTestTag: String = "followToggle"
+const val EditFictionButtonTestTag: String = "editFictionButton"
+const val DeleteFictionButtonTestTag: String = "deleteFictionButton"
 
 @Composable
 private fun FictionHeader(
@@ -579,6 +610,7 @@ private fun FictionHeader(
     chapters: List<ChapterSummary>,
     onResume: (ChapterSummary) -> Unit,
     follow: FollowUi? = null,
+    management: FictionManagementActions? = null,
 ) {
     Row(Modifier.fillMaxWidth()) {
         CoverImage(
@@ -648,7 +680,7 @@ private fun FictionHeader(
                 MetaText(listeningTotalsLabel(totals), color = AarisColor.Muted)
             }
             val target = remember(chapters) { resumeTarget(chapters) }
-            if (target != null || follow != null) {
+            if (target != null || follow != null || management != null) {
                 Spacer(Modifier.height(16.dp))
                 Row(horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
                     if (target != null) {
@@ -663,6 +695,27 @@ private fun FictionHeader(
                         }
                     }
                     follow?.let { FollowButton(it) }
+                    management?.let { actions ->
+                        OutlinedButton(
+                            onClick = actions.onEdit,
+                            enabled = !actions.busy,
+                            shape = RectangleShape,
+                            modifier = Modifier
+                                .pointerHoverIcon(PointerIcon.Hand)
+                                .testTag(EditFictionButtonTestTag),
+                        ) { Text("EDIT") }
+                        OutlinedButton(
+                            onClick = actions.onDelete,
+                            enabled = !actions.busy,
+                            shape = RectangleShape,
+                            colors = ButtonDefaults.outlinedButtonColors(
+                                contentColor = MaterialTheme.colorScheme.error,
+                            ),
+                            modifier = Modifier
+                                .pointerHoverIcon(PointerIcon.Hand)
+                                .testTag(DeleteFictionButtonTestTag),
+                        ) { Text("DELETE") }
+                    }
                 }
             }
         }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementDialogs.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementDialogs.kt
@@ -1,0 +1,139 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+const val AddFictionDialogTestTag: String = "addFictionDialog"
+const val EditFictionDialogTestTag: String = "editFictionDialog"
+
+/** The holder owns the answers; this composable only renders its one active question. */
+@Composable
+fun FictionManagementDialogs(holder: FictionManagementStateHolder) {
+    val state by holder.state.collectAsState()
+    state.editor?.let { editor ->
+        FictionEditorDialog(
+            editor = editor,
+            isBusy = state.isBusy,
+            error = state.error,
+            onUpdateAdd = holder::updateAdd,
+            onUpdateEdit = holder::updateEdit,
+            onSubmit = holder::submitEditor,
+            onDismiss = holder::dismissOverlay,
+        )
+    }
+    state.deleteConfirmation?.let { pending ->
+        ConfirmDialog(
+            title = "DELETE ${pending.title.uppercase()}",
+            body = "This permanently deletes the fiction, every chapter and every user's " +
+                "listening progress from the server. This cannot be undone.",
+            confirmLabel = "DELETE FOR EVERYONE",
+            onConfirm = holder::confirmDelete,
+            onDismiss = holder::dismissOverlay,
+        )
+    }
+}
+
+@Composable
+private fun FictionEditorDialog(
+    editor: FictionEditor,
+    isBusy: Boolean,
+    error: String?,
+    onUpdateAdd: (String?, String?) -> Unit,
+    onUpdateEdit: (String?, String?, String?) -> Unit,
+    onSubmit: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val adding = editor is FictionEditor.Add
+    AlertDialog(
+        onDismissRequest = { if (!isBusy) onDismiss() },
+        modifier = Modifier.testTag(if (adding) AddFictionDialogTestTag else EditFictionDialogTestTag),
+        containerColor = AarisColor.BgRaise,
+        title = {
+            Text(
+                if (adding) "ADD FICTION" else "EDIT FICTION",
+                style = MaterialTheme.typography.titleLarge,
+                color = AarisColor.Ink,
+            )
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                when (editor) {
+                    is FictionEditor.Add -> {
+                        OutlinedTextField(
+                            value = editor.fictionUrl,
+                            onValueChange = { onUpdateAdd(it, null) },
+                            label = { Text("ROYAL ROAD URL OR FICTION ID") },
+                            enabled = !isBusy,
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        OutlinedTextField(
+                            value = editor.voice,
+                            onValueChange = { onUpdateAdd(null, it) },
+                            label = { Text("VOICE (OPTIONAL)") },
+                            supportingText = { Text("Blank uses the server default") },
+                            enabled = !isBusy,
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+
+                    is FictionEditor.Edit -> {
+                        OutlinedTextField(
+                            value = editor.title,
+                            onValueChange = { onUpdateEdit(it, null, null) },
+                            label = { Text("TITLE") },
+                            enabled = !isBusy,
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        OutlinedTextField(
+                            value = editor.author,
+                            onValueChange = { onUpdateEdit(null, it, null) },
+                            label = { Text("AUTHOR") },
+                            supportingText = { Text("Blank clears the author") },
+                            enabled = !isBusy,
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        OutlinedTextField(
+                            value = editor.voice,
+                            onValueChange = { onUpdateEdit(null, null, it) },
+                            label = { Text("VOICE") },
+                            enabled = !isBusy,
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
+                error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = onSubmit,
+                enabled = !isBusy,
+                shape = RectangleShape,
+            ) { Text(if (isBusy) "SAVING…" else if (adding) "ADD FICTION" else "SAVE CHANGES") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !isBusy, shape = RectangleShape) {
+                Text("CANCEL")
+            }
+        },
+    )
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolder.kt
@@ -1,0 +1,295 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.data.FictionCreateRequest
+import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.FictionUpdateRequest
+import dk.perspektiva.ttsroad.desktop.data.LibraryCache
+import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
+import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+enum class FictionManagementAccess {
+    Unsupported,
+    Checking,
+    Admin,
+    NotAdmin,
+    Unavailable,
+}
+
+sealed interface FictionEditor {
+    data class Add(
+        val fictionUrl: String = "",
+        val voice: String = "",
+    ) : FictionEditor
+
+    data class Edit(
+        val fictionId: Int,
+        val title: String,
+        val author: String,
+        val voice: String,
+    ) : FictionEditor
+}
+
+data class FictionDeleteConfirmation(val fictionId: Int, val title: String)
+
+data class FictionManagementUiState(
+    val access: FictionManagementAccess = FictionManagementAccess.Unsupported,
+    val editor: FictionEditor? = null,
+    val deleteConfirmation: FictionDeleteConfirmation? = null,
+    val isBusy: Boolean = false,
+    val error: String? = null,
+    val notice: String? = null,
+    /** Consumed by the root navigator after a successful delete. */
+    val deletedFictionId: Int? = null,
+) {
+    val canManage: Boolean get() = access == FictionManagementAccess.Admin
+    val hasOpenOverlay: Boolean get() = editor != null || deleteConfirmation != null
+}
+
+/**
+ * Admin fiction management, hoisted above navigation so a mutation cannot be lost with a screen.
+ *
+ * Capability discovery says whether the stable routes exist; `/api/mobile/me` independently says
+ * whether this account may use them. Neither the login-time role nor a visible button is treated
+ * as authorization — the server remains the final gate for every write.
+ */
+class FictionManagementStateHolder(
+    private val repository: TtsRoadRepository,
+    private val cache: LibraryCache,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : StateHolder(dispatcher) {
+    private val _state = MutableStateFlow(FictionManagementUiState())
+    val state: StateFlow<FictionManagementUiState> = _state.asStateFlow()
+
+    private var accessJob: Job? = null
+    private var mutationJob: Job? = null
+    private var lastSupported: Boolean? = null
+
+    fun ensureAccess(supported: Boolean, forceRefresh: Boolean = false) {
+        if (!supported) {
+            lastSupported = false
+            accessJob?.cancel()
+            _state.update {
+                FictionManagementUiState(access = FictionManagementAccess.Unsupported)
+            }
+            return
+        }
+        val newlySupported = lastSupported != true
+        lastSupported = true
+        if (accessJob?.isActive == true || (!forceRefresh && !newlySupported && _state.value.access in VerifiedAccess)) {
+            return
+        }
+        accessJob = scope.launch {
+            _state.update { it.copy(access = FictionManagementAccess.Checking, error = null) }
+            runCatching { repository.currentUser() }
+                .onSuccess { user ->
+                    _state.update {
+                        it.copy(
+                            access = when {
+                                user == null -> FictionManagementAccess.Unsupported
+                                user.isAdmin -> FictionManagementAccess.Admin
+                                else -> FictionManagementAccess.NotAdmin
+                            },
+                            error = null,
+                        )
+                    }
+                }
+                .onFailure { failure ->
+                    _state.update {
+                        it.copy(
+                            access = FictionManagementAccess.Unavailable,
+                            error = userFacingMessage(failure, "Could not verify admin access"),
+                        )
+                    }
+                }
+        }
+    }
+
+    fun openAdd() {
+        if (!_state.value.canManage || _state.value.isBusy) return
+        _state.update { it.copy(editor = FictionEditor.Add(), error = null, notice = null) }
+    }
+
+    fun openEdit(fiction: FictionSummary) {
+        if (!_state.value.canManage || _state.value.isBusy || fiction.id <= 0) return
+        _state.update {
+            it.copy(
+                editor = FictionEditor.Edit(
+                    fictionId = fiction.id,
+                    title = fiction.title,
+                    author = fiction.author.orEmpty(),
+                    voice = fiction.voice.orEmpty(),
+                ),
+                error = null,
+                notice = null,
+            )
+        }
+    }
+
+    fun updateAdd(fictionUrl: String? = null, voice: String? = null) {
+        _state.update { current ->
+            val editor = current.editor as? FictionEditor.Add ?: return@update current
+            current.copy(editor = editor.copy(fictionUrl = fictionUrl ?: editor.fictionUrl, voice = voice ?: editor.voice))
+        }
+    }
+
+    fun updateEdit(title: String? = null, author: String? = null, voice: String? = null) {
+        _state.update { current ->
+            val editor = current.editor as? FictionEditor.Edit ?: return@update current
+            current.copy(
+                editor = editor.copy(
+                    title = title ?: editor.title,
+                    author = author ?: editor.author,
+                    voice = voice ?: editor.voice,
+                ),
+            )
+        }
+    }
+
+    fun submitEditor() {
+        val editor = _state.value.editor ?: return
+        if (!_state.value.canManage || _state.value.isBusy) return
+        val validation = when (editor) {
+            is FictionEditor.Add -> "A Royal Road URL or fiction id is required".takeIf {
+                editor.fictionUrl.isBlank()
+            }
+
+            is FictionEditor.Edit -> when {
+                editor.title.isBlank() -> "Title cannot be empty"
+                editor.voice.isBlank() -> "Voice cannot be empty"
+                else -> null
+            }
+        }
+        if (validation != null) {
+            _state.update { it.copy(error = validation) }
+            return
+        }
+        mutationJob?.cancel()
+        mutationJob = scope.launch {
+            _state.update { it.copy(isBusy = true, error = null, notice = null) }
+            val outcome = runCatching {
+                when (editor) {
+                    is FictionEditor.Add -> repository.createFiction(
+                        FictionCreateRequest(
+                            fictionUrl = editor.fictionUrl.trim(),
+                            voice = editor.voice.trim().takeIf(String::isNotEmpty),
+                        ),
+                    )
+
+                    is FictionEditor.Edit -> repository.updateFiction(
+                        editor.fictionId,
+                        FictionUpdateRequest(
+                            title = editor.title.trim(),
+                            author = editor.author.trim(),
+                            voice = editor.voice.trim(),
+                        ),
+                    )
+                }
+            }
+            outcome
+                .onSuccess { fiction ->
+                    cache.patchFiction(fiction)
+                    cache.refreshLibrary()
+                    cache.refreshBrowseAll()
+                    if (editor is FictionEditor.Edit) cache.refreshChapters(editor.fictionId)
+                    _state.update {
+                        it.copy(
+                            editor = null,
+                            isBusy = false,
+                            error = null,
+                            notice = if (editor is FictionEditor.Add) {
+                                "Added ${fiction.title}; chapter discovery is running on the server"
+                            } else {
+                                "Saved ${fiction.title}"
+                            },
+                        )
+                    }
+                }
+                .onFailure { failure ->
+                    _state.update {
+                        it.copy(
+                            isBusy = false,
+                            error = userFacingMessage(failure, "Could not save fiction"),
+                        )
+                    }
+                }
+        }
+    }
+
+    fun askDelete(fiction: FictionSummary) {
+        if (!_state.value.canManage || _state.value.isBusy || fiction.id <= 0) return
+        _state.update {
+            it.copy(
+                deleteConfirmation = FictionDeleteConfirmation(fiction.id, fiction.title),
+                error = null,
+                notice = null,
+            )
+        }
+    }
+
+    fun confirmDelete() {
+        val pending = _state.value.deleteConfirmation ?: return
+        if (!_state.value.canManage || _state.value.isBusy) return
+        mutationJob?.cancel()
+        mutationJob = scope.launch {
+            _state.update { it.copy(deleteConfirmation = null, isBusy = true, error = null, notice = null) }
+            runCatching {
+                check(repository.deleteFiction(pending.fictionId)) {
+                    "The server did not confirm the deletion"
+                }
+                pending
+            }
+                .onSuccess {
+                    cache.forgetFiction(pending.fictionId)
+                    cache.refreshLibrary()
+                    cache.refreshBrowseAll()
+                    _state.update {
+                        it.copy(
+                            isBusy = false,
+                            notice = "Deleted ${pending.title}",
+                            deletedFictionId = pending.fictionId,
+                        )
+                    }
+                }
+                .onFailure { failure ->
+                    _state.update {
+                        it.copy(
+                            isBusy = false,
+                            error = userFacingMessage(failure, "Could not delete fiction"),
+                        )
+                    }
+                }
+        }
+    }
+
+    fun dismissOverlay() {
+        if (_state.value.isBusy) return
+        _state.update { it.copy(editor = null, deleteConfirmation = null, error = null) }
+    }
+
+    fun consumeDeletedFiction() {
+        _state.update { it.copy(deletedFictionId = null) }
+    }
+
+    fun sessionEnded() {
+        accessJob?.cancel()
+        mutationJob?.cancel()
+        lastSupported = null
+        _state.value = FictionManagementUiState()
+    }
+
+    companion object {
+        private val VerifiedAccess = setOf(
+            FictionManagementAccess.Admin,
+            FictionManagementAccess.NotAdmin,
+            FictionManagementAccess.Unsupported,
+        )
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/LibraryScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/LibraryScreen.kt
@@ -85,6 +85,7 @@ import kotlinx.coroutines.launch
 
 /** Test handle for "how many fiction cards did the lazy grid actually compose". */
 const val FictionCardTestTag: String = "fictionCard"
+const val AddFictionButtonTestTag: String = "addFictionButton"
 
 /** Minimum card width; the grid fits as many columns as that allows, like `auto-fill minmax()`. */
 private val MinCardWidth = 200.dp
@@ -124,6 +125,8 @@ fun LibraryScreen(
      * to distinguish from a catalogue and the mode switch is absent entirely.
      */
     followsAvailable: Boolean = false,
+    fictionManagement: FictionManagementUiState = FictionManagementUiState(),
+    onAddFiction: () -> Unit = {},
     /**
      * Local listening history, for the "Jump back in" strip. Defaulted to an in-memory store so a
      * screen test never reads or writes the real config directory.
@@ -253,8 +256,39 @@ fun LibraryScreen(
 
                     fullWidthItem("fictions-header") {
                         Column {
-                            SectionTitle("03", if (browseAll) "Every fiction" else "Fictions")
+                            Row(
+                                Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                SectionTitle(
+                                    "03",
+                                    if (browseAll) "Every fiction" else "Fictions",
+                                    Modifier.weight(1f),
+                                )
+                                if (fictionManagement.canManage) {
+                                    Spacer(Modifier.width(16.dp))
+                                    OutlinedButton(
+                                        onClick = onAddFiction,
+                                        enabled = !fictionManagement.isBusy,
+                                        shape = RectangleShape,
+                                        modifier = Modifier
+                                            .pointerHoverIcon(PointerIcon.Hand)
+                                            .testTag(AddFictionButtonTestTag),
+                                    ) { Text("ADD FICTION") }
+                                }
+                            }
                             Spacer(Modifier.height(16.dp))
+                            fictionManagement.notice?.let {
+                                MetaText(it, color = AarisColor.Ok)
+                                Spacer(Modifier.height(10.dp))
+                            }
+                            if (fictionManagement.access == FictionManagementAccess.Unavailable) {
+                                Text(
+                                    fictionManagement.error ?: "Fiction management is temporarily unavailable",
+                                    color = MaterialTheme.colorScheme.error,
+                                )
+                                Spacer(Modifier.height(10.dp))
+                            }
                             if (followsAvailable) {
                                 LibraryScopeTabs(browseAll) { browsing = it }
                                 Spacer(Modifier.height(14.dp))
@@ -307,7 +341,11 @@ fun LibraryScreen(
                             if (browseAll) {
                                 EmptyState(
                                     "The server has no fictions",
-                                    "Add one on the server and it will show up here.",
+                                    if (fictionManagement.canManage) {
+                                        "Use Add fiction to start tracking one."
+                                    } else {
+                                        "An administrator can add one from a supported client."
+                                    },
                                 )
                             } else {
                                 EmptyState(

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -8,6 +8,8 @@ import dk.perspektiva.ttsroad.desktop.data.ChaptersResponse
 import dk.perspektiva.ttsroad.desktop.data.DeviceSession
 import dk.perspektiva.ttsroad.desktop.data.DeltaSyncResponse
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.FictionCreateRequest
+import dk.perspektiva.ttsroad.desktop.data.FictionUpdateRequest
 import dk.perspektiva.ttsroad.desktop.data.LibraryResponse
 import dk.perspektiva.ttsroad.desktop.data.LoginResult
 import dk.perspektiva.ttsroad.desktop.data.MobileUser
@@ -64,6 +66,9 @@ open class FakeRepository(
     var deleteBookmarkResult: Result<Boolean> = Result.success(true),
     /** `success(null)` is the server saying it has no queue API — not "the queue is empty". */
     var queueResult: Result<ServerQueueResponse?> = Result.success(ServerQueueResponse()),
+    var createFictionResult: Result<FictionSummary> = Result.success(FictionSummary(id = 101, title = "Added")),
+    var updateFictionResult: Result<FictionSummary> = Result.success(FictionSummary(id = 1, title = "Updated")),
+    var deleteFictionResult: Result<Boolean> = Result.success(true),
 ) : TtsRoadRepository {
     var loginCalls: Int = 0
         private set
@@ -79,6 +84,8 @@ open class FakeRepository(
     val chapterDeltaCalls: MutableList<Pair<Int, String>> = mutableListOf()
     val deltaSyncCursors: MutableList<String> = mutableListOf()
     var devicesCalls: Int = 0
+        private set
+    var currentUserCalls: Int = 0
         private set
     var revokeOtherDevicesCalls: Int = 0
         private set
@@ -114,6 +121,9 @@ open class FakeRepository(
     val createdBookmarks: MutableList<BookmarkCreateRequest> = mutableListOf()
     val patchedBookmarks: MutableList<Pair<Int, BookmarkPatchRequest>> = mutableListOf()
     val deletedBookmarks: MutableList<Int> = mutableListOf()
+    val createdFictions: MutableList<FictionCreateRequest> = mutableListOf()
+    val updatedFictions: MutableList<Pair<Int, FictionUpdateRequest>> = mutableListOf()
+    val deletedFictions: MutableList<Int> = mutableListOf()
 
     private val _currentCapabilities = MutableStateFlow(ServerCapabilities.Baseline)
     override val currentCapabilities: StateFlow<ServerCapabilities> = _currentCapabilities.asStateFlow()
@@ -180,7 +190,25 @@ open class FakeRepository(
         return configured.getOrThrow()
     }
 
-    override suspend fun currentUser(): MobileUser? = currentUserResult.getOrThrow()
+    override suspend fun createFiction(request: FictionCreateRequest): FictionSummary {
+        createdFictions += request
+        return createFictionResult.getOrThrow()
+    }
+
+    override suspend fun updateFiction(fictionId: Int, request: FictionUpdateRequest): FictionSummary {
+        updatedFictions += fictionId to request
+        return updateFictionResult.getOrThrow()
+    }
+
+    override suspend fun deleteFiction(fictionId: Int): Boolean {
+        deletedFictions += fictionId
+        return deleteFictionResult.getOrThrow()
+    }
+
+    override suspend fun currentUser(): MobileUser? {
+        currentUserCalls++
+        return currentUserResult.getOrThrow()
+    }
 
     override suspend fun devices(): List<DeviceSession>? {
         devicesCalls++

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/CapabilityDiscoveryTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/CapabilityDiscoveryTest.kt
@@ -56,6 +56,19 @@ class CapabilityDiscoveryTest {
     }
 
     @Test
+    fun `fiction management is enabled only by a literal advertised flag`() {
+        val enabled = ServerCapabilities.from(
+            CapabilitiesResponse(capabilities = mapOf("fiction_management" to true)),
+        )
+        val malformed = ServerCapabilities.from(
+            CapabilitiesResponse(capabilities = mapOf("fiction_management" to "admin")),
+        )
+
+        assertTrue(enabled.fictionManagement)
+        assertFalse(malformed.fictionManagement)
+    }
+
+    @Test
     fun `discovery is unauthenticated and the marker header never reaches the wire`() = runTest {
         // A stale session for the very origin being probed: without the no-auth marker this is
         // exactly when a previous server's token would be handed to whatever is listening.

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/FictionManagementRepositoryTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/FictionManagementRepositoryTest.kt
@@ -1,0 +1,108 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import dk.perspektiva.ttsroad.desktop.authedClient
+import dk.perspektiva.ttsroad.desktop.bodyText
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.Headers
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/** Admin fiction-management request/response shapes on the stable mobile routes. */
+@OptIn(ExperimentalCoroutinesApi::class)
+class FictionManagementRepositoryTest {
+    private lateinit var server: MockWebServer
+    private lateinit var repository: RetrofitTtsRoadRepository
+    private val jsonHeaders = Headers.headersOf("Content-Type", "application/json")
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        val session = InMemorySessionStore(
+            SessionState(
+                serverUrl = server.url("/").toString(),
+                token = "ttsr_admin",
+                username = "admin",
+                isAdmin = true,
+            ),
+        )
+        repository = RetrofitTtsRoadRepository(
+            sessionStore = session,
+            client = authedClient(session),
+            ioDispatcher = UnconfinedTestDispatcher(),
+            deviceNameProvider = { "test-host" },
+        )
+    }
+
+    @AfterEach
+    fun tearDown() = server.close()
+
+    private fun enqueue(body: String) {
+        server.enqueue(MockResponse(code = 200, headers = jsonHeaders, body = body))
+    }
+
+    @Test
+    fun `add posts a Royal Road id and optional voice`() = runTest {
+        server.enqueue(
+            MockResponse(
+                code = 201,
+                headers = jsonHeaders,
+                body = mutationBody(id = 12, title = "New serial", voice = "en-GB-RyanNeural"),
+            ),
+        )
+
+        val added = repository.createFiction(FictionCreateRequest("424242", "en-GB-RyanNeural"))
+
+        assertEquals(12, added.id)
+        assertEquals("en-GB-RyanNeural", added.voice)
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/api/mobile/fictions", request.url.encodedPath)
+        assertEquals("Bearer ttsr_admin", request.headers["Authorization"])
+        val body = request.bodyText()
+        assertTrue(body.contains("\"fiction_url\":\"424242\""), body)
+        assertTrue(body.contains("\"voice\":\"en-GB-RyanNeural\""), body)
+    }
+
+    @Test
+    fun `edit patches only the supported shared metadata fields`() = runTest {
+        enqueue(mutationBody(id = 7, title = "Better", voice = "en-US-AriaNeural"))
+
+        repository.updateFiction(
+            7,
+            FictionUpdateRequest(title = "Better", author = "Writer", voice = "en-US-AriaNeural"),
+        )
+
+        val request = server.takeRequest()
+        assertEquals("PATCH", request.method)
+        assertEquals("/api/mobile/fictions/7", request.url.encodedPath)
+        val body = request.bodyText()
+        assertTrue(body.contains("\"title\":\"Better\""), body)
+        assertTrue(body.contains("\"author\":\"Writer\""), body)
+        assertTrue(body.contains("\"voice\":\"en-US-AriaNeural\""), body)
+        assertFalse(body.contains("slug"), body)
+    }
+
+    @Test
+    fun `delete requires the response to confirm the same fiction id`() = runTest {
+        enqueue("""{"api_version":1,"status":"ok","fiction_id":7,"deleted":true}""")
+        assertTrue(repository.deleteFiction(7))
+        val request = server.takeRequest()
+        assertEquals("DELETE", request.method)
+        assertEquals("/api/mobile/fictions/7", request.url.encodedPath)
+
+        enqueue("""{"api_version":1,"status":"ok","fiction_id":8,"deleted":true}""")
+        assertFalse(repository.deleteFiction(7), "a mismatched acknowledgement cannot confirm deletion")
+    }
+
+    private fun mutationBody(id: Int, title: String, voice: String): String =
+        """{"api_version":1,"status":"ok","fiction":{"id":$id,"title":"$title","voice":"$voice"}}"""
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryCacheTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryCacheTest.kt
@@ -81,6 +81,29 @@ class LibraryCacheTest {
     }
 
     @Test
+    fun `a global edit payload does not erase account-scoped follow membership`() = runTest {
+        val repository = FakeRepository(
+            libraryResult = Result.success(
+                LibraryResponse(
+                    fictions = listOf(
+                        FictionSummary(id = 7, title = "Old", following = true),
+                    ),
+                ),
+            ),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        cache.ensureLibrary()
+        runCurrent()
+
+        cache.patchFiction(FictionSummary(id = 7, title = "New", following = null))
+
+        val patched = cache.library.value.value?.fictions?.single()
+        assertEquals("New", patched?.title)
+        assertEquals(true, patched?.following)
+        cache.close()
+    }
+
+    @Test
     fun `a restart can browse cached library and chapters while the server is offline`() = runTest {
         val fiction = FictionSummary(id = 7, title = "Cached serial")
         val library = LibraryResponse(fictions = listOf(fiction))

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryDiskCacheTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryDiskCacheTest.kt
@@ -84,6 +84,17 @@ class LibraryDiskCacheTest {
     }
 
     @Test
+    fun `confirmed fiction deletion removes its cached chapter metadata`() {
+        val cache = cache()
+        cache.storeChapters(7, chapters, 1)
+
+        cache.removeChapters(7)
+
+        assertNull(cache.loadChapters(7))
+        assertTrue(!File(cache.root, "chapters-7.json").exists())
+    }
+
+    @Test
     fun `a planted metadata symlink is refused and its target remains untouched`() {
         val cache = cache()
         cache.root.mkdirs()

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolderTest.kt
@@ -1,0 +1,155 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.LibraryCache
+import dk.perspektiva.ttsroad.desktop.data.MobileUser
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FictionManagementStateHolderTest {
+
+    @Test
+    fun `capability and current user are independent gates`() = runTest {
+        val repository = FakeRepository(
+            currentUserResult = Result.success(MobileUser(1, "boss", isAdmin = true)),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        val holder = FictionManagementStateHolder(repository, cache, UnconfinedTestDispatcher(testScheduler))
+
+        holder.ensureAccess(supported = false)
+        assertEquals(FictionManagementAccess.Unsupported, holder.state.value.access)
+        assertEquals(0, repository.currentUserCalls)
+
+        holder.ensureAccess(supported = true)
+        runCurrent()
+        assertEquals(FictionManagementAccess.Admin, holder.state.value.access)
+        assertEquals(1, repository.currentUserCalls)
+
+        repository.currentUserResult = Result.success(MobileUser(1, "boss", isAdmin = false))
+        holder.ensureAccess(supported = true, forceRefresh = true)
+        runCurrent()
+        assertEquals(FictionManagementAccess.NotAdmin, holder.state.value.access)
+        assertEquals(2, repository.currentUserCalls)
+
+        holder.clear()
+        cache.close()
+    }
+
+    @Test
+    fun `a non-admin account cannot open a management action`() = runTest {
+        val repository = FakeRepository(
+            currentUserResult = Result.success(MobileUser(2, "listener", isAdmin = false)),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        val holder = FictionManagementStateHolder(repository, cache, UnconfinedTestDispatcher(testScheduler))
+
+        holder.ensureAccess(supported = true)
+        runCurrent()
+        holder.openAdd()
+        holder.openEdit(FictionSummary(id = 7, title = "Serial", voice = "voice"))
+        holder.askDelete(FictionSummary(id = 7, title = "Serial"))
+
+        assertEquals(FictionManagementAccess.NotAdmin, holder.state.value.access)
+        assertFalse(holder.state.value.hasOpenOverlay)
+        holder.clear()
+        cache.close()
+    }
+
+    @Test
+    fun `adding trims the source and leaves a blank voice to the server default`() = runTest {
+        val repository = adminRepository().apply {
+            createFictionResult = Result.success(FictionSummary(id = 12, title = "New serial", voice = "default"))
+        }
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        val holder = adminHolder(repository, cache)
+
+        holder.openAdd()
+        holder.updateAdd(fictionUrl = "  424242  ", voice = "  ")
+        holder.submitEditor()
+        runCurrent()
+
+        assertEquals("424242", repository.createdFictions.single().fictionUrl)
+        assertNull(repository.createdFictions.single().voice)
+        assertNull(holder.state.value.editor)
+        assertTrue(holder.state.value.notice.orEmpty().contains("New serial"))
+        holder.clear()
+        cache.close()
+    }
+
+    @Test
+    fun `editing validates title then sends title author and voice`() = runTest {
+        val repository = adminRepository().apply {
+            updateFictionResult = Result.success(
+                FictionSummary(id = 7, title = "Better", author = null, voice = "new-voice"),
+            )
+        }
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        val holder = adminHolder(repository, cache)
+
+        holder.openEdit(FictionSummary(id = 7, title = "Old", author = "Writer", voice = "old-voice"))
+        holder.updateEdit(title = "   ")
+        holder.submitEditor()
+        assertTrue(holder.state.value.error.orEmpty().contains("Title"))
+        assertTrue(repository.updatedFictions.isEmpty())
+
+        holder.updateEdit(title = " Better ", author = "", voice = " new-voice ")
+        holder.submitEditor()
+        runCurrent()
+
+        val (fictionId, request) = repository.updatedFictions.single()
+        assertEquals(7, fictionId)
+        assertEquals("Better", request.title)
+        assertEquals("", request.author)
+        assertEquals("new-voice", request.voice)
+        assertNull(holder.state.value.editor)
+        holder.clear()
+        cache.close()
+    }
+
+    @Test
+    fun `delete waits for confirmation and publishes the id for navigation`() = runTest {
+        val repository = adminRepository()
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        val holder = adminHolder(repository, cache)
+        val fiction = FictionSummary(id = 7, title = "Shared serial")
+
+        holder.askDelete(fiction)
+        val pending = assertIs<FictionDeleteConfirmation>(holder.state.value.deleteConfirmation)
+        assertEquals(7, pending.fictionId)
+        assertTrue(repository.deletedFictions.isEmpty())
+
+        holder.confirmDelete()
+        runCurrent()
+
+        assertEquals(listOf(7), repository.deletedFictions)
+        assertEquals(7, holder.state.value.deletedFictionId)
+        assertNull(holder.state.value.deleteConfirmation)
+        holder.clear()
+        cache.close()
+    }
+
+    private fun adminRepository(): FakeRepository = FakeRepository(
+        currentUserResult = Result.success(MobileUser(1, "boss", isAdmin = true)),
+    )
+
+    private fun TestScope.adminHolder(
+        repository: FakeRepository,
+        cache: LibraryCache,
+    ): FictionManagementStateHolder =
+        FictionManagementStateHolder(repository, cache, UnconfinedTestDispatcher(testScheduler)).also {
+            it.ensureAccess(supported = true)
+            runCurrent()
+            assertEquals(FictionManagementAccess.Admin, it.state.value.access)
+        }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ScreensUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ScreensUiTest.kt
@@ -7,8 +7,11 @@ import androidx.compose.ui.test.isSelectable
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import dk.perspektiva.ttsroad.desktop.App
 import dk.perspektiva.ttsroad.desktop.FakePlaybackController
@@ -19,6 +22,7 @@ import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackHistoryStore
 import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.InMemoryReaderPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.InMemorySessionStore
+import dk.perspektiva.ttsroad.desktop.data.MobileUser
 import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
 import dk.perspektiva.ttsroad.desktop.data.SessionEnd
 import dk.perspektiva.ttsroad.desktop.data.SessionEndReason
@@ -275,6 +279,73 @@ class ScreensUiTest {
     }
 
     // --- LibraryScreen --------------------------------------------------------------------
+
+    @Test
+    fun `an advertised admin can add edit and reach the destructive delete warning`() {
+        val repository = FakeRepository(
+            libraryResult = Result.success(ParsedFixtures.library),
+            chaptersResult = Result.success(ParsedFixtures.chapters),
+            capabilitiesResult = ServerCapabilities(
+                serverVersion = "2.0.0",
+                fictionManagement = true,
+            ),
+            currentUserResult = Result.success(MobileUser(1, "admin", isAdmin = true)),
+        )
+        val app = container(
+            SessionState(
+                serverUrl = "https://ttsroad.example.com/",
+                token = "ttsr_admin",
+                username = "admin",
+                isAdmin = true,
+            ),
+            repository,
+        )
+
+        compose.setContent { TtsRoadTheme { App(app) } }
+        compose.waitForIdle()
+
+        compose.onNodeWithTag(AddFictionButtonTestTag).performScrollTo().assertIsDisplayed()
+        compose.onNodeWithTag(AddFictionButtonTestTag).performClick()
+        compose.onNodeWithTag(AddFictionDialogTestTag).assertIsDisplayed()
+        compose.onNodeWithText("CANCEL").performClick()
+
+        compose.onAllNodesWithTag(FictionCardTestTag).onFirst().performClick()
+        compose.waitForIdle()
+        compose.onNodeWithTag(EditFictionButtonTestTag).assertIsDisplayed()
+        compose.onNodeWithTag(DeleteFictionButtonTestTag).performClick()
+        compose.onNodeWithText(
+            "This permanently deletes the fiction, every chapter and every user's listening progress",
+            substring = true,
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a non-admin never sees fiction management controls even when routes exist`() {
+        val repository = FakeRepository(
+            libraryResult = Result.success(ParsedFixtures.library),
+            capabilitiesResult = ServerCapabilities(
+                serverVersion = "2.0.0",
+                fictionManagement = true,
+            ),
+            currentUserResult = Result.success(MobileUser(2, "listener", isAdmin = false)),
+        )
+        val app = container(
+            SessionState(
+                serverUrl = "https://ttsroad.example.com/",
+                token = "ttsr_listener",
+                username = "listener",
+                // Deliberately stale: `/me` must win over this login-time claim.
+                isAdmin = true,
+            ),
+            repository,
+        )
+
+        compose.setContent { TtsRoadTheme { App(app) } }
+        compose.waitForIdle()
+
+        assertEquals(0, compose.onAllNodesWithTag(AddFictionButtonTestTag).fetchSemanticsNodes().size)
+        assertEquals(1, repository.currentUserCalls)
+    }
 
     @Test
     fun `the library renders the continue-listening hero and the fictions grid`() {


### PR DESCRIPTION
Addresses #52 (add/edit/delete complete; EPUB upload remains blocked by jonarihen/TTSRoad#122).

## Summary
- gate management on both the advertised `fiction_management` capability and authoritative `/api/mobile/me` admin state
- add Royal Road fiction by URL or bare id, with optional voice
- edit title, author and voice without exposing the audio-directory slug
- require a destructive confirmation that explains chapters and every user's progress are deleted
- patch and refresh visible metadata, evict deleted chapter snapshots, and leave invalid detail navigation
- keep the web-only EPUB endpoint out of the native client pending a stable multipart mobile contract

## Validation
- `xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail -Pttsroad.warningsAsErrors=true`
- focused repository, state-holder, cache, capability and Compose UI tests

## Remaining issue scope
EPUB upload cannot be implemented safely until jonarihen/TTSRoad#122 lands. This PR intentionally uses `Addresses`, not `Fixes`, so #52 remains open only for that dependency.