### PR TITLE
Add resumable M4B export downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ All notable changes to TTSRoad Desktop are recorded here. The format follows
   Playing from the queue starts that chapter's fiction through the ordinary player, so what happens
   at the end of a chapter — including offline — is unchanged. The account's "when the queue is
   empty" preference is therefore displayed rather than acted on; see `docs/adr/0011`.
+- A capability-gated Audiobooks settings pane for administrators. It lists finished server M4B
+  exports and saves them to a user-selected path with authenticated range resume, free-space and
+  container validation, fsync, atomic promotion, and resumable partials. Export creation/deletion
+  remains in the web admin and saved files stay outside TTSRoad-managed offline storage.
 
 ## [1.0.2] - 2026-08-10
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,11 +103,12 @@ apply to audio.
 ### Listening preferences, the sleep timer and history
 
 - `data/PlaybackPreferences.kt` — speed, skip interval, skip silence, volume boost, in
-  `playback.json`. **Machine-local, not session data**: signing out must not reset them and a second
-  account must not inherit them, so the store has no reference to a session at all. The on-disk type
-  is separate and fully nullable, so a file from another build loads degraded rather than throwing;
-  out-of-range values are *snapped*, not defaulted. The offered speed list always includes the
-  stored value even when it isn't a preset.
+  `playback.json`. **OS-profile-local, not session or TTSRoad account data**: signing out must not
+  reset them. Accounts under the same OS login intentionally share the machine's output settings;
+  different OS users get different config roots. Do not synchronize the server's later
+  `player_preferences` keys: speed/skip/silence/gain are output-shaped, and a sleep default merely
+  highlights a choice rather than arming the safety action. The on-disk type is separate and fully
+  nullable, out-of-range values are snapped, and the offered speed list preserves a custom value.
 - **The controller applies preferences, not the player screen.** `QueuePlaybackController` collects
   the store and pushes rate/gain/skip-silence to the engine, so an auto-advanced chapter and a
   media-key start use the same values as one the user pressed play on. `setSpeed` writes the
@@ -149,6 +150,17 @@ apply to audio.
   rows and tombstones through `data/DeltaSync.kt`. Missing/old delta endpoints fall back to a full
   refresh. Settings measures real files, groups downloads by fiction, and keeps confirmed Delete
   all downloads separate from Clear streaming cache.
+
+### Audiobook exports
+
+- `data/AudiobookExports.kt` + `download/AudiobookExportDownloader.kt` consume the read-only admin
+  `/api/mobile/exports` contract when capability `audiobook_export` is true. Settings lists finished
+  exports; create/delete stay in the web admin and `playable_in_app` must remain false.
+- The native picker chooses a destination outside managed storage. Never put an M4B export in the
+  chapter index/cache or delete it on sign-out. The shared authenticated client downloads to a
+  per-export partial beside the destination, resumes ranges, checks space/length/`ftyp`, fsyncs and
+  atomically promotes. Cancellation retains the partial; corrupt completion deletes it. See ADR
+  0013.
 
 ### Read-along
 
@@ -248,7 +260,9 @@ release with no asset for this platform/architecture is announced *without* a do
 
 `GET /api/mobile/capabilities` is unauthenticated and additive. Only a literal JSON `true` enables a
 feature; unknown keys are ignored; `404` means baseline and is cached; a transient failure keeps the
-last known answer rather than downgrading; `api_version` is never a proxy for a feature.
+last known answer rather than downgrading; `api_version` is never a proxy for a feature. The
+Audiobooks settings navigation entry is stricter than older endpoint-probing surfaces: it is visible
+only for the explicit `audiobook_export` flag, then still treats an endpoint 404 as unsupported.
 
 `fiction_management` says only that the admin add/edit/delete routes exist. The UI separately asks
 `/api/mobile/me` and offers controls only for its current `is_admin=true`; never trust the role
@@ -337,8 +351,9 @@ device sessions and Settings (0003), navigation (0004), chapter browsing (0005),
 preferences / sleep timer / MPRIS / shortcuts (0006). Read the relevant one before changing any of
 the invariants above; offline storage and caching are in 0007, read-along is in 0008, and Debian
 packaging/operations are in 0009, and releases/update checking are in 0010. They exist because
-the alternative was tried or measured. The cross-library server queue is in 0011.
-Admin fiction management and its two independent gates are in 0012.
+the alternative was tried or measured. The cross-library server queue is in 0011, admin fiction
+management and its two independent gates are in 0012, and read-only audiobook export downloads are
+in 0013.
 
 ## CI
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Built with Compose for Desktop — real Skia-rendered UI, real OS installers, no
 | Searchable up-next panel for long queues | ✅ |
 | Player UI (play/pause, seek, configurable skip, next/previous, up-next queue) | ✅ |
 | **MP3 audio playback** | ✅ |
-| Settings — two-pane control centre (account, devices, playback, offline, about) | ✅ |
+| Settings — two-pane control centre (account, devices, playback, offline, audiobooks, about) | ✅ |
 | Device sessions — list, mark current, revoke one / revoke all others | ✅ |
 | Playback preferences — speed, skip interval, skip silence, volume boost | ✅ |
 | Sleep timer — 5/15/30/45/60 min or end of chapter, with a fade and "+5 min" | ✅ |
@@ -55,6 +55,7 @@ Built with Compose for Desktop — real Skia-rendered UI, real OS installers, no
 | Offline downloads — per chapter, next 10, restart-safe queue, storage controls | ✅ |
 | Bounded streaming cache and previously loaded library browsing while offline | ✅ |
 | Timestamped delta refresh for cached library and chapter metadata | ✅ |
+| Admin audiobook exports — resumable M4B save to a user-selected file | ✅ |
 | Audio-synchronized read-along — offline text, word seek, find, themes and zoom | ✅ |
 | Streaming playback — audio starts before the chapter has downloaded | ✅ Linux |
 | Seeking without decoding from the start of the chapter | ✅ Linux |
@@ -177,6 +178,8 @@ Read-along parsing, ETag caching, media-time highlighting and account preference
 [`docs/adr/0008-audio-synchronized-read-along.md`](docs/adr/0008-audio-synchronized-read-along.md).
 Linux package identity, dependencies, upgrade semantics, diagnostics and lifecycle verification are
 in [`docs/adr/0009-linux-debian-package.md`](docs/adr/0009-linux-debian-package.md).
+Read-only M4B export listing, resumable user-selected saves and their storage boundary are in
+[`docs/adr/0013-audiobook-export-downloads.md`](docs/adr/0013-audiobook-export-downloads.md).
 
 ## 🚀 Bootstrap
 
@@ -291,6 +294,7 @@ src/main/kotlin/dk/perspektiva/ttsroad/desktop/
 │   └── Shortcuts.kt              the keyboard table and Escape's precedence, as pure functions
 ├── data/
 │   ├── Models.kt                 mobile API models (Moshi)
+│   ├── AudiobookExports.kt       completed server M4B export API models
 │   ├── PlaybackPreferences.kt    speed/skip/silence/boost, machine-local, migrating on read
 │   ├── PlaybackHistory.kt        bounded local snapshots, last-heard and jump-back selection
 │   ├── SyncedPlaybackHistoryStore.kt  cross-device auto-bookmark reconciliation
@@ -337,6 +341,7 @@ src/main/kotlin/dk/perspektiva/ttsroad/desktop/
 │   ├── DownloadIndex.kt          transactional, migrating queue/index state
 │   ├── DownloadStorage.kt        owner-only explicit-download root + safe cleanup
 │   ├── ChapterDownloader.kt      range resume, validation, fsync and atomic promotion
+│   ├── AudiobookExportDownloader.kt authenticated resumable save to a selected M4B path
 │   ├── DownloadManager.kt        bounded queue, backoff, cancellation and restart recovery
 │   ├── DownloadCoordinator.kt    current-account lifecycle, totals and cleanup seam
 │   ├── StreamingCache.kt         bounded validated cache populated while playback reads
@@ -350,6 +355,7 @@ src/main/kotlin/dk/perspektiva/ttsroad/desktop/
     ├── SettingsStateHolder.kt    settings panes, device sessions, confirmations
     ├── FictionManagementStateHolder.kt capability + current-admin gate and mutation state
     ├── FictionManagementDialogs.kt add/edit forms and destructive shared-delete warning
+    ├── AudiobookSavePicker.kt    native user-selected M4B destination
     ├── LibraryScreen.kt          LazyVerticalGrid: hero, shelves, search, fictions
     ├── FictionDetailScreen.kt    LazyColumn: one header item, then chapter rows + bulk controls
     ├── ReaderScreen.kt           lazy selectable reader, follow/find/zoom/theme controls
@@ -427,6 +433,19 @@ and keeps **Delete all downloads** separate from **Clear streaming cache**, each
 Signing out keeps bytes but closes the account's index and fiction titles until that account signs
 in again.
 
+## 🎧 Audiobook exports
+
+When an administrator's server advertises `audiobook_export`, Settings → **Audiobooks** lists its
+finished M4B volumes. The surface is intentionally read-only: create and remove exports in the web
+admin, then save a completed volume to a path chosen through the native file dialog. Exported files
+are for third-party players and are never offered as chapters inside TTSRoad.
+
+Large saves resume from a partial file beside the destination. The downloader uses the same
+same-origin bearer-authenticated client as playback, checks free space and expected length, fsyncs
+and validates the M4B container, then promotes it atomically. Pausing or closing retains a resumable
+partial; a corrupt completed body is removed. Saved exports are user-owned files outside TTSRoad's
+managed offline/cache roots, so sign-out and storage cleanup do not delete them.
+
 ## 📖 Read-along reader
 
 The reader is offered only when capability discovery reports `readalong`. `has_timings` changes the
@@ -451,8 +470,14 @@ is not playing never highlights it against unrelated audio.
 ## 🎚️ Listening preferences, the sleep timer and the desktop
 
 Speed, skip interval, skip silence and volume boost live in `playback.json` next to the session and
-window files — **not** in the session. Signing out does not reset them, and a second account on a
-shared machine does not inherit the first one's. The file has no notion of a user at all.
+window files — **not** in the session. Signing out does not reset them. The file belongs to the OS
+profile and has no TTSRoad account key, so accounts under the same OS login intentionally share the
+machine's output settings; different OS users have separate config directories.
+
+The server's later `player_preferences` capability does not change that boundary. Speed, skip,
+silence removal and gain are output/engine-shaped, and the sleep timer remains an explicit action
+rather than inheriting an account default. Reader appearance is still account-synchronized because
+it describes portable content presentation rather than this machine's audio path.
 
 - **They are applied by the controller, not the player screen.** An auto-advanced chapter and a
   media-key start use the same values as a chapter you pressed play on, because only the controller

--- a/docs/adr/0006-listening-preferences-and-desktop-integration.md
+++ b/docs/adr/0006-listening-preferences-and-desktop-integration.md
@@ -14,8 +14,9 @@ Cinnamon's media applet and the keyboard's transport row saw no player at all.
 
 Four questions had to be answered before any of that could be built.
 
-1. **Where do listening settings live?** They are not account data — the server has no endpoint for
-   them — and they are not session data either.
+1. **Where do listening settings live?** At the time, the server had no preference endpoint and
+   they were not session data either. The account preference contract added later is reconsidered
+   below rather than silently changing the original device-local semantics.
 2. **How is a sleep timer made testable?** The acceptance criteria require deterministic behaviour
    across pause, resume, seek, chapter boundary, manual stop and app close, including a fade.
 3. **What speaks D-Bus?** MPRIS is the only way media keys and the Cinnamon applet reach a Linux
@@ -34,9 +35,9 @@ owner-only through `SecureFiles`. It holds speed, skip interval, skip-silence an
 It is deliberately **not** part of the session:
 
 - signing out must not reset someone's speed and skip interval;
-- signing in as a second account on a shared machine must not inherit the first account's;
-- the file therefore has no notion of a user at all, which is a stronger guarantee than remembering
-  not to key it by one.
+- these controls describe this OS profile's output and listening environment, not server identity;
+- the file therefore has no notion of a TTSRoad user. Two accounts used under the same OS login see
+  the same values; different OS users already have separate config directories.
 
 The on-disk shape is a separate type (`StoredPlaybackPreferences`) in which every field is nullable
 and the enum is a plain string. A file written by an older build is missing keys; a file written by
@@ -47,6 +48,26 @@ an exception during startup. Out-of-range numbers are **snapped, not defaulted**
 Speed gets one extra rule. The offered list always contains the *stored* value even when it is not
 one of this build's presets, so a rate set by another build stays selectable instead of being
 silently rounded away the first time the menu is opened.
+
+### The later account preference API does not change that ownership
+
+Issue #35 revisited this decision after the server added `player_preferences`, with account keys for
+speed, skip interval, skip silence, volume boost and a sleep-timer default. Desktop deliberately
+does not synchronize them:
+
+- speed, skip interval, silence removal and gain depend on the current device, output, engine and
+  listening environment. Moving a speaker-specific boost or a plugin-dependent silence setting to
+  every client is surprising, and an unsupported engine cannot faithfully apply the value;
+- the sleep timer remains an explicit action. The server's `sleep_timer_default_minutes` does not
+  arm playback on the web — it only marks a preferred choice in the menu — while desktop already
+  presents the complete short ladder. Persisting or syncing a highlighted default adds state but
+  does not make the safety-critical act of arming a timer any clearer;
+- sign-out and offline playback keep the same predictable local behaviour. No best-effort network
+  merge can overwrite a choice while audio is already running.
+
+Reader appearance remains account-synchronized because it describes content presentation and is
+portable across devices. Listening controls are local because they describe audio output. The
+different ownership is intentional, not an unfinished capability flag.
 
 ### Volume boost stops at 2×
 
@@ -224,6 +245,8 @@ local fallback was retained rather than replacing it because offline playback is
 - Speed, skip interval, skip-silence and volume boost survive a restart and a sign-out, and are
   applied by the controller, so an auto-advanced chapter and a media-key start use the same values
   as one the user pressed play on.
+- Accounts under one OS profile share those machine-level controls; they are not presented as
+  account preferences and are never synchronized through `player_preferences`.
 - The sleep timer's whole surface is testable without audio, a display or wall-clock waiting.
 - Cinnamon's applet, the lock screen where present, and hardware media keys control playback and
   show correct metadata; seek and rate stay synchronised.
@@ -237,13 +260,14 @@ local fallback was retained rather than replacing it because offline playback is
 
 ## Alternatives considered and rejected
 
-**Preferences on the server.** There is no endpoint, and inventing one would break the roadmap's
-scope rule (keep changes in the desktop client unless a missing server contract is demonstrated).
-Speed and skip interval are also genuinely per-machine — a phone on a commute and a desktop in a
-quiet room do not want the same numbers.
+**Preferences on the server.** There was no endpoint when this decision was first made. The later
+`player_preferences` contract is real but does not change the ownership: a phone on a commute and a
+desktop on speakers do not want the same speed, gain or silence-removal support. Synchronizing only
+`sleep_timer_default_minutes` was also considered; because it merely highlights a menu choice and
+never arms the timer, desktop keeps the simpler explicit timer ladder.
 
-**Preferences inside `session.json`.** Simpler, and wrong: signing out would reset them, and a
-second account on a shared machine would inherit the first's.
+**Preferences inside `session.json`.** Simpler, and wrong: signing out would reset controls that
+belong to the OS profile and output setup.
 
 **A coroutine-based sleep timer with `delay`.** The natural implementation, and untestable against
 the acceptance criteria without either sleeping through real minutes or mocking `delay` at the

--- a/docs/adr/0013-audiobook-export-downloads.md
+++ b/docs/adr/0013-audiobook-export-downloads.md
@@ -1,0 +1,76 @@
+# ADR 0013: Read-only audiobook export downloads
+
+- **Status:** Accepted
+- **Date:** 2026-08-14
+- **Context issue:** [#35 — Three-client parity](https://github.com/jonarihen/TTSRoad-Desktop/issues/35)
+
+## Context
+
+The server can assemble completed fiction chapters into M4B volumes and advertises the
+`audiobook_export` capability. Its mobile contract deliberately exposes a read-only admin list:
+`GET /api/mobile/exports` returns finished exports and authenticated download URLs, while creation
+and deletion remain in the web admin.
+
+A desktop is the natural client for saving these large files, but an export is not another chapter
+download. It is meant for a third-party audiobook player, has no useful per-chapter resume contract,
+and belongs wherever the user chooses rather than inside TTSRoad's account-scoped offline store.
+
+## Decision
+
+### Settings is a read-only export shelf
+
+An **Audiobooks** pane appears only when capability discovery reports `audiobook_export`. It verifies
+the current `/api/mobile/me` response is an administrator before requesting the list. A 404 remains
+an explicit unsupported state, and a server without ffmpeg can still offer already-finished files.
+
+The desktop never creates, deletes or plays an export. It says that management stays in the web
+admin and that normal per-chapter playback remains the in-app path. This keeps server policy and
+long-running export jobs out of a client API that does not define them.
+
+### A saved M4B is user data, not offline cache
+
+The native save dialog chooses the final path and offers a sanitized server filename. Server paths,
+control characters and directory traversal never become a local path. The completed file is not
+indexed as an offline fiction, counted in Settings storage, evicted, or removed on sign-out.
+
+Downloads use the shared OkHttp client, so bearer authentication and the same-origin interceptor
+apply exactly as they do to chapter audio. A 401 ends the local session. A 404 or 410 explains that
+the server export is gone rather than retrying forever.
+
+### Large transfers resume and promote atomically
+
+A partial file sits beside the selected destination as
+`.filename.ttsroad-<export-id>.part`. Re-selecting the same destination sends a range request and
+resumes it. If the server ignores the range and answers 200, the partial is truncated before the
+new body is written. Pause or application shutdown retains the partial; a corrupt completed body
+is deleted.
+
+Before transfer, the client checks available space with a 64 MiB margin. It reports byte progress,
+fsyncs the partial, rejects a short response, verifies the ISO base-media `ftyp` header, and then
+atomically replaces the destination where the filesystem supports it. The final file and partial
+are restricted to the owner where the platform supports POSIX permissions.
+
+The API does not publish a checksum, so exact size plus a structural M4B check is the strongest
+client-side validation available. This is not presented as cryptographic integrity.
+
+## Consequences
+
+- Administrators can save finished whole-fiction M4Bs to any local or mounted destination without
+  duplicating them into the managed chapter-download store.
+- Interrupted multi-gigabyte transfers can continue without starting over.
+- The desktop cannot create or delete exports; those operations require a future explicit mobile
+  contract if they are ever wanted.
+- Export files intentionally remain after sign-out because the user placed them outside app-owned
+  storage.
+
+## Alternatives considered
+
+**Store exports under the offline-download root.** Rejected because that root is account-scoped,
+managed and removable from Settings. A user-selected M4B is an exported document and must not be
+silently swept up by app cleanup.
+
+**Play the M4B in TTSRoad.** Rejected because `playable_in_app` is false and the per-chapter API has
+the queue, progress and read-along semantics the player needs.
+
+**Expose create/delete by copying web routes.** Rejected because those are not part of the mobile
+contract and would make the client depend on HTML/admin implementation details.

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -125,7 +125,12 @@ fun App(container: AppContainer = remember { AppContainer() }) {
         UpdateStateHolder(container.updateChecker, container.updateDownloader, container.updateSettings)
     }
     val settings = rememberStateHolder(repository, sessionStore) {
-        SettingsStateHolder(repository, sessionStore, offlineStorage = container.downloads)
+        SettingsStateHolder(
+            repository,
+            sessionStore,
+            offlineStorage = container.downloads,
+            audiobookDownloader = container.audiobookExportDownloader,
+        )
     }
     // Hoisted for the same reason: following a hit and coming back must find the results still
     // there. A search you have to run twice to use is not a search.

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/AudiobookExports.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/AudiobookExports.kt
@@ -1,0 +1,39 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Json
+
+/** Read-only `/api/mobile/exports`: finished M4B volumes an admin can save elsewhere. */
+data class AudiobookExportsResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    @param:Json(name = "ffmpeg_available") val ffmpegAvailable: Boolean = false,
+    val exports: List<AudiobookExport> = emptyList(),
+)
+
+data class AudiobookExport(
+    val id: Int = 0,
+    @param:Json(name = "fiction_id") val fictionId: Int = 0,
+    @param:Json(name = "fiction_title") val fictionTitle: String? = null,
+    @param:Json(name = "fiction_slug") val fictionSlug: String? = null,
+    @param:Json(name = "batch_id") val batchId: String? = null,
+    @param:Json(name = "part_index") val partIndex: Int = 1,
+    @param:Json(name = "part_count") val partCount: Int = 1,
+    val title: String = "Audiobook",
+    val filename: String = "audiobook.m4b",
+    val status: String = "done",
+    val progress: Int = 100,
+    @param:Json(name = "encode_mode") val encodeMode: String? = null,
+    @param:Json(name = "chapter_count") val chapterCount: Int = 0,
+    @param:Json(name = "first_chapter_number") val firstChapterNumber: Int? = null,
+    @param:Json(name = "last_chapter_number") val lastChapterNumber: Int? = null,
+    @param:Json(name = "duration_seconds") val durationSeconds: Double = 0.0,
+    @param:Json(name = "duration_label") val durationLabel: String? = null,
+    @param:Json(name = "size_bytes") val sizeBytes: Long = 0L,
+    @param:Json(name = "size_label") val sizeLabel: String? = null,
+    @param:Json(name = "created_at") val createdAt: String? = null,
+    @param:Json(name = "completed_at") val completedAt: String? = null,
+    @param:Json(name = "download_url") val downloadUrl: String? = null,
+    val downloadable: Boolean = false,
+    @param:Json(name = "requires_bearer_auth") val requiresBearerAuth: Boolean = true,
+    /** Always false by contract: per-chapter playback has the useful resume semantics. */
+    @param:Json(name = "playable_in_app") val playableInApp: Boolean = false,
+)

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackPreferences.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackPreferences.kt
@@ -24,12 +24,12 @@ enum class VolumeBoost(val label: String, val gain: Double) {
 }
 
 /**
- * Listening settings that belong to the machine, not to the account.
+ * Listening settings that belong to this OS profile and output setup, not to a TTSRoad account.
  *
  * Deliberately persisted outside the session: signing out must not reset someone's speed and skip
- * interval, and signing in as a second account on a shared machine must not inherit the first
- * account's — the file has no notion of a user because these are properties of *this desktop*.
- * Nothing here is secret, and there is nowhere in the type to put something that is.
+ * interval. Two TTSRoad accounts used by the same OS user intentionally see the same values because
+ * the file has no account key; a different OS user has a different config directory. Nothing here
+ * is secret, and there is nowhere in the type to put something that is.
  */
 data class PlaybackPreferences(
     val speed: Float = DefaultSpeed,

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -148,6 +148,9 @@ interface TtsRoadRepository {
      */
     suspend fun devices(): List<DeviceSession>?
 
+    /** Finished M4B exports, or null when this server predates the read-only mobile surface. */
+    suspend fun audiobookExports(): AudiobookExportsResponse? = null
+
     /**
      * Revokes one session.
      *
@@ -447,6 +450,9 @@ class RetrofitTtsRoadRepository(
     override suspend fun currentUser(): MobileUser? = ifEndpointExists { it.me() }?.user
 
     override suspend fun devices(): List<DeviceSession>? = ifEndpointExists { it.devices() }?.devices
+
+    override suspend fun audiobookExports(): AudiobookExportsResponse? =
+        ifEndpointExists { it.audiobookExports() }
 
     override suspend fun revokeDevice(tokenId: Int): Boolean =
         ifEndpointExists { it.revokeDevice(tokenId) } != null

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
@@ -62,6 +62,8 @@ data class ServerCapabilities(
      * player builds is unaffected either way; the two are different things (see [ServerQueueItem]).
      */
     val queue: Boolean = false,
+    /** Read-only list/download surface for finished whole-fiction M4B exports. */
+    val audiobookExport: Boolean = false,
     val maxChaptersPerPage: Int? = null,
     /**
      * How many items `/playback/sync` accepts in one batch.
@@ -94,6 +96,7 @@ data class ServerCapabilities(
             follows = response.capabilities.flag("follows"),
             deviceManagement = response.capabilities.flag("device_management"),
             queue = response.capabilities.flag("queue"),
+            audiobookExport = response.capabilities.flag("audiobook_export"),
             maxChaptersPerPage = response.limits.intLimit("max_chapters_per_page"),
             maxPlaybackSyncItems = response.limits.intLimit("max_playback_sync_items"),
         )

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -46,6 +46,10 @@ interface TtsRoadApi {
     @GET("api/mobile/devices")
     suspend fun devices(): DevicesResponse
 
+    /** Finished admin-created M4B volumes; read-only and admin-only. */
+    @GET("api/mobile/exports")
+    suspend fun audiobookExports(): AudiobookExportsResponse
+
     // Both revoke calls answer with a small status object (`{"status": "ok", ...}`) whose shape is
     // not worth modelling: the client re-reads the list afterwards rather than trusting an echo,
     // because a 404 on the DELETE is ambiguous between "already gone" and "no such endpoint".

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/di/AppContainer.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/di/AppContainer.kt
@@ -14,6 +14,8 @@ import dk.perspektiva.ttsroad.desktop.data.ReadAlongCache
 import dk.perspektiva.ttsroad.desktop.data.ReaderPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.RetrofitTtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.download.DownloadCoordinator
+import dk.perspektiva.ttsroad.desktop.download.AudiobookExportDownloader
+import dk.perspektiva.ttsroad.desktop.download.HttpAudiobookExportDownloader
 import dk.perspektiva.ttsroad.desktop.download.OfflineFirstMediaSourceFactory
 import dk.perspektiva.ttsroad.desktop.data.SessionStore
 import dk.perspektiva.ttsroad.desktop.data.SyncedPlaybackHistoryStore
@@ -120,6 +122,13 @@ class AppContainer(
      */
     downloadCoordinatorFactory: (SessionStore, OkHttpClient, TtsRoadRepository, AppDispatchers) -> DownloadCoordinator =
         { session, client, repo, d -> DownloadCoordinator(session, client, repo, dispatcher = d.io) },
+    audiobookExportDownloaderFactory: (
+        OkHttpClient,
+        TtsRoadRepository,
+        AppDispatchers,
+    ) -> AudiobookExportDownloader = { client, repo, d ->
+        HttpAudiobookExportDownloader(client, repo, d.io)
+    },
     // A store rather than a file path, so a test never writes into the user's config directory.
     windowPreferencesStore: WindowPreferencesStore = FileWindowPreferencesStore(),
     /**
@@ -132,6 +141,8 @@ class AppContainer(
 ) : AutoCloseable {
     val httpClient: OkHttpClient = httpClientFactory(sessionStore)
     val repository: TtsRoadRepository = repositoryFactory(sessionStore, httpClient, dispatchers)
+    val audiobookExportDownloader: AudiobookExportDownloader =
+        audiobookExportDownloaderFactory(httpClient, repository, dispatchers)
 
     /**
      * Offline downloads for whoever is signed in.

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/download/AudiobookExportDownloader.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/download/AudiobookExportDownloader.kt
@@ -1,0 +1,238 @@
+package dk.perspektiva.ttsroad.desktop.download
+
+import dk.perspektiva.ttsroad.desktop.data.AudiobookExport
+import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
+import dk.perspektiva.ttsroad.desktop.data.describeNetworkFailure
+import dk.perspektiva.ttsroad.desktop.data.parseSessionEnd
+import dk.perspektiva.ttsroad.desktop.security.SecureFiles
+import java.io.File
+import java.io.IOException
+import java.io.RandomAccessFile
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+sealed interface AudiobookDownloadResult {
+    data class Success(val file: File, val bytes: Long) : AudiobookDownloadResult
+    data class Failed(val failure: DownloadFailure) : AudiobookDownloadResult
+}
+
+fun interface AudiobookExportDownloader {
+    suspend fun download(
+        export: AudiobookExport,
+        destination: File,
+        onProgress: (Long, Long) -> Unit,
+    ): AudiobookDownloadResult
+}
+
+object UnavailableAudiobookExportDownloader : AudiobookExportDownloader {
+    override suspend fun download(
+        export: AudiobookExport,
+        destination: File,
+        onProgress: (Long, Long) -> Unit,
+    ): AudiobookDownloadResult = AudiobookDownloadResult.Failed(
+        DownloadFailure.Transient("Audiobook downloads are unavailable"),
+    )
+}
+
+/**
+ * Resumable, atomic download of one server-produced M4B into a user-selected path.
+ *
+ * The shared OkHttp client owns authentication and applies it only to the signed-in server's
+ * origin. A partial sits beside the chosen destination and includes the export id in its name, so
+ * choosing the same path later resumes the same volume without confusing two server exports.
+ */
+class HttpAudiobookExportDownloader(
+    private val client: OkHttpClient,
+    private val repository: TtsRoadRepository,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : AudiobookExportDownloader {
+    override suspend fun download(
+        export: AudiobookExport,
+        destination: File,
+        onProgress: (Long, Long) -> Unit,
+    ): AudiobookDownloadResult = withContext(dispatcher) {
+        when {
+            export.id <= 0 || !export.downloadable || export.downloadUrl.isNullOrBlank() ->
+                AudiobookDownloadResult.Failed(DownloadFailure.Gone("This export is not downloadable"))
+
+            export.playableInApp ->
+                AudiobookDownloadResult.Failed(DownloadFailure.Corrupt("The export contract was invalid"))
+
+            else -> downloadReady(export, destination, onProgress)
+        }
+    }
+
+    private suspend fun downloadReady(
+        export: AudiobookExport,
+        destination: File,
+        onProgress: (Long, Long) -> Unit,
+    ): AudiobookDownloadResult {
+        val target = destination.absoluteFile.normalize()
+        val parent = target.parentFile
+            ?: return AudiobookDownloadResult.Failed(DownloadFailure.Corrupt("Choose a destination folder"))
+        val part = File(parent, ".${target.name}.ttsroad-${export.id}.part")
+        if (target.name.isBlank() || Files.isSymbolicLink(target.toPath()) || Files.isSymbolicLink(part.toPath())) {
+            return AudiobookDownloadResult.Failed(DownloadFailure.Corrupt("The destination is not a regular file"))
+        }
+        runCatching { Files.createDirectories(parent.toPath()) }
+            .getOrElse {
+                return AudiobookDownloadResult.Failed(
+                    DownloadFailure.Transient("Could not create the destination folder"),
+                )
+            }
+
+        var alreadyHave = part.takeIf(File::isFile)?.length() ?: 0L
+        if (export.sizeBytes > 0L && alreadyHave > export.sizeBytes) {
+            runCatching { Files.deleteIfExists(part.toPath()) }
+            alreadyHave = 0L
+        }
+        val remaining = (export.sizeBytes - alreadyHave).coerceAtLeast(0L)
+        val usable = parent.usableSpace
+        val required = remaining.coerceAtMost(Long.MAX_VALUE - FreeSpaceMarginBytes) + FreeSpaceMarginBytes
+        if (remaining > 0L && usable > 0L && usable < required) {
+            return AudiobookDownloadResult.Failed(
+                DownloadFailure.OutOfSpace("Not enough free disk space for this audiobook"),
+            )
+        }
+
+        return try {
+            if (export.sizeBytes > 0L && alreadyHave == export.sizeBytes) {
+                RandomAccessFile(part, "rw").use { it.fd.sync() }
+                promote(part, target, alreadyHave)
+            } else {
+                transfer(export, part, target, alreadyHave, onProgress)
+            }
+        } catch (cancelled: kotlinx.coroutines.CancellationException) {
+            throw cancelled
+        } catch (failure: SessionExpiredDownloadException) {
+            AudiobookDownloadResult.Failed(DownloadFailure.SessionExpired(failure.message.orEmpty()))
+        } catch (failure: OutOfSpaceException) {
+            AudiobookDownloadResult.Failed(DownloadFailure.OutOfSpace(failure.message.orEmpty()))
+        } catch (failure: GoneException) {
+            AudiobookDownloadResult.Failed(DownloadFailure.Gone(failure.message.orEmpty()))
+        } catch (failure: Exception) {
+            AudiobookDownloadResult.Failed(DownloadFailure.Transient(describeNetworkFailure(failure)))
+        }
+    }
+
+    private suspend fun transfer(
+        export: AudiobookExport,
+        part: File,
+        target: File,
+        alreadyHave: Long,
+        onProgress: (Long, Long) -> Unit,
+    ): AudiobookDownloadResult {
+        if (repository.authHeaderValue() == null) throw SessionExpiredDownloadException("Not signed in")
+        val request = Request.Builder()
+            .url(repository.resolveUrl(requireNotNull(export.downloadUrl)))
+            .apply { if (alreadyHave > 0L) header("Range", "bytes=$alreadyHave-") }
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            if (response.code == 401) {
+                val end = parseSessionEnd(response.body.string())
+                repository.endSession(end)
+                throw SessionExpiredDownloadException(end.message)
+            }
+            if (response.code == 404 || response.code == 410) {
+                throw GoneException("This audiobook export is no longer on the server")
+            }
+            if (!response.isSuccessful) throw IOException("The server refused the download (HTTP ${response.code})")
+
+            val appending = alreadyHave > 0L && response.code == 206
+            val startAt = if (appending) alreadyHave else 0L
+            val total = export.sizeBytes.takeIf { it > 0L }
+                ?: response.body.contentLength().takeIf { it > 0L }?.plus(startAt)
+                ?: 0L
+            var written = startAt
+            RandomAccessFile(part, "rw").use { output ->
+                SecureFiles.restrictToOwner(part.toPath())
+                output.seek(startAt)
+                if (!appending) output.setLength(0L)
+                val input = response.body.byteStream()
+                val buffer = ByteArray(BufferBytes)
+                while (true) {
+                    coroutineContext.ensureActive()
+                    val read = input.read(buffer)
+                    if (read < 0) break
+                    if (read == 0) continue
+                    try {
+                        output.write(buffer, 0, read)
+                    } catch (failure: IOException) {
+                        if (failure.message?.contains("space", ignoreCase = true) == true) {
+                            throw OutOfSpaceException("The disk is full")
+                        }
+                        throw failure
+                    }
+                    written += read
+                    onProgress(written, total)
+                }
+                output.fd.sync()
+            }
+            if (total > 0L && written != total) {
+                throw IOException("The download ended early ($written of $total bytes)")
+            }
+            return promote(part, target, written)
+        }
+    }
+
+    private fun promote(part: File, target: File, bytes: Long): AudiobookDownloadResult {
+        if (!M4bContainerValidator.looksValid(part)) {
+            runCatching { Files.deleteIfExists(part.toPath()) }
+            return AudiobookDownloadResult.Failed(
+                DownloadFailure.Corrupt("The downloaded file was not a readable M4B container"),
+            )
+        }
+        runCatching {
+            Files.move(
+                part.toPath(),
+                target.toPath(),
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING,
+            )
+        }.recoverCatching {
+            Files.move(part.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        }.getOrElse { throw IOException("Could not finish the audiobook download", it) }
+        SecureFiles.restrictToOwner(target.toPath())
+        return AudiobookDownloadResult.Success(target, bytes)
+    }
+
+    private companion object {
+        const val BufferBytes = 64 * 1024
+        const val FreeSpaceMarginBytes = 64L * 1024 * 1024
+    }
+}
+
+/** A cheap rejection of HTML/error bodies: an ISO base-media file starts with an `ftyp` box. */
+object M4bContainerValidator {
+    fun looksValid(file: File): Boolean {
+        if (!file.isFile || file.length() < MinimumBytes) return false
+        val header = ByteArray(12)
+        return runCatching {
+            file.inputStream().use { input ->
+                if (input.readNBytes(header, 0, header.size) != header.size) return false
+            }
+            val boxSize = header.take(4).fold(0L) { value, byte -> (value shl 8) or (byte.toLong() and 0xff) }
+            boxSize >= 8L && header.copyOfRange(4, 8).decodeToString() == "ftyp"
+        }.getOrDefault(false)
+    }
+
+    private const val MinimumBytes = 32L
+}
+
+/** Never trusts a server-supplied path; only its last, cleaned filename is offered to the picker. */
+fun suggestedAudiobookFileName(filename: String): String {
+    val leaf = (filename.substringAfterLast('/').substringAfterLast('\\')
+        .replace(Regex("[\\u0000-\\u001f\\u007f]"), "_")
+        .trim()
+        .takeIf { candidate -> candidate.any(Char::isLetterOrDigit) })
+        ?: "audiobook.m4b"
+    return if (leaf.endsWith(".m4b", ignoreCase = true)) leaf else "$leaf.m4b"
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/AudiobookSavePicker.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/AudiobookSavePicker.kt
@@ -1,0 +1,23 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import java.awt.FileDialog
+import java.awt.Frame
+import java.awt.GraphicsEnvironment
+import java.io.File
+
+fun interface AudiobookSavePicker {
+    /** Null means the user cancelled the native save dialog. */
+    fun choose(suggestedFileName: String): File?
+}
+
+object DesktopAudiobookSavePicker : AudiobookSavePicker {
+    override fun choose(suggestedFileName: String): File? {
+        if (GraphicsEnvironment.isHeadless()) return null
+        val dialog = FileDialog(null as Frame?, "Save audiobook", FileDialog.SAVE)
+        dialog.file = suggestedFileName
+        dialog.isVisible = true
+        val directory = dialog.directory ?: return null
+        val filename = dialog.file ?: return null
+        return File(directory, filename)
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
@@ -1,7 +1,6 @@
 package dk.perspektiva.ttsroad.desktop.ui
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -16,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.border
 import androidx.compose.foundation.horizontalScroll
@@ -31,6 +29,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Switch
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -56,6 +55,7 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.paneTitle
@@ -63,6 +63,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import dk.perspektiva.ttsroad.desktop.BuildInfo
 import dk.perspektiva.ttsroad.desktop.data.DeviceSession
+import dk.perspektiva.ttsroad.desktop.data.AudiobookExport
 import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferences
 import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferencesStore
@@ -127,12 +128,18 @@ fun SettingsScreen(
     val ui by holder.state.collectAsState()
     val session by sessionStore.session.collectAsState()
     val capabilities by repository.currentCapabilities.collectAsState()
+    val visibleSections = remember(capabilities.audiobookExport) {
+        SettingsSection.entries.filter { section ->
+            section != SettingsSection.Audiobooks || capabilities.audiobookExport
+        }
+    }
 
     LaunchedEffect(ui.section) {
         when (ui.section) {
             SettingsSection.Account -> holder.verifyAccount()
             SettingsSection.Devices -> holder.ensureDevicesLoaded()
             SettingsSection.Offline -> holder.ensureOfflineLoaded()
+            SettingsSection.Audiobooks -> holder.ensureAudiobooksLoaded()
             else -> Unit
         }
     }
@@ -161,6 +168,7 @@ fun SettingsScreen(
                         SettingsSection.Devices -> DevicesPane(ui, session, holder, nowMs)
                         SettingsSection.Playback -> PlaybackPane(preferences, canChangeSpeed, canSkipSilence)
                         SettingsSection.Offline -> OfflinePane(ui.offline, holder)
+                        SettingsSection.Audiobooks -> AudiobookPane(ui.audiobooks, holder)
                         SettingsSection.About -> AboutPane(session, capabilities, sessionStore, updates)
                     }
                 }
@@ -169,13 +177,23 @@ fun SettingsScreen(
 
         if (stacked) {
             Column(Modifier.fillMaxSize()) {
-                SettingsNav(current = ui.section, stacked = true, onSelect = selectSection)
+                SettingsNav(
+                    current = ui.section,
+                    sections = visibleSections,
+                    stacked = true,
+                    onSelect = selectSection,
+                )
                 HorizontalDivider(thickness = 1.dp, color = AarisColor.Line)
                 Box(Modifier.weight(1f).fillMaxWidth()) { pane() }
             }
         } else {
             Row(Modifier.fillMaxSize()) {
-                SettingsNav(current = ui.section, stacked = false, onSelect = selectSection)
+                SettingsNav(
+                    current = ui.section,
+                    sections = visibleSections,
+                    stacked = false,
+                    onSelect = selectSection,
+                )
                 VerticalDivider(thickness = 1.dp, color = AarisColor.Line)
                 Box(Modifier.weight(1f).fillMaxHeight()) { pane() }
             }
@@ -191,6 +209,108 @@ fun SettingsScreen(
             onConfirm = holder::confirm,
             onDismiss = holder::dismissConfirmation,
         )
+    }
+}
+
+const val AudiobookDownloadButtonTestTag: String = "audiobookDownloadButton"
+
+@Composable
+private fun AudiobookPane(ui: AudiobookExportsUiState, holder: SettingsStateHolder) {
+    PaneTitle("Audiobooks", "Save finished whole-fiction M4B exports to this computer")
+    when {
+        ui.unsupported -> InfoCard(
+            "This server has no mobile audiobook-export API. Existing chapter playback and " +
+                "offline downloads are unaffected.",
+        )
+        ui.adminOnly -> InfoCard(
+            "Audiobook exports are shared server files and are available to administrators only.",
+        )
+        ui.isInitialLoad -> Box(Modifier.fillMaxWidth().height(120.dp)) { CenterProgress() }
+        ui.loaded == null -> {
+            Text(
+                ui.error ?: "Could not load audiobook exports",
+                color = MaterialTheme.colorScheme.error,
+            )
+            OutlinedButton(
+                onClick = holder::refreshAudiobooks,
+                enabled = !ui.isLoading,
+                shape = RectangleShape,
+                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+            ) { Text("RETRY") }
+        }
+        else -> {
+            InfoCard(
+                "This list is read-only. Create or remove exports in the server admin; the " +
+                    "desktop saves completed volumes for third-party audiobook players.",
+            )
+            if (!ui.loaded.ffmpegAvailable) {
+                InfoCard(
+                    "The server cannot create a new export right now because ffmpeg is unavailable. " +
+                        "Finished exports below can still be downloaded.",
+                )
+            }
+            if (ui.isLoading) ThinProgress(1f, Modifier.fillMaxWidth(), 2.dp)
+            ui.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+            ui.notice?.let { MetaText(it, color = AarisColor.Ok) }
+
+            if (ui.loaded.exports.isEmpty()) {
+                InfoCard("There are no finished audiobook exports on this server.")
+            } else {
+                ui.loaded.exports.forEach { export ->
+                    AudiobookExportCard(export, ui, holder)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AudiobookExportCard(
+    export: AudiobookExport,
+    ui: AudiobookExportsUiState,
+    holder: SettingsStateHolder,
+) {
+    val downloading = ui.downloadingExportId == export.id
+    SettingsCard {
+        Text(export.title, style = MaterialTheme.typography.titleMedium, color = AarisColor.Ink)
+        export.fictionTitle?.takeIf { it.isNotBlank() }?.let { MetaText(it) }
+        MetaText(
+            buildList {
+                if (export.partCount > 1) add("Part ${export.partIndex} of ${export.partCount}")
+                if (export.chapterCount > 0) add("${export.chapterCount} chapters")
+                export.durationLabel?.takeIf { it.isNotBlank() }?.let(::add)
+                export.sizeLabel?.takeIf { it.isNotBlank() }?.let(::add)
+            }.joinToString(" · ").ifBlank { export.filename },
+            color = AarisColor.Dim,
+        )
+        export.completedAt?.let { completed ->
+            formatServerTimestamp(completed)?.let { MetaText("Completed $it", color = AarisColor.Dim) }
+        }
+        if (downloading) {
+            val progress = ui.progress
+            if (progress == null) {
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            } else {
+                LinearProgressIndicator(progress = { progress }, modifier = Modifier.fillMaxWidth())
+            }
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(
+                onClick = { holder.downloadAudiobook(export) },
+                enabled = export.downloadable && ui.downloadingExportId == null,
+                shape = RectangleShape,
+                modifier = Modifier
+                    .pointerHoverIcon(PointerIcon.Hand)
+                    .testTag(AudiobookDownloadButtonTestTag),
+            ) { Text("SAVE M4B") }
+            if (downloading) {
+                OutlinedButton(
+                    onClick = holder::cancelAudiobookDownload,
+                    shape = RectangleShape,
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                ) { Text("PAUSE") }
+            }
+        }
     }
 }
 
@@ -237,7 +357,12 @@ private fun confirmationCopy(confirmation: SettingsConfirmation): ConfirmationCo
 // --- Navigation ----------------------------------------------------------------------------
 
 @Composable
-private fun SettingsNav(current: SettingsSection, stacked: Boolean, onSelect: (SettingsSection) -> Unit) {
+private fun SettingsNav(
+    current: SettingsSection,
+    sections: List<SettingsSection>,
+    stacked: Boolean,
+    onSelect: (SettingsSection) -> Unit,
+) {
     if (stacked) {
         Row(
             Modifier
@@ -246,7 +371,7 @@ private fun SettingsNav(current: SettingsSection, stacked: Boolean, onSelect: (S
                 .padding(horizontal = PageGutter, vertical = 10.dp),
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            SettingsSection.entries.forEach { NavEntry(it, it == current, onSelect) }
+            sections.forEach { NavEntry(it, it == current, onSelect) }
         }
     } else {
         Column(
@@ -259,7 +384,7 @@ private fun SettingsNav(current: SettingsSection, stacked: Boolean, onSelect: (S
         ) {
             MetaText(text = "// Settings", color = AarisColor.Accent)
             Spacer(Modifier.height(8.dp))
-            SettingsSection.entries.forEach { NavEntry(it, it == current, onSelect) }
+            sections.forEach { NavEntry(it, it == current, onSelect) }
         }
     }
 }
@@ -1035,6 +1160,7 @@ fun describeCapabilities(capabilities: ServerCapabilities): String {
         if (capabilities.batchProgress) add("Batch progress")
         if (capabilities.audioContentHash) add("Audio content hash")
         if (capabilities.deviceManagement) add("Device management")
+        if (capabilities.audiobookExport) add("Audiobook exports")
     }
     return when {
         enabled.isNotEmpty() -> enabled.joinToString(", ")

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsStateHolder.kt
@@ -1,5 +1,7 @@
 package dk.perspektiva.ttsroad.desktop.ui
 
+import dk.perspektiva.ttsroad.desktop.data.AudiobookExport
+import dk.perspektiva.ttsroad.desktop.data.AudiobookExportsResponse
 import dk.perspektiva.ttsroad.desktop.data.DeviceSession
 import dk.perspektiva.ttsroad.desktop.data.MobileUser
 import dk.perspektiva.ttsroad.desktop.data.SessionStore
@@ -9,6 +11,11 @@ import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
 import dk.perspektiva.ttsroad.desktop.download.OfflineStorageController
 import dk.perspektiva.ttsroad.desktop.download.OfflineStorageSummary
 import dk.perspektiva.ttsroad.desktop.download.UnavailableOfflineStorageController
+import dk.perspektiva.ttsroad.desktop.download.AudiobookDownloadResult
+import dk.perspektiva.ttsroad.desktop.download.AudiobookExportDownloader
+import dk.perspektiva.ttsroad.desktop.download.UnavailableAudiobookExportDownloader
+import dk.perspektiva.ttsroad.desktop.download.suggestedAudiobookFileName
+import java.io.File
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -24,6 +31,7 @@ enum class SettingsSection(val label: String) {
     Devices("Device sessions"),
     Playback("Playback"),
     Offline("Offline"),
+    Audiobooks("Audiobooks"),
     About("Updates & About"),
 }
 
@@ -73,6 +81,25 @@ data class OfflineStorageUiState(
     val isInitialLoad: Boolean get() = isLoading && loaded == null && error == null
 }
 
+data class AudiobookExportsUiState(
+    val isLoading: Boolean = false,
+    val loaded: AudiobookExportsResponse? = null,
+    val unsupported: Boolean = false,
+    val adminOnly: Boolean = false,
+    val downloadingExportId: Int? = null,
+    val bytesDownloaded: Long = 0L,
+    val totalBytes: Long = 0L,
+    val error: String? = null,
+    val notice: String? = null,
+) {
+    val isInitialLoad: Boolean
+        get() = isLoading && loaded == null && error == null && !unsupported && !adminOnly
+
+    val progress: Float?
+        get() = totalBytes.takeIf { it > 0L }
+            ?.let { (bytesDownloaded.toDouble() / it).coerceIn(0.0, 1.0).toFloat() }
+}
+
 data class SettingsUiState(
     val section: SettingsSection = SettingsSection.Account,
     val confirmation: SettingsConfirmation? = null,
@@ -81,6 +108,7 @@ data class SettingsUiState(
     val verifiedUser: MobileUser? = null,
     val signingOut: Boolean = false,
     val offline: OfflineStorageUiState = OfflineStorageUiState(),
+    val audiobooks: AudiobookExportsUiState = AudiobookExportsUiState(),
 )
 
 /**
@@ -95,6 +123,8 @@ class SettingsStateHolder(
     private val sessionStore: SessionStore,
     dispatcher: CoroutineDispatcher = Dispatchers.Main,
     private val offlineStorage: OfflineStorageController = UnavailableOfflineStorageController,
+    private val audiobookDownloader: AudiobookExportDownloader = UnavailableAudiobookExportDownloader,
+    private val audiobookSavePicker: AudiobookSavePicker = DesktopAudiobookSavePicker,
 ) : StateHolder(dispatcher) {
     private val _state = MutableStateFlow(SettingsUiState())
     val state: StateFlow<SettingsUiState> = _state.asStateFlow()
@@ -102,6 +132,8 @@ class SettingsStateHolder(
     private var loadJob: Job? = null
     private var verifyJob: Job? = null
     private var offlineJob: Job? = null
+    private var audiobookJob: Job? = null
+    private var audiobookDownloadJob: Job? = null
 
     fun openSection(section: SettingsSection) {
         _state.update { it.copy(section = section) }
@@ -117,6 +149,8 @@ class SettingsStateHolder(
         loadJob?.cancel()
         verifyJob?.cancel()
         offlineJob?.cancel()
+        audiobookJob?.cancel()
+        audiobookDownloadJob?.cancel()
         _state.value = SettingsUiState()
     }
 
@@ -159,6 +193,8 @@ class SettingsStateHolder(
             }
 
             SettingsSection.Offline -> refreshOffline()
+
+            SettingsSection.Audiobooks -> refreshAudiobooks()
 
             else -> Unit
         }
@@ -222,6 +258,118 @@ class SettingsStateHolder(
 
     fun askClearStreamingCache() {
         _state.update { it.copy(confirmation = SettingsConfirmation.ClearStreamingCache) }
+    }
+
+    // --- Audiobook exports ----------------------------------------------------------------
+
+    fun ensureAudiobooksLoaded() {
+        val exports = _state.value.audiobooks
+        if (exports.isLoading || exports.loaded != null || exports.unsupported || exports.adminOnly) return
+        refreshAudiobooks()
+    }
+
+    fun refreshAudiobooks() {
+        audiobookJob?.cancel()
+        audiobookJob = scope.launch {
+            updateAudiobooks { it.copy(isLoading = true, error = null, notice = null) }
+            val capabilities = repository.currentCapabilities.value
+            if (!capabilities.audiobookExport) {
+                updateAudiobooks {
+                    it.copy(isLoading = false, unsupported = true, loaded = null, adminOnly = false)
+                }
+                return@launch
+            }
+            runCatching {
+                val user = repository.currentUser()
+                when {
+                    user == null -> AudiobookLoad.Unsupported
+                    !user.isAdmin -> AudiobookLoad.AdminOnly
+                    else -> repository.audiobookExports()?.let(AudiobookLoad::Loaded)
+                        ?: AudiobookLoad.Unsupported
+                }
+            }
+                .onSuccess { result ->
+                    updateAudiobooks {
+                        when (result) {
+                            AudiobookLoad.Unsupported -> it.copy(
+                                isLoading = false,
+                                unsupported = true,
+                                adminOnly = false,
+                                loaded = null,
+                            )
+                            AudiobookLoad.AdminOnly -> it.copy(
+                                isLoading = false,
+                                unsupported = false,
+                                adminOnly = true,
+                                loaded = null,
+                            )
+                            is AudiobookLoad.Loaded -> it.copy(
+                                isLoading = false,
+                                unsupported = false,
+                                adminOnly = false,
+                                loaded = result.response,
+                                error = null,
+                            )
+                        }
+                    }
+                }
+                .onFailure { failure ->
+                    updateAudiobooks {
+                        it.copy(
+                            isLoading = false,
+                            error = userFacingMessage(failure, "Could not load audiobook exports"),
+                        )
+                    }
+                }
+        }
+    }
+
+    fun downloadAudiobook(export: AudiobookExport) {
+        val known = _state.value.audiobooks.loaded?.exports?.firstOrNull { it.id == export.id } ?: return
+        if (!known.downloadable || audiobookDownloadJob?.isActive == true) return
+        val selected = audiobookSavePicker.choose(suggestedAudiobookFileName(known.filename)) ?: return
+        val destination = File(selected.parentFile, suggestedAudiobookFileName(selected.name))
+        audiobookDownloadJob = scope.launch {
+            updateAudiobooks {
+                it.copy(
+                    downloadingExportId = known.id,
+                    bytesDownloaded = 0L,
+                    totalBytes = known.sizeBytes,
+                    error = null,
+                    notice = null,
+                )
+            }
+            try {
+                when (val result = audiobookDownloader.download(known, destination) { downloaded, total ->
+                    updateAudiobooks {
+                        it.copy(
+                            bytesDownloaded = downloaded,
+                            totalBytes = total.takeIf { value -> value > 0L } ?: it.totalBytes,
+                        )
+                    }
+                }) {
+                    is AudiobookDownloadResult.Success -> updateAudiobooks {
+                        it.copy(notice = "Saved ${known.title} to ${result.file}", error = null)
+                    }
+                    is AudiobookDownloadResult.Failed -> updateAudiobooks {
+                        it.copy(error = result.failure.message)
+                    }
+                }
+            } catch (cancelled: kotlinx.coroutines.CancellationException) {
+                updateAudiobooks {
+                    it.copy(notice = "Download paused; choose the same destination to resume")
+                }
+                throw cancelled
+            } finally {
+                updateAudiobooks {
+                    it.copy(downloadingExportId = null, bytesDownloaded = 0L, totalBytes = 0L)
+                }
+            }
+        }
+    }
+
+    fun cancelAudiobookDownload() {
+        audiobookDownloadJob?.cancel()
     }
 
     fun dismissConfirmation() {
@@ -348,6 +496,16 @@ class SettingsStateHolder(
                 updateDevices { it.copy(error = userFacingMessage(error, failure)) }
             }
         }
+    }
+
+    private fun updateAudiobooks(transform: (AudiobookExportsUiState) -> AudiobookExportsUiState) {
+        _state.update { it.copy(audiobooks = transform(it.audiobooks)) }
+    }
+
+    private sealed interface AudiobookLoad {
+        data object Unsupported : AudiobookLoad
+        data object AdminOnly : AudiobookLoad
+        data class Loaded(val response: AudiobookExportsResponse) : AudiobookLoad
     }
 
     private fun signOut() {

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -3,6 +3,7 @@ package dk.perspektiva.ttsroad.desktop
 import dk.perspektiva.ttsroad.desktop.data.Bookmark
 import dk.perspektiva.ttsroad.desktop.data.BookmarkCreateRequest
 import dk.perspektiva.ttsroad.desktop.data.BookmarkPatchRequest
+import dk.perspektiva.ttsroad.desktop.data.AudiobookExportsResponse
 import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
 import dk.perspektiva.ttsroad.desktop.data.ChaptersResponse
 import dk.perspektiva.ttsroad.desktop.data.DeviceSession
@@ -69,6 +70,7 @@ open class FakeRepository(
     var createFictionResult: Result<FictionSummary> = Result.success(FictionSummary(id = 101, title = "Added")),
     var updateFictionResult: Result<FictionSummary> = Result.success(FictionSummary(id = 1, title = "Updated")),
     var deleteFictionResult: Result<Boolean> = Result.success(true),
+    var audiobookExportsResult: Result<AudiobookExportsResponse?> = Result.success(null),
 ) : TtsRoadRepository {
     var loginCalls: Int = 0
         private set
@@ -86,6 +88,8 @@ open class FakeRepository(
     var devicesCalls: Int = 0
         private set
     var currentUserCalls: Int = 0
+        private set
+    var audiobookExportsCalls: Int = 0
         private set
     var revokeOtherDevicesCalls: Int = 0
         private set
@@ -213,6 +217,11 @@ open class FakeRepository(
     override suspend fun devices(): List<DeviceSession>? {
         devicesCalls++
         return devicesResult.getOrThrow()
+    }
+
+    override suspend fun audiobookExports(): AudiobookExportsResponse? {
+        audiobookExportsCalls++
+        return audiobookExportsResult.getOrThrow()
     }
 
     override suspend fun revokeDevice(tokenId: Int): Boolean {

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/AudiobookExportsRepositoryTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/AudiobookExportsRepositoryTest.kt
@@ -1,0 +1,119 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import dk.perspektiva.ttsroad.desktop.authedClient
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.Headers
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AudiobookExportsRepositoryTest {
+    private lateinit var server: MockWebServer
+    private lateinit var repository: RetrofitTtsRoadRepository
+    private val json = Headers.headersOf("Content-Type", "application/json")
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        val session = InMemorySessionStore(
+            SessionState(
+                serverUrl = server.url("/").toString(),
+                token = "ttsr_admin",
+                username = "admin",
+                isAdmin = true,
+            ),
+        )
+        repository = RetrofitTtsRoadRepository(
+            sessionStore = session,
+            client = authedClient(session),
+            ioDispatcher = UnconfinedTestDispatcher(),
+            deviceNameProvider = { "test-host" },
+        )
+    }
+
+    @AfterEach
+    fun tearDown() = server.close()
+
+    @Test
+    fun `finished exports decode as authenticated downloads and never player items`() = runTest {
+        server.enqueue(MockResponse(code = 200, headers = json, body = ExportPayload))
+
+        val response = requireNotNull(repository.audiobookExports())
+
+        assertTrue(response.ffmpegAvailable)
+        val export = response.exports.single()
+        assertEquals(17, export.id)
+        assertEquals(2, export.partIndex)
+        assertEquals(987654L, export.sizeBytes)
+        assertTrue(export.downloadable)
+        assertTrue(export.requiresBearerAuth)
+        assertFalse(export.playableInApp)
+        val request = server.takeRequest()
+        assertEquals("GET", request.method)
+        assertEquals("/api/mobile/exports", request.url.encodedPath)
+        assertEquals("Bearer ttsr_admin", request.headers["Authorization"])
+    }
+
+    @Test
+    fun `an older server reports the optional endpoint as unavailable`() = runTest {
+        server.enqueue(MockResponse(code = 404, headers = json, body = """{"detail":"Not Found"}"""))
+
+        assertNull(repository.audiobookExports())
+    }
+
+    @Test
+    fun `audiobook export capability requires a literal boolean`() {
+        assertTrue(
+            ServerCapabilities.from(
+                CapabilitiesResponse(capabilities = mapOf("audiobook_export" to true)),
+            ).audiobookExport,
+        )
+        assertFalse(
+            ServerCapabilities.from(
+                CapabilitiesResponse(capabilities = mapOf("audiobook_export" to 1)),
+            ).audiobookExport,
+        )
+    }
+
+    private companion object {
+        val ExportPayload = """
+            {
+              "api_version": 1,
+              "ffmpeg_available": true,
+              "exports": [{
+                "id": 17,
+                "fiction_id": 7,
+                "fiction_title": "A Test Serial",
+                "batch_id": "deadbeef",
+                "part_index": 2,
+                "part_count": 3,
+                "title": "A Test Serial — Part 2",
+                "filename": "a-test-serial-part-2.m4b",
+                "status": "done",
+                "progress": 100,
+                "chapter_count": 12,
+                "duration_seconds": 3600.0,
+                "duration_label": "1h 00m",
+                "size_bytes": 987654,
+                "size_label": "964.5 KB",
+                "created_at": "2026-08-14T10:00:00Z",
+                "completed_at": "2026-08-14T10:03:00Z",
+                "download_url": "https://ttsroad.example.com/api/exports/17/download",
+                "downloadable": true,
+                "requires_bearer_auth": true,
+                "playable_in_app": false
+              }]
+            }
+        """.trimIndent()
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/download/AudiobookExportDownloaderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/download/AudiobookExportDownloaderTest.kt
@@ -1,0 +1,185 @@
+package dk.perspektiva.ttsroad.desktop.download
+
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.authedClient
+import dk.perspektiva.ttsroad.desktop.data.AudiobookExport
+import dk.perspektiva.ttsroad.desktop.data.InMemorySessionStore
+import dk.perspektiva.ttsroad.desktop.data.SessionState
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.Headers
+import okio.Buffer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class AudiobookExportDownloaderTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    private lateinit var server: MockWebServer
+    private lateinit var session: InMemorySessionStore
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        session = InMemorySessionStore(
+            SessionState(serverUrl = server.url("/").toString(), token = "ttsr_admin", username = "admin"),
+        )
+    }
+
+    @AfterEach
+    fun tearDown() = server.close()
+
+    @Test
+    fun `a complete M4B is authenticated validated and atomically promoted`() = runBlocking {
+        val bytes = m4bBytes()
+        server.enqueue(binaryResponse(bytes))
+        val target = File(tempDir, "book.m4b")
+
+        val result = downloader().download(export(bytes.size), target) { _, _ -> }
+
+        assertIs<AudiobookDownloadResult.Success>(result)
+        assertTrue(target.isFile)
+        assertTrue(target.readBytes().contentEquals(bytes))
+        assertFalse(part(target).exists())
+        assertEquals("Bearer ttsr_admin", server.takeRequest().headers["Authorization"])
+    }
+
+    @Test
+    fun `an interrupted volume resumes from its export-specific partial`() = runBlocking {
+        val bytes = m4bBytes(4096)
+        val already = 1024
+        val target = File(tempDir, "book.m4b")
+        part(target).writeBytes(bytes.copyOfRange(0, already))
+        server.enqueue(
+            binaryResponse(
+                bytes.copyOfRange(already, bytes.size),
+                code = 206,
+                headers = Headers.headersOf("Content-Range", "bytes $already-${bytes.lastIndex}/${bytes.size}"),
+            ),
+        )
+
+        val result = downloader().download(export(bytes.size), target) { _, _ -> }
+
+        assertIs<AudiobookDownloadResult.Success>(result)
+        assertEquals("bytes=$already-", server.takeRequest().headers["Range"])
+        assertTrue(target.readBytes().contentEquals(bytes))
+    }
+
+    @Test
+    fun `a server that ignores range restarts instead of appending corruption`() = runBlocking {
+        val bytes = m4bBytes(4096)
+        val target = File(tempDir, "book.m4b")
+        part(target).writeBytes(bytes.copyOfRange(0, 1024))
+        server.enqueue(binaryResponse(bytes))
+
+        val result = downloader().download(export(bytes.size), target) { _, _ -> }
+
+        assertIs<AudiobookDownloadResult.Success>(result)
+        assertTrue(target.readBytes().contentEquals(bytes))
+    }
+
+    @Test
+    fun `pausing retains an export-specific partial that can be resumed`() = runBlocking {
+        val bytes = m4bBytes(256 * 1024)
+        val target = File(tempDir, "book.m4b")
+        server.enqueue(binaryResponse(bytes))
+
+        assertFailsWith<CancellationException> {
+            downloader().download(export(bytes.size), target) { downloaded, _ ->
+                if (downloaded > 0L) throw CancellationException("pause")
+            }
+        }
+
+        assertFalse(target.exists())
+        assertTrue(part(target).isFile)
+        assertTrue(part(target).length() in 1 until bytes.size.toLong())
+    }
+
+    @Test
+    fun `an HTML response is deleted instead of becoming an audiobook`() = runBlocking {
+        val bytes = ByteArray(2048) { '<'.code.toByte() }
+        server.enqueue(binaryResponse(bytes))
+        val target = File(tempDir, "book.m4b")
+
+        val result = downloader().download(export(bytes.size), target) { _, _ -> }
+
+        assertIs<AudiobookDownloadResult.Failed>(result)
+        assertIs<DownloadFailure.Corrupt>(result.failure)
+        assertFalse(target.exists())
+        assertFalse(part(target).exists())
+    }
+
+    @Test
+    fun `a download 401 ends the shared session`() = runBlocking {
+        server.enqueue(MockResponse(code = 401, body = """{"detail":"Token expired"}"""))
+
+        val result = downloader().download(export(0), File(tempDir, "book.m4b")) { _, _ -> }
+
+        assertIs<AudiobookDownloadResult.Failed>(result)
+        assertIs<DownloadFailure.SessionExpired>(result.failure)
+        assertFalse(session.current().isLoggedIn)
+    }
+
+    @Test
+    fun `server filenames are reduced to a safe M4B leaf`() {
+        assertEquals("private.m4b", suggestedAudiobookFileName("../../private.m4b"))
+        assertEquals("private.m4b", suggestedAudiobookFileName("..\\..\\private"))
+        assertEquals("audiobook.m4b", suggestedAudiobookFileName("\u0000"))
+    }
+
+    private fun export(size: Int): AudiobookExport = AudiobookExport(
+        id = 17,
+        title = "A Test Serial",
+        filename = "book.m4b",
+        sizeBytes = size.toLong(),
+        downloadUrl = server.url("/api/exports/17/download").toString(),
+        downloadable = true,
+        requiresBearerAuth = true,
+        playableInApp = false,
+    )
+
+    private fun downloader(): HttpAudiobookExportDownloader {
+        val repository = object : FakeRepository(serverUrl = server.url("/").toString()) {
+            override fun authHeaderValue(): String? = session.current().authorizationHeader
+            override fun resolveUrl(url: String): String = url
+            override suspend fun endSession(end: dk.perspektiva.ttsroad.desktop.data.SessionEnd) {
+                super.endSession(end)
+                session.clearToken()
+            }
+        }
+        return HttpAudiobookExportDownloader(authedClient(session), repository)
+    }
+
+    private fun part(target: File): File = File(target.parentFile, ".${target.name}.ttsroad-17.part")
+
+    private fun m4bBytes(size: Int = 2048): ByteArray = ByteArray(size).also { bytes ->
+        bytes[0] = 0
+        bytes[1] = 0
+        bytes[2] = 0
+        bytes[3] = 24
+        "ftyp".encodeToByteArray().copyInto(bytes, destinationOffset = 4)
+        "M4B ".encodeToByteArray().copyInto(bytes, destinationOffset = 8)
+    }
+
+    private fun binaryResponse(
+        bytes: ByteArray,
+        code: Int = 200,
+        headers: Headers = Headers.headersOf(),
+    ): MockResponse = MockResponse.Builder()
+        .code(code)
+        .headers(headers)
+        .body(Buffer().write(bytes))
+        .build()
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreenUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreenUiTest.kt
@@ -25,6 +25,9 @@ import dk.perspektiva.ttsroad.desktop.FakeRepository
 import dk.perspektiva.ttsroad.desktop.ParsedFixtures
 import dk.perspektiva.ttsroad.desktop.ServerFixtures
 import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.AudiobookExport
+import dk.perspektiva.ttsroad.desktop.data.AudiobookExportsResponse
+import dk.perspektiva.ttsroad.desktop.data.MobileUser
 import dk.perspektiva.ttsroad.desktop.data.InMemorySessionStore
 import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferences
 import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
@@ -141,6 +144,44 @@ class SettingsScreenUiTest {
     }
 
     // --- Account pane ----------------------------------------------------------------------
+
+    @Test
+    fun `the audiobook pane lists finished volumes as save-only files`() {
+        val repository = FakeRepository(
+            currentUserResult = Result.success(MobileUser(1, "admin", isAdmin = true)),
+            audiobookExportsResult = Result.success(
+                AudiobookExportsResponse(
+                    ffmpegAvailable = true,
+                    exports = listOf(
+                        AudiobookExport(
+                            id = 17,
+                            fictionTitle = "A Test Serial",
+                            partIndex = 2,
+                            partCount = 3,
+                            title = "A Test Serial — Part 2",
+                            filename = "a-test-serial-part-2.m4b",
+                            chapterCount = 12,
+                            durationLabel = "1h 00m",
+                            sizeLabel = "964.5 MB",
+                            completedAt = "2026-08-14T10:03:00Z",
+                            downloadUrl = "/api/exports/17/download",
+                            downloadable = true,
+                            playableInApp = false,
+                        ),
+                    ),
+                ),
+            ),
+        )
+        setContent(repository, capabilities = capable.copy(audiobookExport = true))
+
+        navEntry("AUDIOBOOKS").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("A Test Serial — Part 2").assertIsDisplayed()
+        compose.onNodeWithText("PART 2 OF 3 · 12 CHAPTERS · 1H 00M · 964.5 MB").assertIsDisplayed()
+        compose.onNodeWithText("SAVE M4B").assertIsDisplayed().assertHasClickAction()
+        compose.onAllNodesWithText("PLAY").apply { assertEquals(0, fetchSemanticsNodes().size) }
+    }
 
     @Test
     fun `settings opens on the account pane and names the server`() {

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsStateHolderTest.kt
@@ -4,11 +4,17 @@ import dk.perspektiva.ttsroad.desktop.FakeRepository
 import dk.perspektiva.ttsroad.desktop.ParsedFixtures
 import dk.perspektiva.ttsroad.desktop.ServerFixtures
 import dk.perspektiva.ttsroad.desktop.data.DeviceSession
+import dk.perspektiva.ttsroad.desktop.data.AudiobookExport
+import dk.perspektiva.ttsroad.desktop.data.AudiobookExportsResponse
 import dk.perspektiva.ttsroad.desktop.data.InMemorySessionStore
 import dk.perspektiva.ttsroad.desktop.data.MobileUser
 import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
 import dk.perspektiva.ttsroad.desktop.data.SessionState
 import dk.perspektiva.ttsroad.desktop.download.OfflineFictionUsage
+import dk.perspektiva.ttsroad.desktop.download.AudiobookDownloadResult
+import dk.perspektiva.ttsroad.desktop.download.AudiobookExportDownloader
+import dk.perspektiva.ttsroad.desktop.download.DownloadFailure
+import dk.perspektiva.ttsroad.desktop.download.UnavailableAudiobookExportDownloader
 import dk.perspektiva.ttsroad.desktop.download.OfflineStorageController
 import dk.perspektiva.ttsroad.desktop.download.OfflineStorageSummary
 import kotlin.test.assertEquals
@@ -22,6 +28,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import java.io.File
 import org.junit.jupiter.api.Test
 
 /**
@@ -61,6 +68,21 @@ class SettingsStateHolderTest {
         }
     }
 
+    private class FakeAudiobookDownloader(
+        var result: AudiobookDownloadResult = AudiobookDownloadResult.Success(File("saved.m4b"), 100),
+    ) : AudiobookExportDownloader {
+        val destinations = mutableListOf<File>()
+        override suspend fun download(
+            export: AudiobookExport,
+            destination: File,
+            onProgress: (Long, Long) -> Unit,
+        ): AudiobookDownloadResult {
+            destinations += destination
+            onProgress(50, 100)
+            return result
+        }
+    }
+
     private val signedIn = SessionState(
         serverUrl = "https://ttsroad.example.com/",
         token = "ttsr_token",
@@ -78,6 +100,8 @@ class SettingsStateHolderTest {
         repository: FakeRepository,
         store: InMemorySessionStore = InMemorySessionStore(signedIn),
         offline: OfflineStorageController = FakeOfflineStorage(),
+        audiobookDownloader: AudiobookExportDownloader = UnavailableAudiobookExportDownloader,
+        audiobookSavePicker: AudiobookSavePicker = AudiobookSavePicker { null },
     ): SettingsStateHolder {
         // Publishing capabilities is what a real sign-in does; the gate reads them from here.
         val holder = SettingsStateHolder(
@@ -85,8 +109,102 @@ class SettingsStateHolderTest {
             store,
             UnconfinedTestDispatcher(testScheduler),
             offline,
+            audiobookDownloader,
+            audiobookSavePicker,
         )
         return holder
+    }
+
+    @Test
+    fun `audiobook exports require both the capability and a current admin account`() = runTest {
+        val repository = FakeRepository(
+            capabilitiesResult = capable.copy(audiobookExport = true),
+            currentUserResult = Result.success(MobileUser(2, "listener", isAdmin = false)),
+            audiobookExportsResult = Result.success(AudiobookExportsResponse()),
+        )
+        repository.refreshCurrentCapabilities()
+        val holder = holder(repository)
+
+        holder.ensureAudiobooksLoaded()
+        runCurrent()
+
+        assertTrue(holder.state.value.audiobooks.adminOnly)
+        assertEquals(0, repository.audiobookExportsCalls)
+        holder.clear()
+    }
+
+    @Test
+    fun `an admin loads finished exports and saves through the injected native destination`() = runTest {
+        val export = AudiobookExport(
+            id = 17,
+            title = "Serial",
+            filename = "../../serial-part-1",
+            sizeBytes = 100,
+            downloadUrl = "/api/exports/17/download",
+            downloadable = true,
+        )
+        val repository = FakeRepository(
+            capabilitiesResult = capable.copy(audiobookExport = true),
+            currentUserResult = Result.success(MobileUser(1, "admin", isAdmin = true)),
+            audiobookExportsResult = Result.success(
+                AudiobookExportsResponse(ffmpegAvailable = true, exports = listOf(export)),
+            ),
+        )
+        repository.refreshCurrentCapabilities()
+        val downloader = FakeAudiobookDownloader()
+        var suggested = ""
+        val holder = holder(
+            repository,
+            audiobookDownloader = downloader,
+            audiobookSavePicker = AudiobookSavePicker { name ->
+                suggested = name
+                File("chosen/book")
+            },
+        )
+        holder.ensureAudiobooksLoaded()
+        runCurrent()
+
+        holder.downloadAudiobook(export)
+        runCurrent()
+
+        assertEquals("serial-part-1.m4b", suggested)
+        assertEquals("book.m4b", downloader.destinations.single().name)
+        assertTrue(holder.state.value.audiobooks.notice.orEmpty().contains("Saved"))
+        assertNull(holder.state.value.audiobooks.downloadingExportId)
+        holder.clear()
+    }
+
+    @Test
+    fun `an audiobook transfer failure stays in its pane with an actionable reason`() = runTest {
+        val export = AudiobookExport(
+            id = 17,
+            filename = "serial.m4b",
+            downloadUrl = "/api/exports/17/download",
+            downloadable = true,
+        )
+        val repository = FakeRepository(
+            capabilitiesResult = capable.copy(audiobookExport = true),
+            currentUserResult = Result.success(MobileUser(1, "admin", isAdmin = true)),
+            audiobookExportsResult = Result.success(AudiobookExportsResponse(exports = listOf(export))),
+        )
+        repository.refreshCurrentCapabilities()
+        val downloader = FakeAudiobookDownloader(
+            AudiobookDownloadResult.Failed(DownloadFailure.OutOfSpace("Free some disk space")),
+        )
+        val holder = holder(
+            repository,
+            audiobookDownloader = downloader,
+            audiobookSavePicker = AudiobookSavePicker { File("serial.m4b") },
+        )
+        holder.ensureAudiobooksLoaded()
+        runCurrent()
+
+        holder.downloadAudiobook(export)
+        runCurrent()
+
+        assertEquals("Free some disk space", holder.state.value.audiobooks.error)
+        assertNotNull(holder.state.value.audiobooks.loaded)
+        holder.clear()
     }
 
     private suspend fun FakeRepository.publish(capabilities: ServerCapabilities) {


### PR DESCRIPTION
Fixes #35

## Summary
- add the capability-gated, admin-only read-only audiobook export shelf to Settings
- save completed server M4Bs through a native destination picker with authenticated range resume, free-space/length/container checks, fsync, and atomic promotion
- keep exported files outside managed offline storage and retain partials when paused
- deliberately retain OS-profile-local playback preferences instead of synchronizing output-shaped account values; keep sleep timer arming explicit
- document both decisions in ADRs and the maintainer/user guides

The remaining delta-sync item from #35 is implemented separately in #59.

## Validation
- `xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail -Pttsroad.warningsAsErrors=true`