### PR TITLE
Close the release quality gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ All notable changes to TTSRoad Desktop are recorded here. The format follows
 
 ## [Unreleased]
 
+### Changed
+
+- Completed the release quality gate with a documented accessibility/performance/compatibility
+  matrix, maintainer architecture/API/release runbook, 200% text-scale and long-session/navigation
+  soak coverage, and automated WCAG AA contrast checks. Secondary/error/sepia text tokens now meet
+  the 4.5:1 normal-text threshold on their supported surfaces.
+- The README now states the platform support policy once and plainly: Linux is supported and proven
+  by a clean-container install/upgrade/uninstall run, while the Windows and macOS installers are
+  built and smoke-launched but have no clean-machine lifecycle coverage.
+
 ### Added
 
 - Timestamp-based metadata refresh for the library and chapter lists. Servers that advertise the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -362,3 +362,8 @@ under Xvfb, a configuration-only re-run for build-script deprecations, release-d
 Debian metadata/payload inspection, and an Ubuntu 24.04 clean-install/upgrade/uninstall lifecycle.
 Note it has **no base-branch filter** on purpose — roadmap phases land as stacked PRs whose base is
 the preceding phase branch, not `master`.
+
+`docs/QUALITY-GATE.md` maps the release accessibility, performance/soak and compatibility matrix to
+specific executable tests and recorded workflow runs. `docs/MAINTAINER-GUIDE.md` is the operational
+architecture/API/storage/fixtures/release guide. Update both when a change alters a support claim,
+capability surface, release gate or evidence path; an undocumented skip is not a passing gate.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Built with Compose for Desktop — real Skia-rendered UI, real OS installers, no
 ![Compose Multiplatform](https://img.shields.io/badge/Compose%20Multiplatform-1.11.1-4285F4?logo=jetpackcompose&logoColor=white)
 ![JDK](https://img.shields.io/badge/JDK-25-ED8B00?logo=openjdk&logoColor=white)
 ![Gradle](https://img.shields.io/badge/Gradle-9.7.0-02303A?logo=gradle&logoColor=white)
-![Platforms](https://img.shields.io/badge/platforms-Windows%20%7C%20macOS%20%7C%20Linux-informational)
+![Platforms](https://img.shields.io/badge/Linux-supported-success)
+![Platforms](https://img.shields.io/badge/Windows%20%7C%20macOS-best--effort-informational)
 ![Status](https://img.shields.io/badge/status-alpha-orange)
 
 </div>
@@ -25,6 +26,23 @@ Built with Compose for Desktop — real Skia-rendered UI, real OS installers, no
 - 📦 **Real installers** — ships as `.deb` (Linux), `.msi` (Windows) and `.dmg` (macOS) with a **bundled Java runtime**, so end users never install Java. Linux is the platform with a clean-machine install/upgrade/uninstall test; see [Releases](#-releases).
 - 🔗 **Shares the mobile API** — talks to the same `/api/mobile/*` endpoints as the Android app, and wears the same **AARIS** design language.
 - 🔊 **Real audio playback** — bearer-protected chapter MP3s are decoded in pure JVM and streamed to the system audio device.
+
+## 🖧 Platform support, stated once
+
+This is a **Linux-native** client. The other two platforms are *buildable*, not supported, and the
+presence of a `.msi`/`.dmg` target should not be read as more than that:
+
+| Platform | Status | What CI actually proves |
+| --- | --- | --- |
+| Linux (Mint 22.x / Ubuntu 24.04, amd64) | **Supported** | full test suite, `.deb` metadata and payload inspection, and a clean-container install → upgrade → uninstall lifecycle on every PR |
+| Windows x64 | Best-effort | the release workflow builds the `.msi` and starts the application image (`--smoke-test`); the Credential Manager path has its own round-trip test. No clean-machine installer run. |
+| macOS | Best-effort | the release workflow builds the `.dmg` and starts the application image. No clean-machine installer run. |
+
+Variable-rate playback, skip silence, seeking without re-decoding and MPRIS are GStreamer- and
+D-Bus-backed, so they are Linux features; elsewhere the app falls back to the Java Sound engine and
+hides the controls that backend cannot honour. A best-effort platform is still expected to sign in,
+browse, download and play — bug reports for it are welcome — but a release is not blocked on it. The
+full evidence table is in [`docs/QUALITY-GATE.md`](docs/QUALITY-GATE.md).
 
 ## 🧩 What works
 
@@ -218,6 +236,12 @@ Two flags CI adds, which you can use locally to reproduce a CI failure:
 
 > **Note:** Compose UI tests need a display (Skiko renders through AWT even off-screen). They run
 > against your desktop locally, and under `xvfb-run` in CI.
+
+New maintainers should read [`docs/MAINTAINER-GUIDE.md`](docs/MAINTAINER-GUIDE.md) for the
+architecture/data-flow diagram, API and capability rules, fixture conventions, storage boundaries,
+release runbook and dependency process. The executable accessibility/performance/compatibility
+matrix and latest recorded evidence live in
+[`docs/QUALITY-GATE.md`](docs/QUALITY-GATE.md).
 
 ## 🔢 Versioning
 

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -1,0 +1,144 @@
+# Maintainer guide
+
+This is the operational map for changing, testing and releasing TTSRoad Desktop. The ADRs explain
+why individual decisions exist; this guide explains how the pieces fit and which gates a maintainer
+must run.
+
+## Support boundary
+
+- **Supported release target:** Linux Mint 22.x on amd64. CI builds against Ubuntu 24.04, Mint
+  22's ABI base, and installs/upgrades/removes the Debian package in a clean Ubuntu 24.04 container.
+- **Build-and-smoke targets:** Windows x64 MSI and macOS DMG. Their native credential stores and
+  fallback playback paths are tested, and release CI builds and starts their application images,
+  but they do not have clean-machine installer lifecycle coverage. Do not describe them as fully
+  supported until that changes.
+- **Source runs:** any platform with a JDK 17+ capable of starting Gradle; Gradle provisions JDK 25.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    UI[Compose screens] --> State[State holders and navigation]
+    State --> Cache[Library/read-along caches]
+    State --> Repo[TtsRoadRepository]
+    Repo --> HTTP[Shared OkHttp client]
+    HTTP --> Server[Private TTSRoad server]
+    HTTP --> GitHub[Public GitHub release feed]
+    HTTP --> Source[Authenticated media source]
+    Source --> Player[Queue playback controller]
+    Player --> Gst[GStreamer engine]
+    Player --> Java[Java Sound fallback]
+    Player --> MPRIS[MPRIS / media keys]
+    Cache --> Disk[Identity-scoped cache/data roots]
+    State --> Local[Non-secret local preferences/history]
+    Repo --> Keyring[OS credential store]
+```
+
+`AppContainer` is the composition root. `App` owns long-lived state above destinations; screens
+render state and send intent back to holders/controllers. The repository is the only typed server
+API boundary. The shared HTTP client is also used for audio and update checks so the auth
+interceptor's origin rule covers every outbound path. Playback engines never own the queue, retry,
+progress or session-expiry policy; `QueuePlaybackController` does, which keeps it testable without
+audio hardware.
+
+## API and capability contract
+
+Two endpoints are public and explicitly opt out of bearer injection: `POST /api/mobile/login` and
+`GET /api/mobile/capabilities`. All other TTSRoad requests are authenticated, and a 401 ends the
+whole local session. Authorization is attached only when scheme, host and effective port match the
+signed-in origin.
+
+Baseline endpoints are login/logout, `/me`, library, fiction chapters, progress and playback mark.
+Optional surfaces must obey both gates: a literal boolean capability enables the UI, and an
+endpoint 404 becomes a concise unsupported state. Never infer a feature from `api_version`.
+
+| Capability | Consumer | Older-server behaviour |
+| --- | --- | --- |
+| `readalong` | reader + ETag cache | reader actions hidden |
+| `search` | global metadata/narration search | server-search action hidden |
+| `bookmarks` | manual marks and jump-back data | bookmark surface hidden/local history remains |
+| `batch_progress` | progress outbox batch sync | single-item progress endpoint |
+| `follows` | per-account shelf and browse-all | shared library, no follow controls |
+| `device_management` | Settings device sessions | unsupported pane |
+| `queue` | cross-library server queue | queue destination hidden |
+| `delta_sync` | cursor-driven library/chapter metadata refresh | ordinary full refresh of both resources |
+| `fiction_management` | admin add/edit/delete, gated *again* by `/me`'s `is_admin` | management controls hidden |
+| `audiobook_export` | read-only M4B export shelf and resumable save | Audiobooks pane hidden |
+| `audio_content_hash` | reserved/parsed contract flag | no UI is promised merely by parsing |
+
+Capability payloads are loose maps by design: unknown keys and non-boolean values cannot make the
+whole response fail. Limits are server policy, not suggestions; honor them when batching.
+
+## Storage and security boundaries
+
+| Data | Location class | Lifetime |
+| --- | --- | --- |
+| bearer token | OS credential store only | removed on sign-out/revocation |
+| server/account hints, window/listening/reader settings, history | platform config | retained across sign-out; no secrets |
+| requested chapter downloads | platform data, server/account identity namespace | user-managed, never automatically evicted |
+| streamed audio, library metadata, read-along text | platform cache, identity namespace | rebuildable and bounded |
+| logs | platform state | redacted, owner-only, 1 MiB + three backups |
+
+Raw titles, URLs and server filenames never become owned-storage path components. A signed-out
+username hint is not authority to open account indexes. `SecureFiles` provides owner-only atomic
+writes where the platform supports them. See ADR 0002 for credentials, ADR 0007 for storage and
+ADR 0010 for update integrity.
+
+## Contributor workflow and fixtures
+
+Run the exact local gate from the repository root:
+
+```bash
+xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail -Pttsroad.warningsAsErrors=true
+```
+
+Omit `xvfb-run -a` on a workstation with a display. `ServerFixtures.kt` contains complete server
+1.4.0 payloads and intentionally includes fields the client does not model. Repository tests use
+MockWebServer for method/path/body/auth behaviour. `FakePlaybackEngine` drives queue, retry and
+long-session cases without a sound card. Compose tests render real screens under a virtual display.
+`packaging/linux/mock-mobile-server.py` is deliberately stdlib-only so the clean package container
+can prove the installed login window reaches capability discovery.
+
+When adding an endpoint, add a complete representative fixture or MockWebServer response, assert
+the request shape and 401/404 distinction, add its literal capability parser, then cover the state
+holder and rendered unsupported/error paths. Never make a fixture smaller merely to match a model;
+unknown additive fields are part of the compatibility test.
+
+## Release runbook
+
+1. Merge only a green PR and complete the matrix in [QUALITY-GATE.md](QUALITY-GATE.md).
+2. Set `ttsroad.version` once in `gradle.properties`, reset the Debian revision when appropriate,
+   and add a matching non-empty `CHANGELOG.md` section.
+3. Dispatch the **Release** workflow manually on the intended commit. This is the dry run: it runs
+   Linux/Windows/macOS builds, tests, smoke launches, Linux package inspection and lifecycle, but
+   publishes nothing.
+4. Inspect every job and its installer/SBOM artifacts. A skipped platform or lifecycle job is not a
+   successful dry run.
+5. Push `v<ttsroad.version>` only after the dry run succeeds. The workflow rebuilds from that exact
+   commit, creates checksums and signed provenance, and opens a draft release.
+6. Verify the draft's notes and assets, then publish it manually. Never publish artifacts built
+   outside the workflow or reuse artifacts from another commit.
+
+The last recorded dry run and release results are linked from the quality gate. The release remains
+a draft until a human checks it; the application update path verifies `SHA256SUMS` and hands the
+installer to the OS without invoking a package manager.
+
+## Dependency and incident maintenance
+
+Dependabot groups Gradle and GitHub Actions updates weekly. Kotlin and its Compose compiler plugin
+move together. For each update, run the full gate and packaged smoke path; for runtime/build-tool
+changes, also dispatch the release dry run. Dependency Review rejects new high-severity advisories
+when GitHub's dependency graph is enabled. Response targets and private reporting are in
+[SECURITY.md](SECURITY.md).
+
+Do not broaden an ignored advisory, lintian tag or test skip to make CI green without documenting
+why the affected code cannot execute. A security fix takes priority over feature work according to
+the SLA.
+
+## Troubleshooting ownership
+
+Start with `TTSRoad --diagnostics`, then the bounded platform-state log. Playback problems belong at
+the media-source/engine boundary; session loss at the repository/auth boundary; stale UI at the
+holder/cache boundary; package-only failures under `packaging/linux/`. Diagnostics and logs must
+remain useful after redaction and must never contain a bearer token, a private URL path or a local
+home path.

--- a/docs/QUALITY-GATE.md
+++ b/docs/QUALITY-GATE.md
@@ -1,0 +1,78 @@
+# Release quality gate
+
+This matrix is the repeatable evidence for issue #10's final release gate. “Pass” means an automated
+assertion exists and the full command below passed on 2026-08-14; it does not mean a visual claim was
+made from source inspection alone.
+
+## Recorded runs
+
+| Gate | Result | Evidence |
+| --- | --- | --- |
+| clean compile, unit and Compose UI suite with warnings fatal | Pass | `xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail -Pttsroad.warningsAsErrors=true` on Rocky Linux 9.8, JDK 25 toolchain |
+| packaged application image | Pass | `createDistributable`, release-distributable launch and packaged `--smoke-test` on the same checkout |
+| Ubuntu 24.04/Mint 22 ABI package build and clean install/upgrade/uninstall | Pass | [master CI run 31777210303](https://github.com/jonarihen/TTSRoad-Desktop/actions/runs/31777210303); every PR reruns the same jobs |
+| three-platform release dry run | Pass | [release dry run 31407730692](https://github.com/jonarihen/TTSRoad-Desktop/actions/runs/31407730692) |
+| tagged 1.0.2 release gate | Pass | [release run 31426739896](https://github.com/jonarihen/TTSRoad-Desktop/actions/runs/31426739896) |
+
+The first two rows must be refreshed on the candidate commit. The CI/Release links establish that
+the package and publishing machinery have completed end to end; the candidate's own PR and dry-run
+checks remain authoritative for code changed afterwards.
+
+## Accessibility
+
+| Requirement | Status and executable evidence |
+| --- | --- |
+| meaningful semantics/content descriptions | Pass — `ChapterBrowsingUiTest`, `ServerQueueScreenUiTest`, `SettingsScreenUiTest`, `ReaderScreenUiTest` query actions and state through the semantics tree |
+| logical keyboard focus/order and keyboard-only primary flows | Pass — `NavigationUiTest`, `SettingsScreenUiTest`, `ShortcutsTest`; dialogs focus Cancel and Escape closes an overlay before navigating |
+| visible focus | Pass — shared cards, header/nav rows, chapter/queue rows and transport controls consume focused interaction state and draw an accent border; focusability is asserted in Compose tests |
+| 100–200% scaling | Pass — ordinary UI tests cover 100%; `NavigationUiTest` drives library → Settings at `fontScale=2.0` and reaches content through scrolling |
+| reader zoom | Pass — `ReaderScreenUiTest` changes the keyboard-reachable reading settings; `ReaderPreferencesTest` clamps 14–30 pt and 1.3–2.4 line height |
+| sufficient contrast | Pass — `ThemeAccessibilityTest` calculates WCAG relative luminance and requires 4.5:1 for every normal app text token on every app surface and for every reader palette |
+| no color-only state | Pass — played/playing/converting/failed/queued/excluded, focus, progress, errors and selection all have text or semantics in the screen tests; color is a redundant cue |
+
+Compose semantics and the bundled `jdk.accessibility` module are automated. A native Orca/NVDA/
+VoiceOver announcement pass is a release-candidate smoke check because those assistive technology
+processes are outside the deterministic JVM test harness; a failure is release-blocking and should
+be recorded here.
+
+## Performance and soak
+
+| Scenario | Status and executable evidence |
+| --- | --- |
+| 1,000 fictions | Pass — `NavigationUiTest` asserts lazy composition stays under 100 cards before and after scrolling to item 900 |
+| 1,000-chapter fiction | Pass — `ChapterBrowsingUiTest` asserts under 100 rows before and after a deep scroll |
+| 10,000-word reader | Pass — `ReaderScreenUiTest` builds 500 × 20-word paragraphs and asserts only visible paragraph nodes compose |
+| four-hour playback | Pass — `QueuePlaybackControllerTest` advances the fake engine to exactly four hours, asserts the Long position is preserved and the 14,400-second progress save is emitted |
+| repeated navigation | Pass — `AppNavigationTest` runs 10,000 library/fiction/player loops and returns to the one-entry root stack; Compose round trips assert retained filters/scroll |
+| bounded state | Pass — `StreamingCacheTest`, `ReadAlongDiskCacheTest`, `AppLoggingTest` and `PlaybackHistoryTest` pin byte/file/backup/entry bounds |
+
+The fake-engine soak deliberately advances media time rather than sleeping for four wall-clock
+hours. GStreamer linkage, duration, seek, rate and failure paths run separately in
+`GstPlaybackEngineIntegrationTest` on CI with real plugins and a fake audio sink.
+
+## Compatibility and recovery
+
+| Scenario | Status and executable evidence |
+| --- | --- |
+| fresh install, in-place upgrade, uninstall on supported ABI | Pass — `verify-install-lifecycle.sh` installs two Debian revisions in Ubuntu 24.04, launches both against a mock server, preserves settings/downloads, removes app files and leaves user data |
+| 2FA login | Pass — `LoginTest`, `StateHolderTest` cover missing, wrong and accepted code states and exact wire bodies |
+| older server without capabilities | Pass — `CapabilityDiscoveryTest` maps 404 to baseline; screen/repository tests hide or explain each additive endpoint without breaking library/playback |
+| server 1.4.0 | Pass — complete `ServerFixtures` payloads cover login, capabilities, library, chapters and sessions while unknown additive fields are ignored |
+| session expiry/revocation | Pass — `RepositoryTest`, `DevicesRepositoryTest`, `AudioSessionExpiryTest`, `ScreensUiTest` end the session, stop audio, clear protected state and explain the server reason |
+| offline start | Pass — `LibraryCacheTest` restores library/chapters from identity-scoped disk while refresh fails; `DownloadCoordinatorTest` reopens the advertised namespace |
+| corrupt/truncated download | Pass — `ChapterDownloaderTest` and `OfflineFirstMediaSourceTest` reject/de-index bad data and never advertise it as Offline |
+| transient network/audio failure | Pass — repository, download manager and queue controller tests retain content, use bounded retries and expose Retry after exhaustion |
+| keyring unavailable | Pass — `CredentialStoreTest`, `SessionStoreTest`, `DiagnosticsTest` prove session-only fallback, visible diagnostics and no file-secret fallback |
+
+## Documentation gate
+
+- Architecture, ownership, API/capability rules, fixtures, contributor flow, release runbook and
+  dependency maintenance: [MAINTAINER-GUIDE.md](MAINTAINER-GUIDE.md).
+- Storage/security model and incident SLA: [SECURITY.md](SECURITY.md), ADR 0002 and ADR 0007.
+- Playback design: ADR 0002-playback-engine and ADR 0006.
+- Packaging/release/update design: ADR 0009 and ADR 0010.
+- Bootstrap, supported/buildable platform distinction and user troubleshooting: repository README.
+
+Before closing a candidate, update the recorded command results, inspect failed/skipped checks and
+record any exception with an owner. “Not run” is not a pass; a release-blocking failure keeps the
+candidate and its issue open.

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderScreen.kt
@@ -127,7 +127,7 @@ fun readerPalette(theme: ReaderTheme): ReaderPalette = when (theme) {
         AarisColor.Accent, AarisColor.BgHover, Color(0x665B7CFF),
     )
     ReaderTheme.Sepia -> ReaderPalette(
-        Color(0xFFF2E7CF), Color(0xFF382F26), Color(0xFF776752), Color(0xFFCDBB99),
+        Color(0xFFF2E7CF), Color(0xFF382F26), Color(0xFF756550), Color(0xFFCDBB99),
         Color(0xFF9A431C), Color(0x33A86D32), Color(0x55638BA8),
     )
     ReaderTheme.Light -> ReaderPalette(

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/Theme.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/Theme.kt
@@ -40,14 +40,18 @@ object AarisColor {
     val BgInput = Color(0xFF0B0D11)
     val Ink = Color(0xFFE9ECEF)
     val Muted = Color(0xFF8B939E)
-    val Dim = Color(0xFF4D545E)
+    // Secondary text still has to be text. This is the lowest AARIS foreground that maintains
+    // WCAG AA 4.5:1 against Bg, BgRaise, BgHover and BgInput; the old #4D545E was only 2.39:1 on
+    // cards and made durations/status hints effectively decorative for low-vision listeners.
+    val Dim = Color(0xFF808995)
     val Line = Color(0xFF232830)
     val LineSoft = Color(0xFF1A1E25)
     val Accent = Color(0xFFFF5A1F)
     val AccentHover = Color(0xFFFF7A44)
     val Ok = Color(0xFF3FD97F)
     val Warning = Color(0xFFFFB224)
-    val Danger = Color(0xFFE5484D)
+    // Bright enough to keep error text above 4.5:1 even on the hover surface.
+    val Danger = Color(0xFFEC555A)
 }
 
 val MonoFamily: FontFamily = FontFamily.Monospace

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/nav/AppNavigationTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/nav/AppNavigationTest.kt
@@ -106,6 +106,19 @@ class AppNavigationTest {
     }
 
     @Test
+    fun `ten thousand ordinary navigation loops keep the stack bounded`() {
+        var stack = rootBackStack
+        repeat(10_000) { index ->
+            stack = stack
+                .navigateTo(fiction(index % 17 + 1))
+                .navigateTo(Destination.Player)
+                .navigateTo(Destination.Library)
+        }
+
+        assertEquals(rootBackStack, stack)
+    }
+
+    @Test
     fun `popping walks back one entry at a time`() {
         val stack = rootBackStack.navigateTo(fiction(7)).navigateTo(Destination.Player)
 

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackControllerTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackControllerTest.kt
@@ -166,6 +166,28 @@ class QueuePlaybackControllerTest {
     }
 
     @Test
+    fun `a four-hour playback position stays precise and is persisted`() = runBlocking {
+        val engine = FakePlaybackEngine()
+        val repository = FakeRepository()
+        val controller = controllerFor(engine, repository = repository)
+        val fourHoursMs = 4L * 60 * 60 * 1_000
+
+        controller.play(
+            chapter(101, "A very long chapter", durationSeconds = 5.0 * 60 * 60),
+            FictionSummary(id = 7, title = "A Test Serial"),
+        )
+        controller.await("playback to start") { it.hasMedia && it.isPlaying }
+        engine.setPosition(fourHoursMs)
+        controller.await("the four-hour engine position") { it.positionMs == fourHoursMs }
+        awaitCondition("the four-hour progress save") {
+            repository.savedProgress.any { it == Triple(101, 4.0 * 60 * 60, false) }
+        }
+
+        assertEquals(fourHoursMs, controller.state.value.positionMs)
+        controller.release()
+    }
+
+    @Test
     fun `opening a bookmark starts at the mark rather than at the saved position`() = runBlocking {
         val engine = FakePlaybackEngine(completeOnPlay = true)
         val controller = controllerFor(engine)

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/NavigationUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/NavigationUiTest.kt
@@ -1,6 +1,8 @@
 package dk.perspektiva.ttsroad.desktop.ui
 
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
@@ -24,6 +26,7 @@ import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.withKeyDown
+import androidx.compose.ui.unit.Density
 import dk.perspektiva.ttsroad.desktop.App
 import dk.perspektiva.ttsroad.desktop.FakePlaybackController
 import dk.perspektiva.ttsroad.desktop.FakeRepository
@@ -242,6 +245,26 @@ class NavigationUiTest {
         val composed = compose.onAllNodesWithTag(FictionCardTestTag).fetchSemanticsNodes().size
         assertTrue(composed in 1..100, "the lazy grid composed $composed cards after scrolling")
         compose.onNodeWithText("Serial 900").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the primary library and settings flows remain usable at two hundred percent text scaling`() {
+        val repository = FakeRepository(libraryResult = Result.success(bigLibrary(4)))
+        compose.setContent {
+            val density = LocalDensity.current
+            CompositionLocalProvider(LocalDensity provides Density(density.density, fontScale = 2f)) {
+                TtsRoadTheme { App(container(repository, FakePlaybackController())) }
+            }
+        }
+        compose.waitForIdle()
+
+        compose.onNodeWithText("SEARCH TITLE, AUTHOR OR TAG").assertIsDisplayed()
+        compose.onNodeWithText("Serial 01").assertIsDisplayed()
+        compose.onNodeWithText("SETTINGS").performClick()
+        compose.waitForIdle()
+
+        compose.onAllNodesWithText("ACCOUNT", useUnmergedTree = true)[0].assertIsDisplayed()
+        compose.onNodeWithText("SIGN OUT").performScrollTo().assertIsDisplayed()
     }
 
     // --- Settings as a destination --------------------------------------------------------------

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ThemeAccessibilityTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ThemeAccessibilityTest.kt
@@ -1,0 +1,81 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.ui.graphics.Color
+import dk.perspektiva.ttsroad.desktop.data.ReaderTheme
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/** Pins the measurable half of the visual accessibility audit instead of relying on screenshots. */
+class ThemeAccessibilityTest {
+    @Test
+    fun `every normal AARIS text token meets WCAG AA on every application surface`() {
+        val foregrounds = mapOf(
+            "ink" to AarisColor.Ink,
+            "muted" to AarisColor.Muted,
+            "dim" to AarisColor.Dim,
+            "accent" to AarisColor.Accent,
+            "success" to AarisColor.Ok,
+            "warning" to AarisColor.Warning,
+            "danger" to AarisColor.Danger,
+        )
+        val surfaces = mapOf(
+            "background" to AarisColor.Bg,
+            "card" to AarisColor.BgRaise,
+            "hover" to AarisColor.BgHover,
+            "input" to AarisColor.BgInput,
+        )
+
+        foregrounds.forEach { (foregroundName, foreground) ->
+            surfaces.forEach { (surfaceName, surface) ->
+                assertContrast(foregroundName, foreground, surfaceName, surface)
+            }
+        }
+        assertContrast("filled-button ink", AarisColor.Bg, "accent", AarisColor.Accent)
+        assertContrast("hovered filled-button ink", AarisColor.Bg, "accent hover", AarisColor.AccentHover)
+    }
+
+    @Test
+    fun `reader ink muted copy and word accent meet WCAG AA in every theme`() {
+        ReaderTheme.entries.forEach { theme ->
+            val palette = readerPalette(theme)
+            assertContrast("$theme reader ink", palette.ink, "$theme background", palette.background)
+            assertContrast("$theme reader muted", palette.muted, "$theme background", palette.background)
+            assertContrast("$theme reader accent", palette.accent, "$theme background", palette.background)
+        }
+    }
+
+    private fun assertContrast(
+        foregroundName: String,
+        foreground: Color,
+        backgroundName: String,
+        background: Color,
+    ) {
+        val ratio = contrastRatio(foreground, background)
+        assertTrue(
+            ratio >= MinimumNormalTextContrast,
+            "$foregroundName on $backgroundName is ${"%.2f".format(ratio)}:1, below $MinimumNormalTextContrast:1",
+        )
+    }
+
+    private fun contrastRatio(first: Color, second: Color): Double {
+        val firstLuminance = first.relativeLuminance()
+        val secondLuminance = second.relativeLuminance()
+        return (max(firstLuminance, secondLuminance) + 0.05) /
+            (min(firstLuminance, secondLuminance) + 0.05)
+    }
+
+    private fun Color.relativeLuminance(): Double =
+        0.2126 * red.toDouble().linearChannel() +
+            0.7152 * green.toDouble().linearChannel() +
+            0.0722 * blue.toDouble().linearChannel()
+
+    private fun Double.linearChannel(): Double =
+        if (this <= 0.04045) this / 12.92 else ((this + 0.055) / 1.055).pow(2.4)
+
+    private companion object {
+        const val MinimumNormalTextContrast = 4.5
+    }
+}


### PR DESCRIPTION
Fixes #10. Also delivers the README platform-support item from #41.

Release automation and observability landed in #31; the final gate — accessibility, performance/soak, the compatibility matrix and maintainer documentation — was what remained open on #10.

## What this adds

Every row of the gate is backed by an executable assertion rather than a claim read out of the source:

- **`ThemeAccessibilityTest`** computes WCAG relative luminance and requires 4.5:1 for every normal AARIS text token on every application surface, and for every reader palette. It found two real failures: `Dim` was **2.39:1** on cards — durations and status hints were effectively decorative for low-vision listeners — and `Danger` fell below the threshold on the hover surface. Both are raised to the lowest value that passes, as is the sepia reader's muted ink.
- **`NavigationUiTest`** drives library → Settings at `fontScale = 2.0`, covering the 200% scaling requirement.
- **`QueuePlaybackControllerTest`** advances the fake engine to exactly four hours and asserts both the preserved `Long` position and the emitted 14,400-second progress save.
- **`AppNavigationTest`** runs 10,000 navigation loops and returns to the one-entry root stack.

## Documentation

- **`docs/QUALITY-GATE.md`** maps each accessibility, performance/soak and compatibility requirement to the specific test or recorded workflow run that proves it. It is explicit about the one part that cannot be automated: a native Orca/NVDA/VoiceOver announcement pass is named as a blocking release-candidate manual step rather than quietly counted as passing.
- **`docs/MAINTAINER-GUIDE.md`** is the operational guide — composition root and data flow, the API/capability contract with per-flag older-server behaviour, storage/security boundaries, fixture conventions, the release runbook and the dependency/incident process.
- **README** now states the platform support policy once: Linux is supported and has the clean-container install/upgrade/uninstall run; Windows and macOS are built and smoke-launched and are best-effort. The `.msi`/`.dmg` targets implied more than CI proves, which is exactly the concern raised in #41.

## Validation

```
xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail -Pttsroad.warningsAsErrors=true
```

`BUILD SUCCESSFUL` locally on this branch; CI runs the same gate plus packaging and the Debian lifecycle.

## Not in scope

Self-hosted crash reporting stays out, for the reason recorded on #10: no endpoint exists, so an opt-in toggle would configure nothing.