### PR TITLE
Add distraction-free reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ All notable changes to TTSRoad Desktop are recorded here. The format follows
 
 ### Added
 
+- Distraction-free reading. `F11` in the reader — or the new toolbar button — hides the header, the
+  now-playing bar and the reader's own toolbar, and narrows the text to a comfortable measure. The
+  frame returns when the pointer reaches either edge, along with a transport that can pause and skip
+  so hiding the now-playing bar never leaves the audio unreachable. `Escape` restores the frame
+  rather than leaving the chapter.
 - Timestamp-based metadata refresh for the library and chapter lists. Servers that advertise the
   delta-sync contract now receive one small change-index request followed only by the sparse data
   that changed; older servers continue to receive ordinary full refreshes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,13 @@ apply to audio.
   falls back because the session no longer authorizes account content. `App` clears memory and
   `DownloadCoordinator` makes the retained disk namespace unreachable on sign-out.
 - `ReaderScreen` renders one lazy item per paragraph, not one composable per word. Wheel, drag and
-  scrollbar input permanently surrender follow until Back to current. Highlighting a chapter other
+  scrollbar input permanently surrender follow until Back to current.
+- Distraction-free reading (`F11`) is owned by `App`, because the header and now-playing bar are half
+  of what it hides. It is a posture, not a preference: never persisted, dropped on leaving the reader,
+  and never a fifth `/api/me/preferences` key. `readingModeChromeVisible` is the pure reveal rule —
+  an unmoved or departed pointer is the same `null` and keeps the chrome hidden, and the bottom-edge
+  rule requires a measured viewport. Hiding the now-playing bar obliges the mode to draw pause and
+  the two skips; chapter stepping is deliberately left to the shortcuts. Highlighting a chapter other
   than the one playing is forbidden; queue advance changes the document only after the reader has
   actually followed its own chapter.
 - Reader appearance is local-first in `reader.json` and synchronized only through the four known

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Built with Compose for Desktop — real Skia-rendered UI, real OS installers, no
 | Timestamped delta refresh for cached library and chapter metadata | ✅ |
 | Admin audiobook exports — resumable M4B save to a user-selected file | ✅ |
 | Audio-synchronized read-along — offline text, word seek, find, themes and zoom | ✅ |
+| Distraction-free reading — F11 hides every frame, hover brings the transport back | ✅ |
 | Streaming playback — audio starts before the chapter has downloaded | ✅ Linux |
 | Seeking without decoding from the start of the chapter | ✅ Linux |
 | Variable-rate playback ("speed"), pitch-preserving 0.5×–3.0× | ✅ Linux |
@@ -466,6 +467,11 @@ is not playing never highlights it against unrelated audio.
 - Font size (14–30), line height (1.3–2.4), dark/sepia/light theme, and sentence/word/off highlight
   are saved locally first and synchronized through `GET/PATCH /api/me/preferences` when supported.
   An older or offline server leaves the last-known local values usable.
+- **Distraction-free reading** (`F11`, or the toolbar button) hides the header, the now-playing bar
+  and the reader's own toolbar, and narrows the text from 920 dp to a 760 dp measure. Move the
+  pointer to either edge and the frame comes back, with a transport that can pause and skip — the
+  mode never leaves the audio without a visible way to stop it. `Escape` restores the frame rather
+  than leaving the chapter, and the mode is dropped on leaving the reader rather than remembered.
 
 ## 🎚️ Listening preferences, the sleep timer and the desktop
 
@@ -533,6 +539,8 @@ a note in the log rather than a failure.
 | `Ctrl+,` | Settings |
 | `F5` / `Ctrl+R` | Refresh the current screen |
 | `Escape` | Close a dialog, or go back |
+| `Ctrl+B` / `Ctrl+Shift+B` | Bookmark this spot / your bookmarks |
+| `F11` | Distraction-free reading, in the reader |
 | `F1` / `Ctrl+/` | The in-app shortcut list |
 
 **Shortcuts that would type do not fire while you are typing.** That is structural rather than a

--- a/docs/adr/0008-audio-synchronized-read-along.md
+++ b/docs/adr/0008-audio-synchronized-read-along.md
@@ -69,9 +69,43 @@ GET merges supported values over the local fallback. PATCH contains exactly thos
 cannot overwrite unrelated preferences in the account JSON blob. A 404 or offline server leaves the
 last-known local values active.
 
+### Distraction-free reading is a posture, not a preference
+
+`F11` in the reader hides both the app chrome — header and now-playing bar, which `App` owns — and
+the reader's own toolbar, and narrows the measure from 920 dp to 760 dp. On a maximised window the
+wider measure is a layout constraint rather than a typographic one, and hiding the frame around a
+line nobody can track is not worth doing.
+
+Three decisions worth recording:
+
+- **It is not persisted.** The mode lives in `App` and is dropped on leaving the reader. A stored
+  flag would reopen the client a week later with no header, which reads as broken rather than as
+  focused, and there is nothing to be distraction-free *from* on a settings pane.
+- **The frame comes back when you reach for it.** `readingModeChromeVisible` is pure, over the
+  pointer's y, the measured viewport and a `pinned` flag. The interesting case is the pointer that
+  has never moved: a reader opened straight into the mode reports no pointer at all, and both that
+  and a pointer that has *left* the window are the same `null` — both want the chrome hidden. The
+  measured height is a precondition of the bottom-edge rule rather than a number to subtract, since
+  before the first layout pass it is zero and every coordinate would satisfy `y >= 0 - reveal`.
+  It is watched on the **initial** pointer pass, so a scrolling lazy list underneath cannot consume
+  the movement that should have brought the toolbar back.
+- **The mode owes the listener a transport.** Hiding the now-playing bar without offering pause and
+  the two skips would take away the only visible way to stop the audio. Next/previous chapter are
+  deliberately *not* there: moving off the page being read is the one thing this mode should never
+  do by accident, and the chapter shortcuts still exist for someone who means it.
+
+`Escape` restores the frame before it navigates, so the key that undoes the last mode change does
+not also lose the reader's place. `F11` is classified `firesWhileTyping`, so it still works from
+inside the find bar.
+
 ## Rejected alternatives
 
 - Advancing highlights from a frame/wall clock: drifts after speed, pause, seek, and skip-silence.
+- A stored "reading mode" preference, or a fifth `/api/me/preferences` key for it: the four reader
+  keys are a cross-repo contract, and a client-only posture does not belong in an account blob.
+- Auto-hiding the chrome on a timer: a reader who stops moving the mouse to *read* is precisely the
+  reader who has not asked for anything, and a frame that vanishes on its own mid-sentence is a
+  worse surprise than one that stays.
 - One composable per cue/word: makes long chapters retain thousands of live nodes.
 - Hiding chapters without `has_timings`: discards useful narration text from older conversions.
 - Serving cached text after 401: treats retained login hints as authority and exposes protected

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -235,11 +235,28 @@ fun App(container: AppContainer = remember { AppContainer() }) {
     // Returns whether the key did anything, so an Escape that means nothing is not swallowed here.
     var showShortcuts by remember { mutableStateOf(false) }
 
+    /**
+     * Distraction-free reading, owned here because half of what it hides is this file's chrome.
+     *
+     * Not a stored preference: it is a posture the reader takes for one sitting, and a client that
+     * silently reopened with no header a week later would look broken rather than focused. Leaving
+     * the reader drops it for the same reason — there is nothing to be distraction-free *from* on a
+     * settings pane.
+     */
+    var readingMode by remember { mutableStateOf(false) }
+    LaunchedEffect(nav.current) { if (nav.current !is Destination.Reader) readingMode = false }
+
     fun dismissOrGoBack(): Boolean {
         // The shortcuts dialog is owned here rather than by a screen, so it is the first thing
         // Escape closes — ahead of a settings confirmation that may also be open behind it.
         if (showShortcuts) {
             showShortcuts = false
+            return true
+        }
+        // Escape restores the frame before it leaves the chapter: the first press of the key that
+        // means "undo the last mode change" should not also lose the reader's place.
+        if (readingMode) {
+            readingMode = false
             return true
         }
         if (fictionManagementState.hasOpenOverlay) {
@@ -297,6 +314,12 @@ fun App(container: AppContainer = remember { AppContainer() }) {
 
             AppShortcut.OpenBookmarks -> capabilities.bookmarks.also {
                 if (it) nav.open(Destination.Bookmarks)
+            }
+
+            // Only the reader has a frame worth hiding, so anywhere else the key reports itself
+            // unhandled rather than arming a mode with nothing to show.
+            AppShortcut.ToggleReadingMode -> (nav.current is Destination.Reader).also {
+                if (it) readingMode = !readingMode
             }
 
             AppShortcut.ShowShortcuts -> {
@@ -389,21 +412,26 @@ fun App(container: AppContainer = remember { AppContainer() }) {
             BoxWithConstraints(Modifier.fillMaxSize()) {
                 val sizeClass = windowSizeClassFor(maxWidth)
                 Column(Modifier.fillMaxSize()) {
-                    HeaderBar(
-                        serverName = session.serverName,
-                        current = nav.current,
-                        canGoBack = nav.canGoBack,
-                        canRefresh = nav.current.isRefreshable,
-                        // Gated the way the speed and skip-silence controls are: no entry at all
-                        // where the server cannot answer, rather than one that leads to a 404.
-                        showBookmarks = capabilities.bookmarks,
-                        compact = sizeClass == WindowSizeClass.Compact,
-                        queueAvailable = capabilities.queue,
-                        onBack = { nav.back() },
-                        onRefresh = ::refreshCurrentScreen,
-                        onSelect = { nav.open(it) },
-                    )
-                    HorizontalDivider(thickness = 1.dp, color = AarisColor.Line)
+                    // Distraction-free reading takes the whole window: the header and the
+                    // now-playing bar are exactly the two things framing the page, so hiding the
+                    // reader's own toolbar while leaving these would not be the mode at all.
+                    if (!readingMode) {
+                        HeaderBar(
+                            serverName = session.serverName,
+                            current = nav.current,
+                            canGoBack = nav.canGoBack,
+                            canRefresh = nav.current.isRefreshable,
+                            // Gated the way the speed and skip-silence controls are: no entry at all
+                            // where the server cannot answer, rather than one that leads to a 404.
+                            showBookmarks = capabilities.bookmarks,
+                            compact = sizeClass == WindowSizeClass.Compact,
+                            queueAvailable = capabilities.queue,
+                            onBack = { nav.back() },
+                            onRefresh = ::refreshCurrentScreen,
+                            onSelect = { nav.open(it) },
+                        )
+                        HorizontalDivider(thickness = 1.dp, color = AarisColor.Line)
+                    }
                     Box(Modifier.weight(1f).fillMaxWidth()) {
                         val destination = nav.current
                         // The state provider is what makes Back restore a screen rather than
@@ -556,6 +584,8 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                     onAddBookmark = { positionMs, label ->
                                         bookmarks.add(destination.chapterId, positionMs, label)
                                     },
+                                    readingMode = readingMode,
+                                    onToggleReadingMode = { readingMode = !readingMode },
                                     onBack = { nav.back() },
                                     onChapterAdvanced = { chapterId, title ->
                                         nav.replaceTop(Destination.Reader(chapterId, title))
@@ -564,7 +594,7 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                             }
                         }
                     }
-                    if (playerState.hasSession && nav.current != Destination.Player) {
+                    if (playerState.hasSession && nav.current != Destination.Player && !readingMode) {
                         NowPlayingBar(playback, compact = sizeClass == WindowSizeClass.Compact) {
                             nav.open(Destination.Player)
                         }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/nav/Shortcuts.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/nav/Shortcuts.kt
@@ -54,6 +54,15 @@ enum class AppShortcut {
     /** Ctrl+Shift+B — the list of them. */
     OpenBookmarks,
 
+    /**
+     * F11 — distraction-free reading.
+     *
+     * Only the reader acts on it; everywhere else it is a key that does nothing, which is a better
+     * answer than a mode that appears on a screen with no text in it. F11 is the platform habit for
+     * "get the frame out of the way", and no text field claims it.
+     */
+    ToggleReadingMode,
+
     /** F1 or Ctrl+slash. */
     ShowShortcuts,
     ;
@@ -73,7 +82,7 @@ enum class AppShortcut {
     val firesWhileTyping: Boolean
         get() = when (this) {
             Back, Refresh, Dismiss, OpenLibrary, OpenSettings, ShowShortcuts,
-            AddBookmark, OpenBookmarks,
+            AddBookmark, OpenBookmarks, ToggleReadingMode,
             -> true
             PlayPause, SeekBackward, SeekForward, PreviousChapter, NextChapter -> false
         }
@@ -114,6 +123,7 @@ private fun match(key: Key, alt: Boolean, ctrl: Boolean, meta: Boolean, shift: B
         key == Key.Escape -> AppShortcut.Dismiss
         key == Key.F5 -> AppShortcut.Refresh
         key == Key.F1 -> AppShortcut.ShowShortcuts
+        key == Key.F11 -> AppShortcut.ToggleReadingMode
         key == Key.R && accel -> AppShortcut.Refresh
         key == Key.L && accel -> AppShortcut.OpenLibrary
         key == Key.Comma && accel -> AppShortcut.OpenSettings
@@ -191,6 +201,7 @@ val ShortcutHelpTable: List<ShortcutHelp> = listOf(
     ShortcutHelp("Ctrl+L", "Library"),
     ShortcutHelp("Ctrl+B", "Bookmark this spot"),
     ShortcutHelp("Ctrl+Shift+B", "Your bookmarks"),
+    ShortcutHelp("F11", "Distraction-free reading, in the reader"),
     ShortcutHelp("Ctrl+,", "Settings"),
     ShortcutHelp("F5 / Ctrl+R", "Refresh the current screen"),
     ShortcutHelp("Escape", "Close a dialog, or go back"),

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreen.kt
@@ -390,13 +390,13 @@ private fun formatSpeed(speed: Float): String {
  * seconds is a worse answer than an unnumbered one — the content description carries the number
  * either way, so nothing is lost for a screen reader.
  */
-private fun rewindIconFor(seconds: Int): ImageVector = when (seconds) {
+internal fun rewindIconFor(seconds: Int): ImageVector = when (seconds) {
     10 -> Icons.Default.Replay10
     30 -> Icons.Default.Replay30
     else -> Icons.Default.FastRewind
 }
 
-private fun forwardIconFor(seconds: Int): ImageVector = when (seconds) {
+internal fun forwardIconFor(seconds: Int): ImageVector = when (seconds) {
     10 -> Icons.Default.Forward10
     30 -> Icons.Default.Forward30
     else -> Icons.Default.FastForward

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderScreen.kt
@@ -33,6 +33,10 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.BookmarkAdd
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Fullscreen
+import androidx.compose.material.icons.filled.FullscreenExit
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
@@ -69,11 +73,13 @@ import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
@@ -110,6 +116,52 @@ const val ReaderFindFieldTestTag: String = "readerFindField"
 const val ReaderSettingsButtonTestTag: String = "readerSettingsButton"
 const val ReaderParagraphTestTag: String = "readerParagraph"
 const val ReaderBookmarkButtonTestTag: String = "readerBookmarkButton"
+const val ReaderToolbarTestTag: String = "readerToolbar"
+const val ReaderTransportTestTag: String = "readerTransport"
+const val ReaderModeButtonTestTag: String = "readerModeButton"
+
+/**
+ * The measure the text is set to.
+ *
+ * Ordinary reading keeps the existing 920 dp, which is what the chrome around it is proportioned
+ * for. Reading mode narrows to a typographic measure instead of a layout one: on a maximised 27"
+ * window 920 dp of 20 pt text is well past the line length anyone tracks comfortably, and the whole
+ * point of hiding the frame is that what remains should be *worth* the whole window.
+ */
+val ReaderMeasure = 920.dp
+val ReadingModeMeasure = 760.dp
+
+/** How close to an edge the pointer comes before hidden reading chrome returns, in pixels. */
+const val ReadingModeRevealPx: Float = 96f
+
+/**
+ * Whether the reader's own chrome — toolbar and transport — is on screen.
+ *
+ * Pure, because "the frame comes back when you reach for it" is a rule with four inputs and one
+ * genuinely surprising case: a pointer that has never moved. A window opened straight into reading
+ * mode reports no pointer at all, and treating that as "at the top edge" would show the chrome the
+ * mode exists to hide, while treating a *departed* pointer as hovering would strand it on screen.
+ * Both are the same `null`, and both want the chrome hidden.
+ *
+ * [pinned] is the keyboard's door in: the find bar and the settings dialog are opened by key, and a
+ * search field that appears under an invisible toolbar is worse than no reading mode at all.
+ */
+fun readingModeChromeVisible(
+    readingMode: Boolean,
+    pointerY: Float?,
+    viewportHeightPx: Float,
+    pinned: Boolean = false,
+    revealPx: Float = ReadingModeRevealPx,
+): Boolean {
+    if (!readingMode) return true
+    if (pinned) return true
+    val y = pointerY ?: return false
+    if (y <= revealPx) return true
+    // The measured height is a precondition of the bottom rule, not a number to subtract blindly:
+    // before the first layout pass it is zero, and `y >= 0 - revealPx` is true for every pointer
+    // on screen — which would show the chrome the mode exists to hide.
+    return viewportHeightPx > revealPx && y >= viewportHeightPx - revealPx
+}
 
 data class ReaderPalette(
     val background: Color,
@@ -207,6 +259,11 @@ fun ReaderScreen(
     /** Capability-gated like everywhere else: no control at all without the server API. */
     bookmarksAvailable: Boolean = false,
     onAddBookmark: (positionMs: Long, label: String?) -> Unit = { _, _ -> },
+    /**
+     * Distraction-free reading, owned by `App` because the app chrome is half of what it hides.
+     */
+    readingMode: Boolean = false,
+    onToggleReadingMode: () -> Unit = {},
     onBack: () -> Unit,
     onChapterAdvanced: (chapterId: Int, title: String) -> Unit,
 ) {
@@ -278,6 +335,11 @@ fun ReaderScreen(
                 palette = palette,
                 bookmarksAvailable = bookmarksAvailable,
                 onAddBookmark = onAddBookmark,
+                readingMode = readingMode,
+                onToggleReadingMode = onToggleReadingMode,
+                // The dialog is modal chrome of its own, so the toolbar behind it stays put
+                // rather than vanishing under the pointer that is about to close it.
+                settingsOpen = showSettings,
                 onBack = onBack,
                 onOpenSettings = { showSettings = true },
             )
@@ -303,6 +365,9 @@ private fun ReaderDocumentPage(
     palette: ReaderPalette,
     bookmarksAvailable: Boolean,
     onAddBookmark: (positionMs: Long, label: String?) -> Unit,
+    readingMode: Boolean,
+    onToggleReadingMode: () -> Unit,
+    settingsOpen: Boolean,
     onBack: () -> Unit,
     onOpenSettings: () -> Unit,
 ) {
@@ -394,10 +459,34 @@ private fun ReaderDocumentPage(
         else -> false
     }
 
+    var pointerY by remember { mutableStateOf<Float?>(null) }
+    var viewportHeightPx by remember { mutableIntStateOf(0) }
+    val chromeVisible = readingModeChromeVisible(
+        readingMode = readingMode,
+        pointerY = pointerY,
+        viewportHeightPx = viewportHeightPx.toFloat(),
+        pinned = findOpen || settingsOpen,
+    )
+
     val focusRequester = remember { FocusRequester() }
     Box(
         Modifier
             .fillMaxSize()
+            .onSizeChanged { viewportHeightPx = it.height }
+            // Watched on the *initial* pass, before the list and the paragraphs get the event.
+            // Whether the frame comes back must not depend on which descendant happens to be
+            // under the pointer, and a scrolling lazy list is a descendant that consumes.
+            .pointerInput(Unit) {
+                awaitPointerEventScope {
+                    while (true) {
+                        val event = awaitPointerEvent(PointerEventPass.Initial)
+                        pointerY = when (event.type) {
+                            PointerEventType.Exit -> null
+                            else -> event.changes.lastOrNull()?.position?.y ?: pointerY
+                        }
+                    }
+                }
+            }
             .focusRequester(focusRequester)
             .focusable()
             .onPreviewKeyEvent { event ->
@@ -410,21 +499,29 @@ private fun ReaderDocumentPage(
                 }
             },
     ) {
-        Column(Modifier.align(Alignment.TopCenter).fillMaxSize().widthIn(max = 920.dp)) {
-            ReaderToolbar(
-                title = document.title.ifBlank { "Chapter" },
-                palette = palette,
-                // Present but inert while reading a chapter that is not playing: hiding it as the
-                // narration catches up would move the other toolbar buttons under the cursor.
-                bookmarkEnabled = bookmarksAvailable && bookmarkAnchor != null,
-                showBookmark = bookmarksAvailable,
-                onBookmark = {
-                    bookmarkAnchor?.let { onAddBookmark(it.positionMs, it.label) }
-                },
-                onBack = onBack,
-                onFind = { findOpen = !findOpen },
-                onSettings = onOpenSettings,
-            )
+        Column(
+            Modifier.align(Alignment.TopCenter).fillMaxSize()
+                .widthIn(max = if (readingMode) ReadingModeMeasure else ReaderMeasure),
+        ) {
+            if (chromeVisible) {
+                ReaderToolbar(
+                    title = document.title.ifBlank { "Chapter" },
+                    palette = palette,
+                    // Present but inert while reading a chapter that is not playing: hiding it as
+                    // the narration catches up would move the other toolbar buttons under the
+                    // cursor.
+                    bookmarkEnabled = bookmarksAvailable && bookmarkAnchor != null,
+                    showBookmark = bookmarksAvailable,
+                    readingMode = readingMode,
+                    onBookmark = {
+                        bookmarkAnchor?.let { onAddBookmark(it.positionMs, it.label) }
+                    },
+                    onBack = onBack,
+                    onFind = { findOpen = !findOpen },
+                    onToggleReadingMode = onToggleReadingMode,
+                    onSettings = onOpenSettings,
+                )
+            }
             if (findOpen) {
                 ReaderFindBar(
                     query = query,
@@ -489,6 +586,20 @@ private fun ReaderDocumentPage(
             }
         }
 
+        // In reading mode the app's own now-playing bar is gone with the rest of the chrome, so
+        // the transport comes back with the toolbar rather than leaving the listener with no
+        // visible way to pause. Outside reading mode the bar below the screen already has it.
+        if (readingMode && chromeVisible && player.hasSession) {
+            ReadingModeTransport(
+                player = player,
+                palette = palette,
+                onPlayPause = playback::togglePlayPause,
+                onSkipBackward = playback::skipBackward,
+                onSkipForward = playback::skipForward,
+                modifier = Modifier.align(Alignment.BottomCenter),
+            )
+        }
+
         if (!followPlayback && activeParagraph >= 0) {
             OutlinedButton(
                 onClick = {
@@ -496,9 +607,57 @@ private fun ReaderDocumentPage(
                     scope.launch { scrollToActive() }
                 },
                 shape = RectangleShape,
-                modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 14.dp)
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = if (readingMode && chromeVisible && player.hasSession) 72.dp else 14.dp)
                     .background(palette.background).pointerHoverIcon(PointerIcon.Hand),
             ) { Text("BACK TO CURRENT", color = palette.accent) }
+        }
+    }
+}
+
+/**
+ * The minimum transport reading mode owes a listener: pause, and the two skips.
+ *
+ * Deliberately not a second now-playing bar. Next/previous chapter would move the reader off the
+ * page being read, which is the one thing a distraction-free mode should not do by accident; the
+ * chapter shortcuts still exist for someone who means it.
+ */
+@Composable
+private fun ReadingModeTransport(
+    player: PlayerUiState,
+    palette: ReaderPalette,
+    onPlayPause: () -> Unit,
+    onSkipBackward: () -> Unit,
+    onSkipForward: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val skipSeconds = (player.skipIntervalMs / 1000).toInt()
+    Row(
+        modifier
+            .padding(bottom = 14.dp)
+            .background(palette.background)
+            .border(1.dp, palette.line)
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+            .testTag(ReaderTransportTestTag),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        IconButton(onClick = onSkipBackward) {
+            Icon(rewindIconFor(skipSeconds), "Skip back $skipSeconds seconds", tint = palette.ink)
+        }
+        IconButton(onClick = onPlayPause) {
+            Icon(
+                if (player.isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                if (player.isPlaying) "Pause" else "Play",
+                tint = palette.accent,
+            )
+        }
+        IconButton(onClick = onSkipForward) {
+            Icon(forwardIconFor(skipSeconds), "Skip forward $skipSeconds seconds", tint = palette.ink)
+        }
+        remainingLabel(player.positionMs, player.durationMs, player.speed)?.let {
+            MetaText(it, color = palette.muted, modifier = Modifier.padding(end = 8.dp))
         }
     }
 }
@@ -509,19 +668,29 @@ private fun ReaderToolbar(
     palette: ReaderPalette,
     bookmarkEnabled: Boolean,
     showBookmark: Boolean,
+    readingMode: Boolean,
     onBookmark: () -> Unit,
     onBack: () -> Unit,
     onFind: () -> Unit,
+    onToggleReadingMode: () -> Unit,
     onSettings: () -> Unit,
 ) {
     Row(
-        Modifier.fillMaxWidth().padding(horizontal = PageGutter, vertical = 10.dp),
+        Modifier.fillMaxWidth().padding(horizontal = PageGutter, vertical = 10.dp)
+            .testTag(ReaderToolbarTestTag),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         IconButton(onClick = onBack) {
             Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back", tint = palette.ink)
         }
         Text(title, color = palette.ink, maxLines = 1, modifier = Modifier.weight(1f))
+        IconButton(onClick = onToggleReadingMode, modifier = Modifier.testTag(ReaderModeButtonTestTag)) {
+            Icon(
+                if (readingMode) Icons.Default.FullscreenExit else Icons.Default.Fullscreen,
+                if (readingMode) "Leave distraction-free reading" else "Distraction-free reading",
+                tint = if (readingMode) palette.accent else palette.ink,
+            )
+        }
         if (showBookmark) {
             IconButton(
                 onClick = onBookmark,

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/nav/ShortcutsTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/nav/ShortcutsTest.kt
@@ -99,6 +99,16 @@ class ShortcutsTest {
     }
 
     @Test
+    fun `F11 asks for distraction-free reading and survives a focused search box`() {
+        assertEquals(AppShortcut.ToggleReadingMode, shortcutFor(Key.F11, KeyEventType.KeyDown))
+        assertEquals(
+            AppShortcut.ToggleReadingMode,
+            shortcutFor(Key.F11, KeyEventType.KeyDown, textInputFocused = true),
+            "F11 is not a key any text field claims, so the find bar must not swallow it",
+        )
+    }
+
+    @Test
     fun `the keyboard transport row maps to the same actions`() {
         assertEquals(AppShortcut.PlayPause, shortcutFor(Key.MediaPlayPause, KeyEventType.KeyDown))
         assertEquals(AppShortcut.NextChapter, shortcutFor(Key.MediaNext, KeyEventType.KeyDown))

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/NavigationUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/NavigationUiTest.kt
@@ -2,6 +2,7 @@ package dk.perspektiva.ttsroad.desktop.ui
 
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsFocused
@@ -416,6 +417,48 @@ class NavigationUiTest {
 
         compose.onNodeWithText("The real reader is here.").assertIsDisplayed()
         compose.onNodeWithText("// TEXT ONLY").assertIsDisplayed()
+    }
+
+    @Test
+    fun `F11 in the reader hides the app chrome and Escape brings it back without leaving`() {
+        val repository = FakeRepository(
+            libraryResult = Result.success(bigLibrary(60)),
+            chaptersResult = Result.success(chapters),
+            capabilitiesResult = ServerCapabilities(serverVersion = "1.4.0", readAlong = true),
+            readAlongResult = Result.success(
+                ReadAlongFetchResult.Modified(
+                    ReadAlongResponse(
+                        chapter = ReadAlongChapter(5001, 50, "Chapter One", hasTimings = false),
+                        text = "The real reader is here.",
+                        paragraphs = listOf(listOf(0.0, 24.0)),
+                    ),
+                    "\"reader\"",
+                ),
+            ),
+        )
+        compose.setContent { TtsRoadTheme { App(container(repository)) } }
+        compose.waitForIdle()
+
+        compose.onNodeWithTag(LibraryGridTestTag).performScrollToNode(hasText("Serial 50"))
+        compose.onNodeWithText("Serial 50").performClick()
+        compose.waitForIdle()
+        compose.onNodeWithContentDescription("Read chapter text").performClick()
+        compose.waitForIdle()
+        compose.onNodeWithText("SETTINGS").assertIsDisplayed()
+
+        compose.onRoot().performKeyInput { pressKey(Key.F11) }
+        compose.waitForIdle()
+
+        // The header is half of what distraction-free reading is free of.
+        compose.onAllNodesWithText("SETTINGS").assertCountEquals(0)
+        compose.onNodeWithText("The real reader is here.").assertIsDisplayed()
+
+        // Escape restores the frame rather than leaving the chapter, so the reader keeps its place.
+        compose.onRoot().performKeyInput { pressKey(Key.Escape) }
+        compose.waitForIdle()
+
+        compose.onNodeWithText("SETTINGS").assertIsDisplayed()
+        compose.onNodeWithText("The real reader is here.").assertIsDisplayed()
     }
 
     @Test

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderBehaviourTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderBehaviourTest.kt
@@ -113,4 +113,51 @@ class ReaderBehaviourTest {
         assertEquals(61_400L, readerBookmarkAnchor(true, true, 61_400, -3.0, "x")?.positionMs)
         assertEquals(61_400L, readerBookmarkAnchor(true, true, 61_400, Double.NaN, "x")?.positionMs)
     }
+
+    // --- Distraction-free reading ---------------------------------------------------------------
+
+    @Test
+    fun `outside reading mode the chrome is simply always there`() {
+        assertTrue(readingModeChromeVisible(readingMode = false, pointerY = 400f, viewportHeightPx = 800f))
+        assertTrue(readingModeChromeVisible(readingMode = false, pointerY = null, viewportHeightPx = 800f))
+    }
+
+    @Test
+    fun `reaching for either edge brings the frame back`() {
+        fun visibleAt(y: Float?) =
+            readingModeChromeVisible(readingMode = true, pointerY = y, viewportHeightPx = 800f)
+
+        assertTrue(visibleAt(0f), "the very top edge")
+        assertTrue(visibleAt(ReadingModeRevealPx))
+        assertFalse(visibleAt(ReadingModeRevealPx + 1f))
+        assertFalse(visibleAt(400f), "the middle of the page is where reading happens")
+        assertTrue(visibleAt(800f - ReadingModeRevealPx))
+        assertTrue(visibleAt(800f), "the very bottom edge")
+    }
+
+    @Test
+    fun `a pointer that never moved or has left the window is not hovering an edge`() {
+        assertFalse(readingModeChromeVisible(readingMode = true, pointerY = null, viewportHeightPx = 800f))
+    }
+
+    @Test
+    fun `an overlay opened by keyboard pins the frame regardless of the pointer`() {
+        assertTrue(
+            readingModeChromeVisible(
+                readingMode = true,
+                pointerY = 400f,
+                viewportHeightPx = 800f,
+                pinned = true,
+            ),
+            "Ctrl+F must not put a search field under an invisible toolbar",
+        )
+    }
+
+    @Test
+    fun `a viewport that has not been measured yet does not strand the frame on screen`() {
+        // Before the first layout pass the height is zero, which would make every coordinate both
+        // "within revealPx of the top" and "past height - revealPx" if the rule were written the
+        // obvious way round.
+        assertFalse(readingModeChromeVisible(readingMode = true, pointerY = 400f, viewportHeightPx = 0f))
+    }
 }

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderScreenUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderScreenUiTest.kt
@@ -1,5 +1,6 @@
 package dk.perspektiva.ttsroad.desktop.ui
 
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
@@ -9,7 +10,9 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performTextInput
 import dk.perspektiva.ttsroad.desktop.FakePlaybackController
 import dk.perspektiva.ttsroad.desktop.FakeRepository
@@ -62,6 +65,7 @@ class ReaderScreenUiTest {
         onAdvanced: (Int, String) -> Unit = { _, _ -> },
         bookmarksAvailable: Boolean = false,
         onAddBookmark: (Long, String?) -> Unit = { _, _ -> },
+        readingMode: Boolean = false,
     ) {
         val repository = FakeRepository(
             readAlongResult = Result.success(ReadAlongFetchResult.Modified(response, "\"etag\"")),
@@ -76,6 +80,7 @@ class ReaderScreenUiTest {
                     playback = player,
                     bookmarksAvailable = bookmarksAvailable,
                     onAddBookmark = onAddBookmark,
+                    readingMode = readingMode,
                     onBack = {},
                     onChapterAdvanced = onAdvanced,
                 )
@@ -225,5 +230,56 @@ class ReaderScreenUiTest {
 
         val composed = compose.onAllNodesWithTag(ReaderParagraphTestTag).fetchSemanticsNodes().size
         assertTrue(composed in 1..80, "the lazy reader composed $composed of 500 paragraphs")
+    }
+
+    // --- Distraction-free reading -------------------------------------------------------------
+
+    @Test
+    fun `reading mode hides the reader's own toolbar until the pointer has not moved`() {
+        screen(player = playingThisChapter(), readingMode = true)
+
+        compose.onAllNodesWithTag(ReaderToolbarTestTag).assertCountEquals(0)
+        compose.onAllNodesWithTag(ReaderTransportTestTag).assertCountEquals(0)
+        // The page itself is untouched: this hides the frame, not the chapter.
+        compose.onAllNodesWithTag(ReaderParagraphTestTag).assertCountEquals(1)
+    }
+
+    @Test
+    fun `ordinary reading keeps the toolbar and offers the mode`() {
+        screen(player = playingThisChapter())
+
+        compose.onNodeWithTag(ReaderToolbarTestTag).assertIsDisplayed()
+        compose.onNodeWithTag(ReaderModeButtonTestTag).assertHasClickAction()
+        compose.onNodeWithContentDescription("Distraction-free reading").assertIsDisplayed()
+        // The now-playing bar belongs to `App`; the reader draws no transport of its own here.
+        compose.onAllNodesWithTag(ReaderTransportTestTag).assertCountEquals(0)
+    }
+
+    @Test
+    fun `reaching for the top edge brings the frame and the transport back`() {
+        screen(player = playingThisChapter(), readingMode = true)
+
+        compose.onRoot().performMouseInput { moveTo(Offset(120f, 4f)) }
+        compose.waitForIdle()
+
+        compose.onNodeWithTag(ReaderToolbarTestTag).assertIsDisplayed()
+        // Hiding the app's now-playing bar without offering a pause is the trap this avoids.
+        compose.onNodeWithTag(ReaderTransportTestTag).assertIsDisplayed()
+        compose.onNodeWithContentDescription("Leave distraction-free reading").assertIsDisplayed()
+    }
+
+    @Test
+    fun `moving back into the page hides the frame again`() {
+        screen(player = playingThisChapter(), readingMode = true)
+
+        compose.onRoot().performMouseInput { moveTo(Offset(120f, 4f)) }
+        compose.waitForIdle()
+        compose.onNodeWithTag(ReaderToolbarTestTag).assertIsDisplayed()
+
+        compose.onRoot().performMouseInput { moveTo(Offset(120f, 320f)) }
+        compose.waitForIdle()
+
+        compose.onAllNodesWithTag(ReaderToolbarTestTag).assertCountEquals(0)
+        compose.onAllNodesWithTag(ReaderTransportTestTag).assertCountEquals(0)
     }
 }


### PR DESCRIPTION
Addresses the **distraction-free reading** item (§3) in #41.

`ReaderScreen` is the strongest read-along implementation of the three clients, and it was framed by the app chrome. `F11` — or the new toolbar button — now hides the header, the now-playing bar and the reader's own toolbar, and narrows the measure from 920 dp to 760 dp.

## Three decisions, recorded in ADR 0008

- **It is a posture, not a preference.** The flag lives in `App` and is dropped on leaving the reader. A stored one would reopen the client a week later with no header — that reads as broken, not focused — and it is emphatically *not* a fifth `/api/me/preferences` key, since those four are a cross-repo contract.
- **The frame comes back when you reach for it.** `readingModeChromeVisible` is a pure rule over the pointer's y, the measured viewport and a `pinned` flag. The case that earns the function is the pointer that has never moved: a reader opened straight into the mode reports no pointer at all, and that and a pointer that has *left* the window are the same `null` — both want the chrome hidden. The measured height is a precondition of the bottom-edge rule rather than a number to subtract, because before the first layout pass it is zero and every coordinate satisfies `y >= 0 - reveal`. The pointer is watched on the **initial** pass, so the scrolling lazy list underneath cannot consume the movement that should have brought the toolbar back.
- **The mode owes the listener a transport.** Hiding the now-playing bar without offering pause and the two skips would remove the only visible way to stop the audio. Next/previous chapter are deliberately absent: moving off the page being read is the one thing this mode must not do by accident, and the chapter shortcuts still exist for someone who means it.

`Escape` restores the frame *before* it navigates, so the key that undoes the last mode change does not also lose the reader's place. `F11` is classified `firesWhileTyping`, so it still works from inside the find bar.

## Coverage

- `ReaderBehaviourTest` — six cases over the pure reveal rule, including the unmoved pointer and the unmeasured viewport.
- `ReaderScreenUiTest` — the mode hides the toolbar and transport without touching the page; reaching the top edge brings both back; moving into the page hides them again.
- `NavigationUiTest` — through the real `App`: F11 in the reader removes the header, Escape restores it *without* leaving the chapter.
- `ShortcutsTest` — F11 maps, and survives a focused text field.

## Validation

```
xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail -Pttsroad.warningsAsErrors=true
```

`BUILD SUCCESSFUL`.