### PR TITLE
Add a system tray with the transport on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ All notable changes to TTSRoad Desktop are recorded here. The format follows
 
 ### Added
 
+- A system tray icon with the transport on it, so the app can get out of the way without stopping.
+  It names the chapter and serial, offers play/pause and the two skips, and its Quit entry always
+  stops the app for good. **Closing the window still quits by default** — the new Playback setting
+  "Keep playing when the window closes" is what changes that, and the first close-to-tray says once
+  that TTSRoad is still running. A desktop session with no system tray says so and keeps closing.
 - Distraction-free reading. `F11` in the reader — or the new toolbar button — hides the header, the
   now-playing bar and the reader's own toolbar, and narrows the text to a comfortable measure. The
   frame returns when the pointer reaches either edge, along with a transport that can pause and skip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,18 @@ means no MPRIS and a fully working player. `Position` is never announced via `Pr
 the spec excludes it; discontinuities go out as `Seeked`. `AppContainer.startMpris` is called from
 `Main` rather than the constructor because Raise/Quit need the window.
 
+### The tray, and what closing the window means
+
+`ui/TrayPresentation.kt` is pure — `windowCloseIntent`, `trayTooltip`, the two label helpers — and
+`Main` is the plumbing, the same split as MPRIS. Two rules are load-bearing: **both** the preference
+and `isTraySupported` must say yes before a close hides rather than quits (hiding into a tray the
+platform will not draw is a process the user cannot reach), and the preference **defaults to off**,
+because a close control that closes is what everyone expects and the reverse leaves a media session
+running for people who believed they had quit. The tray tooltip reuses MPRIS's audiobook mapping so
+one desktop never shows two different answers. `WindowPlacement` carries the flag; geometry and
+behaviour are written by different hands at different times, so the close handler merges through
+`withBehaviourOf` rather than saving the startup snapshot wholesale.
+
 ### Keyboard shortcuts
 
 `nav/Shortcuts.kt` is a pure matcher plus an `AppShortcut.firesWhileTyping` classification. `App`

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ full evidence table is in [`docs/QUALITY-GATE.md`](docs/QUALITY-GATE.md).
 | Sleep timer — 5/15/30/45/60 min or end of chapter, with a fade and "+5 min" | ✅ |
 | Cross-device listening history — local-first "Jump back in", dismissible per snapshot | ✅ |
 | MPRIS over D-Bus — Cinnamon applet, lock screen, hardware media keys | ✅ Linux |
+| System tray transport, and an optional keep-playing-on-close | ✅ where the desktop has a tray |
 | App shortcuts — Space, arrows, Ctrl+arrows, Ctrl+L, Ctrl+, plus an F1 list | ✅ |
 | Offline downloads — per chapter, next 10, restart-safe queue, storage controls | ✅ |
 | Bounded streaming cache and previously loaded library browsing while offline | ✅ |
@@ -550,6 +551,13 @@ screen and hardware media keys show the right metadata and control playback. It 
 dbus-java over the JDK's own AF_UNIX socket — so it adds no native library to the bundled runtime.
 No session bus (Windows, macOS, a bare SSH session) means no MPRIS and a fully working player, with
 a note in the log rather than a failure.
+
+Where the desktop offers a **system tray**, TTSRoad puts an icon there with the chapter and serial
+as its tooltip, play/pause, both skips, *Show TTSRoad* and *Quit*. Closing the window **quits** by
+default; Settings → Playback → *Keep playing when the window closes* is what changes that, and the
+first time it happens the tray says once that TTSRoad is still running. The default is the way round
+that cannot surprise anyone — a close control that closes — and a session with no tray at all says
+so and keeps closing, rather than hiding a window nobody could get back to.
 
 ## ⌨️ Keyboard
 

--- a/docs/adr/0006-listening-preferences-and-desktop-integration.md
+++ b/docs/adr/0006-listening-preferences-and-desktop-integration.md
@@ -240,6 +240,44 @@ Two decisions worth recording:
 This amends the original local-only decision after the shared bookmark contract landed. Keeping a
 local fallback was retained rather than replacing it because offline playback is a first-class path.
 
+### The tray, and what the window's close control means
+
+Where the desktop offers a system tray, TTSRoad puts an icon there with the chapter and serial as
+its tooltip, play/pause, both skips, *Show TTSRoad* and *Quit*. `ui/TrayPresentation.kt` holds the
+rules as pure functions and `Main` holds the plumbing — the same split as `MprisState` and
+`MprisService`, and for the same reason: the interesting half is testable without a session bus, a
+tray, or a display.
+
+The tooltip reuses the MPRIS mapping (chapter as the title, serial as what it belongs to) because
+the two are answering the same question on the same desktop, and two different answers would look
+like a bug in one of them.
+
+Two decisions carry the weight:
+
+- **Closing quits, unless the user asked otherwise.** This is the question the idea raised —
+  closing to tray surprises people who meant to quit, quitting surprises people who meant to keep
+  listening — and the tie is broken by which surprise is worse. A close control that closes is what
+  every window on the desktop does; the other way round leaves a process running and holding a media
+  session for someone who believed they had quit. So it is a setting, it defaults to off, and the
+  first close-to-tray sends one tray notification saying TTSRoad is still running. Once: somebody
+  who asked for this knows it by the second time, and a notification on every close is exactly the
+  tray noise the feature exists to avoid.
+- **The platform gets a veto.** `windowCloseIntent` requires *both* the preference and
+  `isTraySupported`. Several Wayland sessions ship without a tray, and hiding a window into an icon
+  the platform will not draw produces a running process the user can neither see nor quit — strictly
+  worse than either honest answer. Where there is no tray, Settings says so instead of offering a
+  switch that promises nothing.
+
+`WindowPlacement` carries the flag, which makes `window.json` the file with both halves of "what
+this window does". They are written by different hands at different times — geometry once as the
+window closes, against the placement loaded at startup; the preference whenever Settings is touched
+— so the close handler merges through `withBehaviourOf` rather than writing the startup snapshot
+wholesale, which would silently revert a setting changed five minutes earlier.
+
+MPRIS `Raise` un-hides as well as raising, since after a close-to-tray the window is not merely
+behind something, and `Quit` from a shell quits rather than hiding: a client asking a player to quit
+is not asking it to get out of the way.
+
 ## Consequences
 
 - Speed, skip interval, skip-silence and volume boost survive a restart and a sign-out, and are

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.isTraySupported
 import dk.perspektiva.ttsroad.desktop.data.Bookmark
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.di.AppContainer
@@ -114,6 +115,10 @@ fun App(container: AppContainer = remember { AppContainer() }) {
     val playback = container.playback
     val cache = container.libraryCache
     val session by sessionStore.session.collectAsState()
+    val closeToTray by container.closeToTray.collectAsState()
+    // Whether this desktop session has a system tray at all. Read once — it cannot change while
+    // the process runs — and `false` in a Compose test, where the setting is honestly unavailable.
+    val traySupported = remember { runCatching { isTraySupported }.getOrDefault(false) }
     val sessionEnd by repository.sessionEnd.collectAsState()
     val capabilities by repository.currentCapabilities.collectAsState()
     // Hoisted above navigation on purpose: `when (destination)` disposes the screen it leaves, so a
@@ -540,6 +545,9 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                     // can do by construction.
                                     canChangeSpeed = playerState.canChangeSpeed,
                                     canSkipSilence = playerState.canSkipSilence,
+                                    closeToTray = closeToTray,
+                                    onCloseToTrayChange = container::setCloseToTray,
+                                    traySupported = traySupported,
                                     updates = updates,
                                     // Keeps the destination and the open pane in step, so the
                                     // Devices deep link and the in-screen pane list are the same

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/Main.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/Main.kt
@@ -1,6 +1,15 @@
 package dk.perspektiva.ttsroad.desktop
 
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.window.Notification
+import androidx.compose.ui.window.Tray
+import androidx.compose.ui.window.isTraySupported
+import androidx.compose.ui.window.rememberTrayState
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
@@ -12,10 +21,16 @@ import dk.perspektiva.ttsroad.desktop.data.ScreenBounds
 import dk.perspektiva.ttsroad.desktop.data.AppLog
 import dk.perspektiva.ttsroad.desktop.data.WindowPlacement
 import dk.perspektiva.ttsroad.desktop.data.WindowPlacements
+import dk.perspektiva.ttsroad.desktop.data.withBehaviourOf
 import dk.perspektiva.ttsroad.desktop.di.AppContainer
 import dk.perspektiva.ttsroad.desktop.resources.Res
 import dk.perspektiva.ttsroad.desktop.resources.ttsroad
 import dk.perspektiva.ttsroad.desktop.ui.TtsRoadTheme
+import dk.perspektiva.ttsroad.desktop.ui.WindowCloseIntent
+import dk.perspektiva.ttsroad.desktop.ui.trayNowPlayingLabel
+import dk.perspektiva.ttsroad.desktop.ui.trayPlayPauseLabel
+import dk.perspektiva.ttsroad.desktop.ui.trayTooltip
+import dk.perspektiva.ttsroad.desktop.ui.windowCloseIntent
 import java.awt.Dimension
 import java.awt.EventQueue
 import java.awt.Frame
@@ -176,12 +191,88 @@ private fun runDesktop(smokeTest: Boolean) {
     application {
         val state = rememberWindowState()
         val appIcon = painterResource(Res.drawable.ttsroad)
+
+        // A tray is a platform capability, not a preference: several Wayland sessions ship without
+        // one. Read once, because it cannot change while the process runs, and because a close
+        // control whose meaning flickered would be worse than either fixed answer.
+        // Skipped under --smoke-test for the reason MPRIS is: putting an icon in CI's tray for the
+        // two seconds before the process exits buys no coverage.
+        val traySupported = remember { !smokeTest && runCatching { isTraySupported }.getOrDefault(false) }
+        val trayState = rememberTrayState()
+        var windowVisible by remember { mutableStateOf(true) }
+        val closeToTray by container.closeToTray.collectAsState()
+        val player by container.playback.state.collectAsState()
+
+        fun savePlacement() {
+            // Behaviour from the file as it stands now, geometry from this run's window: Settings
+            // may have flipped the close preference since the placement was loaded at startup.
+            frame.get()?.let {
+                container.windowPreferences.save(
+                    currentPlacement(it, restored).withBehaviourOf(container.windowPreferences.load()),
+                )
+            }
+        }
+
+        fun quit() {
+            savePlacement()
+            container.close()
+            exitApplication()
+        }
+
+        fun showWindow() {
+            windowVisible = true
+            frame.get()?.let {
+                if (it.extendedState == Frame.ICONIFIED) it.extendedState = Frame.NORMAL
+                it.toFront()
+                it.requestFocus()
+            }
+        }
+
+        if (traySupported) {
+            Tray(
+                icon = appIcon,
+                state = trayState,
+                tooltip = trayTooltip(player),
+                onAction = ::showWindow,
+                menu = {
+                    trayNowPlayingLabel(player)?.let { Item(it, onClick = ::showWindow) }
+                    Item(trayPlayPauseLabel(player), enabled = player.hasMedia) {
+                        container.playback.togglePlayPause()
+                    }
+                    Item("Skip back", enabled = player.hasMedia) { container.playback.skipBackward() }
+                    Item("Skip forward", enabled = player.hasMedia) { container.playback.skipForward() }
+                    Separator()
+                    Item("Show ${BuildInfo.APP_NAME}", onClick = ::showWindow)
+                    Item("Quit", onClick = ::quit)
+                },
+            )
+        }
+
         Window(
             onCloseRequest = {
-                frame.get()?.let { container.windowPreferences.save(currentPlacement(it, restored)) }
-                container.close()
-                exitApplication()
+                when (windowCloseIntent(closeToTray, traySupported)) {
+                    WindowCloseIntent.Quit -> quit()
+                    WindowCloseIntent.HideToTray -> {
+                        // Saved on the way *down*, not only on quit: a machine that loses power
+                        // while TTSRoad sits in the tray would otherwise forget the window it had.
+                        savePlacement()
+                        windowVisible = false
+                        // Said once, the first time it happens. Somebody who asked for this knows
+                        // what they asked for by the second time, and a notification on every close
+                        // is exactly the tray noise this feature is supposed to avoid.
+                        if (container.consumeTrayNotice()) {
+                            trayState.sendNotification(
+                                Notification(
+                                    BuildInfo.APP_NAME,
+                                    "Still running in the tray. Use its Quit entry to stop it.",
+                                    Notification.Type.Info,
+                                ),
+                            )
+                        }
+                    }
+                }
             },
+            visible = windowVisible,
             title = "${BuildInfo.APP_NAME} ${BuildInfo.VERSION}",
             icon = appIcon,
             state = state,
@@ -197,11 +288,17 @@ private fun runDesktop(smokeTest: Boolean) {
                 if (!smokeTest) {
                     container.startMpris(
                         onRaise = {
+                            // Also un-hides: after a close-to-tray the window is not merely behind
+                            // something, and a Raise that only calls toFront would do nothing at
+                            // all from a media applet.
+                            windowVisible = true
                             window.toFront()
                             window.requestFocus()
                             if (window.extendedState == Frame.ICONIFIED) window.extendedState = Frame.NORMAL
                         },
-                        onQuit = { window.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING)) },
+                        // Quit means quit, even with close-to-tray on: a shell asking a player to
+                        // quit is not asking it to hide.
+                        onQuit = ::quit,
                     )
                 }
                 window.minimumSize = Dimension(WindowPlacements.MinWidth, WindowPlacements.MinHeight)

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/WindowPreferences.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/WindowPreferences.kt
@@ -12,12 +12,13 @@ data class ScreenBounds(val x: Int, val y: Int, val width: Int, val height: Int)
 }
 
 /**
- * The safe-to-persist part of the window's appearance.
+ * The safe-to-persist part of the window's appearance and behaviour.
  *
- * Everything here is a layout fact. Nothing transient (open dialogs, the current destination, a
- * half-typed search) and nothing secret is representable in this type at all, which is stronger
- * than remembering not to write it: a future field cannot leak a credential into
- * `window.json` by accident because there is nowhere to put one.
+ * Everything here is a fact about the window itself — its geometry, and what its own close control
+ * does. Nothing transient (open dialogs, the current destination, a half-typed search) and nothing
+ * secret is representable in this type at all, which is stronger than remembering not to write it:
+ * a future field cannot leak a credential into `window.json` by accident because there is nowhere
+ * to put one.
  *
  * A null [x]/[y] means "let the window system place it" — that is what an unusable saved position
  * degrades to, rather than a window opening off-screen.
@@ -29,7 +30,29 @@ data class WindowPlacement(
     val height: Int = WindowPlacements.DefaultHeight,
     val isMaximized: Boolean = false,
     val sidebarWidth: Int = WindowPlacements.DefaultSidebarWidth,
+    /**
+     * Whether closing the window keeps playing in the tray instead of quitting.
+     *
+     * Defaults to **off**, which is the answer that cannot surprise anyone: a close control that
+     * closes is what every user already expects, and a listener who wants the other behaviour has
+     * a reason to go and ask for it. The reverse default would leave a process running, holding a
+     * media session, for people who believed they had quit.
+     */
+    val closeToTray: Boolean = false,
+    /** Whether the "still playing" notice has already been shown for a close-to-tray. */
+    val trayNoticeShown: Boolean = false,
 )
+
+/**
+ * Geometry from this run's window, behaviour from whatever the file says **now**.
+ *
+ * The two halves of `window.json` are written by different things at different times: geometry is
+ * captured once, as the window closes, against the placement loaded at startup, while Settings can
+ * flip the close behaviour at any point in between. Saving the startup snapshot wholesale would
+ * quietly undo a setting the user changed five minutes ago.
+ */
+fun WindowPlacement.withBehaviourOf(latest: WindowPlacement): WindowPlacement =
+    copy(closeToTray = latest.closeToTray, trayNoticeShown = latest.trayNoticeShown)
 
 object WindowPlacements {
     /**

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/di/AppContainer.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/di/AppContainer.kt
@@ -45,6 +45,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import okhttp3.OkHttpClient
 
 /**
@@ -241,6 +244,31 @@ class AppContainer(
 
     /** Remembered window size/position/maximised state. Never holds anything transient or secret. */
     val windowPreferences: WindowPreferencesStore = windowPreferencesStore
+
+    /**
+     * The one window-behaviour flag a screen can change while the window is open.
+     *
+     * A flow rather than a re-read of `window.json`, because two places need the same answer at the
+     * same moment and neither owns it: Settings writes it, and `Main`'s close handler and tray read
+     * it. Written through to the file immediately so the choice survives a crash, and republished so
+     * the toggle reflects what was actually stored rather than what was clicked.
+     */
+    private val _closeToTray = MutableStateFlow(windowPreferencesStore.load().closeToTray)
+    val closeToTray: StateFlow<Boolean> = _closeToTray.asStateFlow()
+
+    fun setCloseToTray(enabled: Boolean) {
+        if (_closeToTray.value == enabled) return
+        _closeToTray.value = enabled
+        windowPreferences.save(windowPreferences.load().copy(closeToTray = enabled))
+    }
+
+    /** Records that the "still playing in the tray" notice has been shown, and whether to show it. */
+    fun consumeTrayNotice(): Boolean {
+        val stored = windowPreferences.load()
+        if (stored.trayNoticeShown) return false
+        windowPreferences.save(stored.copy(trayNoticeShown = true))
+        return true
+    }
 
     /**
      * Looks for a newer published build. On the shared HTTP client on purpose: the auth

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
@@ -117,6 +117,17 @@ fun SettingsScreen(
      */
     canChangeSpeed: Boolean = false,
     canSkipSilence: Boolean = false,
+    /**
+     * Whether closing the window keeps playing in the tray, and how to change it.
+     *
+     * Passed in for the same reason the two engine flags are: the answer is owned by the window,
+     * which is `Main`'s business rather than a screen's, and a pane that reached for the store
+     * itself could not be rendered in a test without one.
+     */
+    closeToTray: Boolean = false,
+    onCloseToTrayChange: (Boolean) -> Unit = {},
+    /** False on a desktop session with no system tray, where the control would promise nothing. */
+    traySupported: Boolean = true,
     // Injected so "expires in 42 days" can be asserted without the test depending on wall time.
     nowMs: () -> Long = System::currentTimeMillis,
     /**
@@ -166,7 +177,14 @@ fun SettingsScreen(
                     when (ui.section) {
                         SettingsSection.Account -> AccountPane(ui, session, capabilities, sessionStore, holder, selectSection, nowMs)
                         SettingsSection.Devices -> DevicesPane(ui, session, holder, nowMs)
-                        SettingsSection.Playback -> PlaybackPane(preferences, canChangeSpeed, canSkipSilence)
+                        SettingsSection.Playback -> PlaybackPane(
+                            preferences,
+                            canChangeSpeed,
+                            canSkipSilence,
+                            closeToTray,
+                            onCloseToTrayChange,
+                            traySupported,
+                        )
                         SettingsSection.Offline -> OfflinePane(ui.offline, holder)
                         SettingsSection.Audiobooks -> AudiobookPane(ui.audiobooks, holder)
                         SettingsSection.About -> AboutPane(session, capabilities, sessionStore, updates)
@@ -674,6 +692,9 @@ private fun PlaybackPane(
     preferences: PlaybackPreferencesStore,
     canChangeSpeed: Boolean,
     canSkipSilence: Boolean,
+    closeToTray: Boolean,
+    onCloseToTrayChange: (Boolean) -> Unit,
+    traySupported: Boolean,
 ) {
     val prefs by preferences.preferences.collectAsState()
 
@@ -734,6 +755,25 @@ private fun PlaybackPane(
             MetaText(
                 "Silence removal needs the GStreamer \"removesilence\" element, which ships in " +
                     "gst-plugins-bad. It is not installed here, so the control is not shown.",
+            )
+        }
+
+        RowDivider()
+
+        if (traySupported) {
+            ToggleRow(
+                label = "KEEP PLAYING WHEN THE WINDOW CLOSES",
+                description = "Closing the window puts TTSRoad in the system tray and keeps the " +
+                    "chapter playing. Off by default, because a close control that closes is what " +
+                    "everyone expects. The tray icon's Quit entry always stops it for good.",
+                checked = closeToTray,
+                onCheckedChange = onCloseToTrayChange,
+            )
+        } else {
+            SettingRow("KEEP PLAYING WHEN THE WINDOW CLOSES", "No system tray on this desktop")
+            MetaText(
+                "This desktop session does not offer a system tray, so closing the window would " +
+                    "leave TTSRoad running with no way back to it. Closing quits instead.",
             )
         }
     }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/TrayPresentation.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/TrayPresentation.kt
@@ -1,0 +1,62 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.player.PlayerUiState
+
+/**
+ * What pressing the window's close control actually does.
+ *
+ * A value rather than a branch inside `onCloseRequest`, because the rule has a failure mode that is
+ * invisible until someone runs the app on the wrong desktop: a tray that the platform will not
+ * show. Closing to a tray icon nobody can see is a process the user cannot reach and cannot quit,
+ * which is strictly worse than either honest answer.
+ */
+enum class WindowCloseIntent {
+    /** Save the placement, close the container, leave. */
+    Quit,
+
+    /** Hide the window, keep playing, keep the tray icon as the way back. */
+    HideToTray,
+}
+
+/**
+ * The close rule.
+ *
+ * Both inputs are required to say yes. The preference is the user's answer to "what should the X
+ * do"; [traySupported] is the platform's answer to "can I put anything in the tray", and it is
+ * false on a desktop with no system tray at all — several Wayland sessions ship without one. When
+ * the platform says no, the honest behaviour is the one every window has: it closes.
+ */
+fun windowCloseIntent(closeToTray: Boolean, traySupported: Boolean): WindowCloseIntent =
+    if (closeToTray && traySupported) WindowCloseIntent.HideToTray else WindowCloseIntent.Quit
+
+/**
+ * The tray icon's hover text.
+ *
+ * The same audiobook mapping `MprisState` uses — the chapter is the title and the serial is what it
+ * belongs to — because a tray tooltip and a media applet are answering the same question, and two
+ * different answers on the same desktop would look like a bug in one of them.
+ *
+ * Not "TTSRoad — nothing playing": the app name alone already says which icon this is, and a
+ * tooltip that reports absence is noise on a tray whose whole purpose is to be glanceable.
+ */
+fun trayTooltip(player: PlayerUiState, appName: String = "TTSRoad"): String {
+    val chapter = trayNowPlayingLabel(player) ?: return appName
+    val state = if (player.isPlaying) "Playing" else "Paused"
+    return "$appName — $state: $chapter"
+}
+
+/** The label of the tray's play/pause entry, which has to name the *action*, not the state. */
+fun trayPlayPauseLabel(player: PlayerUiState): String = if (player.isPlaying) "Pause" else "Play"
+
+/**
+ * The chapter line at the top of the tray menu, or null when there is nothing to name.
+ *
+ * Kept out of [trayTooltip] because a menu entry and a tooltip fail differently: an empty tooltip
+ * is a tooltip that does not appear, while an empty menu entry is a blank clickable row.
+ */
+fun trayNowPlayingLabel(player: PlayerUiState): String? {
+    if (!player.hasSession) return null
+    val chapter = player.title.takeIf { it.isNotBlank() } ?: return null
+    val serial = player.fictionTitle?.takeIf { it.isNotBlank() } ?: return chapter
+    return "$chapter · $serial"
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/WindowPreferencesTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/WindowPreferencesTest.kt
@@ -190,4 +190,39 @@ class WindowPreferencesTest {
         assertEquals(WindowPlacement(), missing.load())
         assertEquals(WindowPlacement(), FileWindowPreferencesStore(corrupt).load())
     }
+
+    // --- Window behaviour, written by a different hand than the geometry -------------------------
+
+    @Test
+    fun `closing quits by default, so nobody is left with a process they thought they closed`() {
+        assertFalse(WindowPlacement().closeToTray)
+        assertFalse(WindowPlacement().trayNoticeShown)
+    }
+
+    @Test
+    fun `saving this run's geometry does not undo a close preference changed since startup`() {
+        // Geometry is captured once, against the placement loaded at startup; Settings can flip the
+        // close behaviour at any point in between. Writing the startup snapshot wholesale would
+        // silently revert it.
+        val loadedAtStartup = WindowPlacement(x = 10, y = 20, width = 1000, height = 700)
+        val onDiskNow = loadedAtStartup.copy(closeToTray = true, trayNoticeShown = true)
+        val closingGeometry = loadedAtStartup.copy(x = 400, y = 300)
+
+        val saved = closingGeometry.withBehaviourOf(onDiskNow)
+
+        assertEquals(400, saved.x)
+        assertEquals(300, saved.y)
+        assertTrue(saved.closeToTray)
+        assertTrue(saved.trayNoticeShown)
+    }
+
+    @Test
+    fun `clamping a window back onto an attached display leaves its behaviour alone`() {
+        val stored = WindowPlacement(x = 9_000, y = 9_000, closeToTray = true, trayNoticeShown = true)
+
+        val clamped = WindowPlacements.clampToDisplays(stored, listOf(ScreenBounds(0, 0, 1920, 1080)))
+
+        assertTrue(clamped.closeToTray)
+        assertTrue(clamped.trayNoticeShown)
+    }
 }

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreenUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreenUiTest.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsSelected
@@ -115,6 +117,9 @@ class SettingsScreenUiTest {
         canChangeSpeed: Boolean = true,
         canSkipSilence: Boolean = true,
         offline: OfflineStorageController = FakeOfflineStorage(),
+        closeToTray: Boolean = false,
+        onCloseToTrayChange: (Boolean) -> Unit = {},
+        traySupported: Boolean = true,
     ) {
         val store = InMemorySessionStore(session)
         repository.capabilitiesResult = capabilities
@@ -128,6 +133,9 @@ class SettingsScreenUiTest {
                     preferences = preferences,
                     canChangeSpeed = canChangeSpeed,
                     canSkipSilence = canSkipSilence,
+                    closeToTray = closeToTray,
+                    onCloseToTrayChange = onCloseToTrayChange,
+                    traySupported = traySupported,
                     nowMs = { now },
                 )
             }
@@ -366,6 +374,30 @@ class SettingsScreenUiTest {
         compose.onNodeWithContentDescription("SKIP SILENCE").performScrollTo().performClick()
         compose.waitForIdle()
         assertTrue(preferences.preferences.value.skipSilence)
+    }
+
+    @Test
+    fun `closing the window quits by default and the tray choice is offered`() {
+        var asked: Boolean? = null
+        setContent(FakeRepository(), onCloseToTrayChange = { asked = it })
+        openPlayback()
+
+        compose.onNodeWithContentDescription("KEEP PLAYING WHEN THE WINDOW CLOSES")
+            .performScrollTo()
+            .assertIsOff()
+            .performClick()
+        compose.waitForIdle()
+
+        assertEquals(true, asked)
+    }
+
+    @Test
+    fun `a desktop with no system tray explains itself instead of offering a dead switch`() {
+        setContent(FakeRepository(), traySupported = false)
+        openPlayback()
+
+        compose.onAllNodesWithContentDescription("KEEP PLAYING WHEN THE WINDOW CLOSES").assertCountEquals(0)
+        compose.onNodeWithText("No system tray on this desktop", ignoreCase = true).assertExists()
     }
 
     @Test

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/TrayPresentationTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/TrayPresentationTest.kt
@@ -1,0 +1,73 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.player.PlayerUiState
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
+
+class TrayPresentationTest {
+
+    private val playing = PlayerUiState(
+        title = "Chapter 41",
+        fictionTitle = "A Test Serial",
+        hasMedia = true,
+        isPlaying = true,
+        durationMs = 600_000,
+    )
+
+    // --- What the close control does ------------------------------------------------------------
+
+    @Test
+    fun `closing quits unless the user asked for the tray`() {
+        assertEquals(
+            WindowCloseIntent.Quit,
+            windowCloseIntent(closeToTray = false, traySupported = true),
+        )
+        assertEquals(
+            WindowCloseIntent.HideToTray,
+            windowCloseIntent(closeToTray = true, traySupported = true),
+        )
+    }
+
+    @Test
+    fun `a desktop with no tray closes even when the preference says otherwise`() {
+        // The failure this prevents is the worst one available: a hidden window, a playing process,
+        // and no icon anywhere to reach either of them from.
+        assertEquals(
+            WindowCloseIntent.Quit,
+            windowCloseIntent(closeToTray = true, traySupported = false),
+        )
+    }
+
+    // --- What the tray says ---------------------------------------------------------------------
+
+    @Test
+    fun `the tooltip names the chapter, the serial and whether it is running`() {
+        assertEquals("TTSRoad — Playing: Chapter 41 · A Test Serial", trayTooltip(playing))
+        assertEquals("TTSRoad — Paused: Chapter 41 · A Test Serial", trayTooltip(playing.copy(isPlaying = false)))
+    }
+
+    @Test
+    fun `with nothing loaded the tooltip is just the app name`() {
+        // Not "TTSRoad — nothing playing": a tray tooltip that reports absence is noise.
+        assertEquals("TTSRoad", trayTooltip(PlayerUiState()))
+    }
+
+    @Test
+    fun `a chapter with no serial behind it still names itself`() {
+        assertEquals("Chapter 41", trayNowPlayingLabel(playing.copy(fictionTitle = null)))
+        assertEquals("TTSRoad — Playing: Chapter 41", trayTooltip(playing.copy(fictionTitle = null)))
+    }
+
+    @Test
+    fun `there is no now-playing entry to draw before anything has loaded`() {
+        // An empty tooltip simply does not appear; an empty menu entry is a blank clickable row.
+        assertNull(trayNowPlayingLabel(PlayerUiState()))
+    }
+
+    @Test
+    fun `the play-pause entry names the action rather than the state`() {
+        assertEquals("Pause", trayPlayPauseLabel(playing))
+        assertEquals("Play", trayPlayPauseLabel(playing.copy(isPlaying = false)))
+    }
+}


### PR DESCRIPTION
Addresses the **minimise to tray, with a mini player** item (§2) in #41.

An audiobook client is a background listening surface, and this one had to keep a window to keep playing. Where the desktop offers a tray, TTSRoad now puts an icon there with the chapter and serial as its tooltip, play/pause, both skips, *Show TTSRoad* and *Quit*.

`ui/TrayPresentation.kt` holds the rules as pure functions and `Main` holds the plumbing — the same split as `MprisState`/`MprisService`, for the same reason: the interesting half is testable with no tray, no bus and no display. The tooltip reuses the MPRIS audiobook mapping, because a media applet and a tray tooltip answer the same question on the same desktop and two different answers would look like a bug in one of them.

## The two decisions, recorded in ADR 0006

- **Closing quits, unless the user asked otherwise.** This is exactly the question #41 flags as the part worth getting right. The tie breaks on which surprise is worse: a close control that closes is what every other window on the desktop does, while the reverse leaves a process running and holding a media session for someone who believed they had quit. So it is a Playback setting, it **defaults to off**, and the first close-to-tray sends one tray notification saying TTSRoad is still running. *Once* — by the second time the user knows, and a notification on every close is the tray noise this feature exists to avoid.
- **The platform gets a veto.** `windowCloseIntent` requires *both* the preference and `isTraySupported`. Several Wayland sessions ship without a tray, and hiding a window into an icon the platform will not draw leaves a running process the user can neither see nor quit — strictly worse than either honest answer. Where there is none, Settings explains that instead of offering a dead switch.

`WindowPlacement` carries the flag, so geometry and behaviour now share `window.json`. They are written by different hands at different times — geometry once as the window closes, against the placement loaded at startup; the preference whenever Settings is touched — so the close handler merges through `withBehaviourOf` rather than saving the startup snapshot wholesale, which would silently revert a setting changed five minutes earlier.

MPRIS `Raise` un-hides as well as raising (after a close-to-tray the window is not merely behind something), and a shell's `Quit` quits rather than hides. The tray is skipped under `--smoke-test`, for the reason MPRIS is.

## Coverage

- `TrayPresentationTest` — the close rule including the no-tray veto, the tooltip with and without a serial, the empty case, and the play/pause label.
- `WindowPreferencesTest` — the quit-by-default guarantee, that clamping a window back onto a display leaves behaviour alone, and that saving this run's geometry does not undo a preference changed since startup.
- `SettingsScreenUiTest` — the toggle is off and reports a change; a desktop with no tray gets an explanation and no switch.

## Validation

```
xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail -Pttsroad.warningsAsErrors=true
xvfb-run -a ./gradlew --no-daemon run --args="--smoke-test"
```

Both `BUILD SUCCESSFUL`; the smoke run reports `TTSRoad 1.0.2 smoke test OK`.