### PR TITLE
Give each serial its own playback speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ All notable changes to TTSRoad Desktop are recorded here. The format follows
 
 ### Added
 
+- Per-book playback speed. Changing speed in the player now sets it for the serial that is playing,
+  since different narrators want different paces; Settings owns the default every book starts at,
+  and a book with its own rate offers a one-click way back to that default.
 - A system tray icon with the transport on it, so the app can get out of the way without stopping.
   It names the chapter and serial, offers play/pause and the two skips, and its Quit entry always
   stops the app for good. **Closing the window still quits by default** — the new Playback setting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,12 @@ apply to audio.
   the store and pushes rate/gain/skip-silence to the engine, so an auto-advanced chapter and a
   media-key start use the same values as one the user pressed play on. `setSpeed` writes the
   *preference*; the collector is the only thing that touches the engine.
+- **Speed is per serial, with a default.** `fictionSpeeds` in `playback.json` overrides `speed` for
+  one fiction id; `setSpeed` writes the loaded serial's entry and only falls back to the default
+  when nothing is loaded. Fiction ids are safe in this account-less file because a fiction is a
+  shared server object. `reapplyRate` is the **single writer** of the rate and holds `rateLock`:
+  the preference collector and a queue being loaded otherwise interleave as compute-then-write, and
+  a stale answer landing last leaves the engine and the UI disagreeing until the next change.
 - `player/SleepTimer.kt` — a state machine over an injected clock, ticked by the controller's
   existing 250 ms loop. No coroutine, no `delay`: determinism under a fake clock is an acceptance
   criterion. Fade gain is published as a multiplier and combined with the volume boost in one place,

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ full evidence table is in [`docs/QUALITY-GATE.md`](docs/QUALITY-GATE.md).
 | **MP3 audio playback** | ✅ |
 | Settings — two-pane control centre (account, devices, playback, offline, audiobooks, about) | ✅ |
 | Device sessions — list, mark current, revoke one / revoke all others | ✅ |
-| Playback preferences — speed, skip interval, skip silence, volume boost | ✅ |
+| Playback preferences — default + per-book speed, skip interval, skip silence, volume boost | ✅ |
 | Sleep timer — 5/15/30/45/60 min or end of chapter, with a fade and "+5 min" | ✅ |
 | Cross-device listening history — local-first "Jump back in", dismissible per snapshot | ✅ |
 | MPRIS over D-Bus — Cinnamon applet, lock screen, hardware media keys | ✅ Linux |

--- a/docs/adr/0006-listening-preferences-and-desktop-integration.md
+++ b/docs/adr/0006-listening-preferences-and-desktop-integration.md
@@ -49,6 +49,36 @@ Speed gets one extra rule. The offered list always contains the *stored* value e
 one of this build's presets, so a rate set by another build stays selectable instead of being
 silently rounded away the first time the menu is opened.
 
+### Speed is per serial, over a default
+
+`speed` is the rate every book starts at; `fictionSpeeds` overrides it for one fiction id. The
+player's control writes the **loaded serial's** entry and only falls back to the default when
+nothing is loaded, because that is the question a listener at the transport is actually answering:
+different narrators want different paces, and a pace chosen for a dense translation should not
+follow them into the next book. Settings owns the default, where it reads as one.
+
+Three consequences worth recording:
+
+- **The way back is drawn only when there is something to go back to.** A row that always carried a
+  "use the default" entry would imply an override exists whenever a book is open; a row that never
+  carried one would leave a rate the listener could change and not undo. It also *names* the
+  default — "use 1.25×" — because asking someone to remember a number from another screen is not
+  offering them a way back.
+- **Fiction ids are safe in this account-less file.** A fiction is a shared server object, not a
+  per-account one, so an id here says nothing about who read it — the same reasoning that lets two
+  accounts under one OS login share the rest of the file.
+- **The map is bounded, oldest first.** `playback.json` is written for the life of the install, so
+  an unbounded map would be a slow leak on exactly the machines of the people who use the app most.
+  Insertion order is the only ordering a stored map has, and the least recently *set* rate is the
+  least likely to be missed.
+
+`reapplyRate` is the single writer of the rate, and it holds a lock. Two paths resolve one
+concurrently — the preference collector and a queue being loaded — and without serialisation they
+interleave as *compute, then write*: a collector that resolved the rate before a queue arrived can
+land its now-stale answer after the queue applied the serial's own, leaving the engine on one rate
+and the UI showing another until the next preference change. That is not a hypothetical; it showed
+up as a flaky test the first time both paths existed.
+
 ### The later account preference API does not change that ownership
 
 Issue #35 revisited this decision after the server added `player_preferences`, with account keys for

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackPreferences.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackPreferences.kt
@@ -42,8 +42,40 @@ data class PlaybackPreferences(
      */
     val skipSilence: Boolean = false,
     val volumeBoost: VolumeBoost = VolumeBoost.Off,
+    /**
+     * Rates that belong to one serial rather than to the listener in general.
+     *
+     * Different narrators want different paces, and a listener who slows down for a dense
+     * translation should not have to remember to speed back up for the next book. [speed] stays the
+     * default; an entry here overrides it while that serial is playing.
+     *
+     * Keyed by fiction id, which is safe to keep in this account-less file for the same reason the
+     * rest of it is: a fiction is a **shared** server object, not a per-account one, so an id here
+     * says nothing about who read it. Bounded, because it grows for the life of the install.
+     */
+    val fictionSpeeds: Map<Int, Float> = emptyMap(),
 ) {
+    /** The rate to play [fictionId] at: its own, or the listener's default. */
+    fun speedFor(fictionId: Int): Float = fictionSpeeds[fictionId] ?: speed
+
+    /** Sets one serial's rate, or clears it back to the default with a null [speed]. */
+    fun withFictionSpeed(fictionId: Int, speed: Float?): PlaybackPreferences {
+        if (fictionId <= 0) return this
+        val next = if (speed == null) fictionSpeeds - fictionId else fictionSpeeds + (fictionId to speed)
+        return copy(fictionSpeeds = next)
+    }
+
     companion object {
+        /**
+         * How many serials keep their own rate.
+         *
+         * A bound rather than a policy about *which* to forget: this file is written for the life
+         * of the install, and an unbounded map would be a slow leak on exactly the machines of the
+         * people who use the app most. Oldest-first, because insertion order is the only ordering
+         * the stored map has and the least recently *set* is the least likely to be missed.
+         */
+        const val MaxFictionSpeeds: Int = 200
+
         const val DefaultSpeed: Float = 1f
         const val MinSpeed: Float = 0.5f
         const val MaxSpeed: Float = 3.0f
@@ -108,6 +140,8 @@ internal data class StoredPlaybackPreferences(
     val skipIntervalSeconds: Int? = null,
     val skipSilence: Boolean? = null,
     val volumeBoost: String? = null,
+    /** JSON object keys are strings; a key that is not an id at all is dropped rather than fatal. */
+    val fictionSpeeds: Map<String, Float>? = null,
 ) {
     fun toPreferences(): PlaybackPreferences = PlaybackPreferences(
         speed = PlaybackPreferences.normaliseSpeed(speed ?: PlaybackPreferences.DefaultSpeed),
@@ -118,6 +152,9 @@ internal data class StoredPlaybackPreferences(
         // An unrecognised name falls back to Off rather than to the loudest thing in the enum.
         volumeBoost = VolumeBoost.entries.firstOrNull { it.name.equals(volumeBoost, ignoreCase = true) }
             ?: VolumeBoost.Off,
+        fictionSpeeds = fictionSpeeds.orEmpty()
+            .mapNotNull { (key, value) -> key.toIntOrNull()?.takeIf { it > 0 }?.let { it to value } }
+            .toMap(),
     )
 
     companion object {
@@ -130,6 +167,7 @@ internal data class StoredPlaybackPreferences(
             skipIntervalSeconds = preferences.skipIntervalSeconds,
             skipSilence = preferences.skipSilence,
             volumeBoost = preferences.volumeBoost.name,
+            fictionSpeeds = preferences.fictionSpeeds.mapKeys { (id, _) -> id.toString() },
         )
     }
 }
@@ -208,4 +246,17 @@ class FilePlaybackPreferencesStore(
 internal fun PlaybackPreferences.sanitised(): PlaybackPreferences = copy(
     speed = PlaybackPreferences.normaliseSpeed(speed),
     skipIntervalSeconds = PlaybackPreferences.normaliseSkipSeconds(skipIntervalSeconds),
+    // Trimmed from the front: a `LinkedHashMap` keeps insertion order, so the oldest entry is the
+    // one whose rate was set longest ago and is least likely to be missed.
+    fictionSpeeds = fictionSpeeds
+        .filterKeys { it > 0 }
+        .mapValues { (_, rate) -> PlaybackPreferences.normaliseSpeed(rate) }
+        .let { rates ->
+            if (rates.size <= PlaybackPreferences.MaxFictionSpeeds) {
+                rates
+            } else {
+                rates.entries.drop(rates.size - PlaybackPreferences.MaxFictionSpeeds)
+                    .associate { it.key to it.value }
+            }
+        },
 )

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackController.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackController.kt
@@ -42,6 +42,14 @@ data class PlayerUiState(
      */
     val canChangeSpeed: Boolean = false,
     /**
+     * Whether [speed] came from this serial's own rate rather than the listener's default.
+     *
+     * The player needs to distinguish them to offer a way back: a rate that silently overrode the
+     * default with no visible sign and no way to clear it would be a setting the user could not
+     * find again.
+     */
+    val speedIsPerFiction: Boolean = false,
+    /**
      * Whether this backend can drop silent passages.
      *
      * Same rule as [canChangeSpeed]: the control is drawn only where the engine can honour it.
@@ -124,7 +132,17 @@ interface PlaybackController {
     fun skipToQueueIndex(index: Int)
 
     /** Requests a playback rate. What the backend actually applied appears in [state]. */
+    /**
+     * Sets the rate for the serial that is loaded, or the listener's default when none is.
+     *
+     * Per-serial because that is the question a listener is actually answering: different narrators
+     * want different paces, and the pace chosen for a dense translation should not follow them into
+     * the next book. Settings owns the default; this owns the exception.
+     */
     fun setSpeed(speed: Float)
+
+    /** Drops the loaded serial's own rate so it follows the default again. No-op with none set. */
+    fun clearFictionSpeed() = Unit
 
     /** Arms, re-arms or (with [SleepTimerMode.Off]) cancels the sleep timer. */
     fun setSleepTimer(mode: SleepTimerMode) = Unit

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
@@ -113,6 +113,24 @@ class QueuePlaybackController(
 
     @Volatile private var speed = preferencesStore.preferences.value.speed
 
+    /**
+     * The serial whose rate is in force, or 0 for none.
+     *
+     * Held separately from [queueFiction] because the rate has to be resolved from the *chapter*
+     * when playback started from a library shelf, which carries no `FictionSummary` at all.
+     */
+    @Volatile private var speedFictionId = 0
+
+    /**
+     * Serialises every path that resolves a rate.
+     *
+     * Two of them run concurrently: the preference collector and a queue being loaded. Without a
+     * lock they interleave as *compute, then write*, so a collector that resolved the rate before a
+     * queue arrived could land its now-stale answer after the queue had applied the serial's own —
+     * leaving the engine on one rate and the UI showing another until the next preference change.
+     */
+    private val rateLock = Any()
+
     /** Playing time since the last cross-device jump-back breadcrumb. Pauses add nothing. */
     private var playedSinceHistoryRecordMs = 0L
 
@@ -133,16 +151,10 @@ class QueuePlaybackController(
         // the restored preferences would take effect one chapter late.
         scope.launch {
             preferencesStore.preferences.collect { preferences ->
-                speed = preferences.speed
-                val applied = engine.setRate(preferences.speed)
+                reapplyRate()
                 engine.setSkipSilence(preferences.skipSilence)
                 applyGain()
-                _state.update {
-                    it.copy(
-                        speed = applied,
-                        skipIntervalMs = preferences.skipIntervalMs,
-                    )
-                }
+                _state.update { it.copy(skipIntervalMs = preferences.skipIntervalMs) }
             }
         }
 
@@ -171,6 +183,40 @@ class QueuePlaybackController(
         skipIntervalMs = preferencesStore.preferences.value.skipIntervalMs,
         sleepTimer = sleepTimer.state.value,
     )
+
+    /**
+     * Points the rate at the serial now loaded, and applies its rate if that changes anything.
+     *
+     * Called as the queue's fiction is established rather than on every chapter, because
+     * auto-advance stays inside one serial and re-pushing an unchanged rate to the engine mid-book
+     * is a needless pipeline poke.
+     */
+    private fun useFictionSpeed(fictionId: Int) {
+        val next = fictionId.takeIf { it > 0 } ?: 0
+        if (next == speedFictionId) return
+        reapplyRate(next)
+    }
+
+    /**
+     * Resolves the rate from the current preferences and the loaded serial, and pushes it.
+     *
+     * The single writer of [speed], so the value the engine holds and the value the UI shows can
+     * never disagree about which serial they were derived from. Reads the store rather than taking
+     * a snapshot argument for the same reason: inside the lock, "current" has one meaning.
+     */
+    private fun reapplyRate(fictionId: Int? = null) = synchronized(rateLock) {
+        fictionId?.let { speedFictionId = it }
+        val preferences = preferencesStore.preferences.value
+        val wanted = preferences.speedFor(speedFictionId)
+        speed = wanted
+        val applied = engine.setRate(wanted)
+        _state.update {
+            it.copy(
+                speed = applied,
+                speedIsPerFiction = preferences.fictionSpeeds.containsKey(speedFictionId),
+            )
+        }
+    }
 
     override suspend fun play(chapter: ChapterSummary, fiction: FictionSummary?) {
         if (chapter.audio == null) {
@@ -202,6 +248,7 @@ class QueuePlaybackController(
         queue = listOf(chapter)
         queueFiction = fiction
         queueOwnerKey = ownerKey()
+        useFictionSpeed(fictionIdOf(chapter, fiction))
         begin(0, resumeMsOf(chapter), leaveCurrent = false)
     }
 
@@ -224,6 +271,7 @@ class QueuePlaybackController(
         queue = playable
         queueFiction = fiction
         queueOwnerKey = ownerKey()
+        useFictionSpeed(fictionIdOf(playable.first(), fiction))
         val startIndex = playable.indexOfFirst { it.resolvedChapterId == startChapterId }.coerceAtLeast(0)
         // An explicit start position only applies to the chapter that was asked for. Falling back
         // to the saved position when the requested chapter is not in the queue is what stops a
@@ -296,7 +344,21 @@ class QueuePlaybackController(
         //
         // An engine that cannot resample still stores the wish — a listener who set 1.5× on a
         // machine without GStreamer and later installs it should find 1.5× waiting.
-        preferencesStore.update { it.copy(speed = speed) }
+        //
+        // With a serial loaded this is *that serial's* rate: a listener slowing down for a dense
+        // translation is answering a question about the narrator in front of them, not about every
+        // book they will ever open. The default lives in Settings, where it reads as a default.
+        val fictionId = speedFictionId
+        if (fictionId > 0) {
+            preferencesStore.update { it.withFictionSpeed(fictionId, speed) }
+        } else {
+            preferencesStore.update { it.copy(speed = speed) }
+        }
+    }
+
+    override fun clearFictionSpeed() {
+        val fictionId = speedFictionId.takeIf { it > 0 } ?: return
+        preferencesStore.update { it.withFictionSpeed(fictionId, null) }
     }
 
     override fun setSleepTimer(mode: SleepTimerMode) {
@@ -619,6 +681,7 @@ class QueuePlaybackController(
         durationMs = ((chapter.audioDuration ?: 0.0) * 1000).toLong(),
         positionMs = positionMs,
         speed = engine.capabilities.coerceSpeed(speed),
+        speedIsPerFiction = preferencesStore.preferences.value.fictionSpeeds.containsKey(speedFictionId),
         canChangeSpeed = engine.capabilities.variableSpeed,
         canSkipSilence = engine.capabilities.skipSilence,
         // Rebuilt from the live values rather than copied from the previous state: this function

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreen.kt
@@ -279,7 +279,14 @@ private fun PlayerMain(
         // then there is no control at all rather than one that silently does nothing.
         if (s.canChangeSpeed) {
             Spacer(Modifier.height(18.dp))
-            SpeedControl(current = s.speed, enabled = s.hasMedia) { playback.setSpeed(it) }
+            SpeedControl(
+                current = s.speed,
+                enabled = s.hasMedia,
+                perFiction = s.speedIsPerFiction,
+                defaultSpeed = prefs.speed,
+                onSelect = playback::setSpeed,
+                onUseDefault = playback::clearFictionSpeed,
+            )
         }
         // Skip-silence belongs next to speed rather than only in Settings: both change how long
         // the chapter takes, and a listener reaching for one is usually reaching for the other.
@@ -332,10 +339,25 @@ private fun PlayerMain(
 private val SpeedPresets = listOf(0.75f, 1f, 1.25f, 1.5f, 1.75f, 2f, 3f)
 
 const val SpeedChipTestTag = "player-speed-chip"
+const val SpeedDefaultChipTestTag = "player-speed-default"
 const val RetryButtonTestTag = "player-retry"
 
+/**
+ * The rate row, which sets the rate for *this serial* while one is loaded.
+ *
+ * The way back is drawn only when there is something to go back to. A row that always carried a
+ * "use default" entry would imply an override exists whenever a serial is open, and a row that
+ * never carried one would leave a rate the listener could change but not undo.
+ */
 @Composable
-private fun SpeedControl(current: Float, enabled: Boolean, onSelect: (Float) -> Unit) {
+private fun SpeedControl(
+    current: Float,
+    enabled: Boolean,
+    perFiction: Boolean,
+    defaultSpeed: Float,
+    onSelect: (Float) -> Unit,
+    onUseDefault: () -> Unit,
+) {
     Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
         MetaText("Speed", color = AarisColor.Dim)
         SpeedPresets.forEach { preset ->
@@ -354,6 +376,19 @@ private fun SpeedControl(current: Float, enabled: Boolean, onSelect: (Float) -> 
                     .clickable(enabled = enabled) { onSelect(preset) }
                     .pointerHoverIcon(PointerIcon.Hand)
                     .padding(horizontal = 8.dp, vertical = 4.dp),
+            )
+        }
+        if (perFiction) {
+            Text(
+                text = "THIS BOOK ONLY · USE ${formatSpeed(defaultSpeed)}",
+                color = if (enabled) AarisColor.Muted else AarisColor.Dim,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier
+                    .testTag(SpeedDefaultChipTestTag)
+                    .clickable(enabled = enabled, onClick = onUseDefault)
+                    .pointerHoverIcon(PointerIcon.Hand)
+                    .padding(horizontal = 8.dp, vertical = 4.dp)
+                    .semantics { contentDescription = "Use the default speed for this book" },
             )
         }
     }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
@@ -703,7 +703,7 @@ private fun PlaybackPane(
     SettingsCard {
         if (canChangeSpeed) {
             ChoiceRow(
-                label = "SPEED",
+                label = "DEFAULT SPEED",
                 // The offered list carries the stored value even when it is not a preset, so a
                 // rate set by another build stays selectable instead of vanishing on first open.
                 options = PlaybackPreferences.speedOptions(prefs.speed),
@@ -711,8 +711,17 @@ private fun PlaybackPane(
                 labelOf = ::formatSpeed,
                 onSelect = { value -> preferences.update { it.copy(speed = value) } },
             )
+            MetaText(
+                if (prefs.fictionSpeeds.isEmpty()) {
+                    "The rate every book starts at. Changing speed in the player sets it for that " +
+                        "book alone, since different narrators want different paces."
+                } else {
+                    "The rate every book starts at. ${prefs.fictionSpeeds.size} book(s) have " +
+                        "their own rate, set from the player; each can be put back there."
+                },
+            )
         } else {
-            SettingRow("SPEED", "Fixed at ${formatSpeed(1f)}")
+            SettingRow("DEFAULT SPEED", "Fixed at ${formatSpeed(1f)}")
             MetaText(
                 "The audio backend on this computer cannot resample, so speed is not offered " +
                     "rather than offered and ignored. Installing GStreamer enables it.",

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -403,6 +403,10 @@ class FakePlaybackController(initial: PlayerUiState = PlayerUiState()) : Playbac
         calls += "speed($speed)"
     }
 
+    override fun clearFictionSpeed() {
+        calls += "clearFictionSpeed"
+    }
+
     override fun stop() {
         calls += "stop"
     }

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackPreferencesTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/PlaybackPreferencesTest.kt
@@ -164,4 +164,67 @@ class PlaybackPreferencesTest {
         assertFalse(prefsFile.name.contains("session"))
         assertEquals(2f, FilePlaybackPreferencesStore(prefsFile).preferences.value.speed)
     }
+
+    // --- Per-serial rates -------------------------------------------------------------------------
+
+    @Test
+    fun `a serial without its own rate simply uses the default`() {
+        val preferences = PlaybackPreferences(speed = 1.25f, fictionSpeeds = mapOf(7 to 2f))
+
+        assertEquals(2f, preferences.speedFor(7))
+        assertEquals(1.25f, preferences.speedFor(8))
+        assertEquals(1.25f, preferences.speedFor(0), "no serial loaded is not a serial with no rate")
+    }
+
+    @Test
+    fun `setting and clearing one serial's rate leaves the others and the default alone`() {
+        val start = PlaybackPreferences(speed = 1.25f, fictionSpeeds = mapOf(7 to 2f))
+
+        val added = start.withFictionSpeed(8, 0.75f)
+        assertEquals(mapOf(7 to 2f, 8 to 0.75f), added.fictionSpeeds)
+
+        val cleared = added.withFictionSpeed(7, null)
+        assertEquals(mapOf(8 to 0.75f), cleared.fictionSpeeds)
+        assertEquals(1.25f, cleared.speed, "the default is not what the player was changing")
+    }
+
+    @Test
+    fun `a serial rate that is out of range is snapped rather than handed to the engine`() {
+        val store = InMemoryPlaybackPreferencesStore()
+
+        store.update { it.withFictionSpeed(7, 9f).withFictionSpeed(8, -1f) }
+
+        assertEquals(PlaybackPreferences.MaxSpeed, store.preferences.value.fictionSpeeds[7])
+        assertEquals(PlaybackPreferences.MinSpeed, store.preferences.value.fictionSpeeds[8])
+    }
+
+    @Test
+    fun `per-serial rates are bounded, oldest first`() {
+        // This file is written for the life of the install; an unbounded map would leak on exactly
+        // the machines of the people who use the app most.
+        val store = InMemoryPlaybackPreferencesStore()
+
+        store.update { start ->
+            (1..PlaybackPreferences.MaxFictionSpeeds + 5).fold(start) { acc, id ->
+                acc.withFictionSpeed(id, 1.5f)
+            }
+        }
+
+        val kept = store.preferences.value.fictionSpeeds
+        assertEquals(PlaybackPreferences.MaxFictionSpeeds, kept.size)
+        assertFalse(kept.containsKey(1), "the rate set longest ago is the one to forget")
+        assertTrue(kept.containsKey(PlaybackPreferences.MaxFictionSpeeds + 5))
+    }
+
+    @Test
+    fun `per-serial rates round-trip through the file, and a nonsense key is dropped`(@TempDir dir: File) {
+        val file = dir.resolve("playback.json")
+        FilePlaybackPreferencesStore(file).update { it.withFictionSpeed(7, 1.5f) }
+
+        assertEquals(mapOf(7 to 1.5f), FilePlaybackPreferencesStore(file).preferences.value.fictionSpeeds)
+
+        // A file from another build — or a hand-edited one — must load degraded, never throw.
+        file.writeText("""{"version":1,"speed":1.0,"fictionSpeeds":{"7":1.5,"not-an-id":2.0,"0":3.0}}""")
+        assertEquals(mapOf(7 to 1.5f), FilePlaybackPreferencesStore(file).preferences.value.fictionSpeeds)
+    }
 }

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackPreferencesApplyTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackPreferencesApplyTest.kt
@@ -149,6 +149,78 @@ class PlaybackPreferencesApplyTest {
         awaitCondition("the reported speed to stay at 1x") { playback.state.value.speed == 1f }
     }
 
+    // --- Per-serial speed -----------------------------------------------------------------------
+
+    @Test
+    fun `changing speed while a serial is playing sets it for that serial, not for everything`() =
+        runBlocking {
+            val engine = FakePlaybackEngine()
+            val preferences = InMemoryPlaybackPreferencesStore()
+            val playback = controller(engine, preferences)
+            playback.playQueue(listOf(chapter(1)), startChapterId = 1, fiction = null)
+
+            playback.setSpeed(1.5f)
+
+            awaitCondition("the serial's own rate to be stored") {
+                preferences.preferences.value.fictionSpeeds[7] == 1.5f
+            }
+            // The whole point: the next book does not inherit it.
+            assertEquals(1f, preferences.preferences.value.speed)
+            awaitCondition("the engine to be told") { engine.requestedRates.contains(1.5f) }
+            awaitCondition("the player to say the rate belongs to this book") {
+                playback.state.value.speedIsPerFiction
+            }
+        }
+
+    @Test
+    fun `opening a different serial goes back to the default rate`() = runBlocking {
+        val engine = FakePlaybackEngine()
+        val preferences = InMemoryPlaybackPreferencesStore(
+            PlaybackPreferences(speed = 1.25f, fictionSpeeds = mapOf(7 to 2f)),
+        )
+        val playback = controller(engine, preferences)
+
+        playback.playQueue(listOf(chapter(1)), startChapterId = 1, fiction = null)
+        awaitCondition("the serial's own rate") { playback.state.value.speed == 2f }
+
+        val elsewhere = chapter(9).copy(fictionId = 8)
+        playback.playQueue(listOf(elsewhere), startChapterId = 9, fiction = null)
+
+        awaitCondition("the default rate to come back") { playback.state.value.speed == 1.25f }
+        assertFalse(playback.state.value.speedIsPerFiction)
+    }
+
+    @Test
+    fun `clearing a serial's rate puts it back on the default`() = runBlocking {
+        val engine = FakePlaybackEngine()
+        val preferences = InMemoryPlaybackPreferencesStore(
+            PlaybackPreferences(speed = 1.25f, fictionSpeeds = mapOf(7 to 2f)),
+        )
+        val playback = controller(engine, preferences)
+        playback.playQueue(listOf(chapter(1)), startChapterId = 1, fiction = null)
+        awaitCondition("the serial's own rate") { playback.state.value.speed == 2f }
+
+        playback.clearFictionSpeed()
+
+        awaitCondition("the default rate") { playback.state.value.speed == 1.25f }
+        assertTrue(preferences.preferences.value.fictionSpeeds.isEmpty())
+        assertFalse(playback.state.value.speedIsPerFiction)
+    }
+
+    @Test
+    fun `with nothing loaded the speed control still sets the default`() = runBlocking {
+        // The player is reachable before anything plays, and there is no serial to attribute a
+        // rate to — so the only honest thing to change is the default.
+        val engine = FakePlaybackEngine()
+        val preferences = InMemoryPlaybackPreferencesStore()
+        val playback = controller(engine, preferences)
+
+        playback.setSpeed(1.75f)
+
+        awaitCondition("the default to move") { preferences.preferences.value.speed == 1.75f }
+        assertTrue(preferences.preferences.value.fictionSpeeds.isEmpty())
+    }
+
     // --- Skip interval --------------------------------------------------------------------------
 
     @Test

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreenUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreenUiTest.kt
@@ -1,14 +1,19 @@
 package dk.perspektiva.ttsroad.desktop.ui
 
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import dk.perspektiva.ttsroad.desktop.FakePlaybackController
+import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferences
 import dk.perspektiva.ttsroad.desktop.player.PlayerUiState
 import dk.perspektiva.ttsroad.desktop.player.QueueItem
 import kotlin.test.assertEquals
@@ -53,6 +58,38 @@ class PlayerScreenUiTest {
         compose.onAllNodesWithText("Chapter 3 — The Descent").onFirst().assertIsDisplayed()
         // MetaText uppercases its content.
         compose.onNodeWithText("A TEST SERIAL").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a rate that belongs to one book offers the way back to the default`() {
+        val playback = FakePlaybackController(
+            playingState().copy(canChangeSpeed = true, speed = 1.5f, speedIsPerFiction = true),
+        )
+        compose.setContent {
+            TtsRoadTheme {
+                PlayerScreen(
+                    playback,
+                    onBack = {},
+                    preferences = InMemoryPlaybackPreferencesStore(PlaybackPreferences(speed = 1.25f)),
+                )
+            }
+        }
+
+        // Naming the default is the point: "use the default" without saying what it is asks the
+        // listener to remember a number from another screen.
+        compose.onNodeWithTag(SpeedDefaultChipTestTag).assertIsDisplayed().performClick()
+        compose.waitForIdle()
+
+        assertTrue(playback.calls.contains("clearFictionSpeed"), "calls were ${playback.calls}")
+    }
+
+    @Test
+    fun `a book following the default is not offered a way back to it`() {
+        // A row that always carried the entry would imply an override exists whenever a book is open.
+        val playback = FakePlaybackController(playingState().copy(canChangeSpeed = true, speed = 1.25f))
+        compose.setContent { TtsRoadTheme { PlayerScreen(playback, onBack = {}) } }
+
+        compose.onAllNodesWithTag(SpeedDefaultChipTestTag).assertCountEquals(0)
     }
 
     @Test


### PR DESCRIPTION
Addresses the **per-fiction playback speed** item (§6) in #41.

Speed was one number for the whole client. Different narrators want different paces, and a listener who slows down for a dense translation should not have to remember to speed back up for the next book.

`speed` is now the rate every book *starts* at, and `fictionSpeeds` overrides it per fiction id. The player's control writes the **loaded serial's** entry and only falls back to the default when nothing is loaded — that is the question a listener at the transport is actually answering. Settings owns the default, relabelled `DEFAULT SPEED`, and says how many books currently have their own.

## Three decisions, recorded in ADR 0006

- **The way back is drawn only when there is something to go back to.** A row that always carried a "use the default" entry would imply an override exists whenever a book is open; one that never carried it would leave a rate the listener could change and not undo. It *names* the default — "USE 1.25×" — because asking someone to remember a number from another screen is not offering them a way back.
- **Fiction ids are safe in this account-less file.** A fiction is a shared server object, so an id in `playback.json` says nothing about who read it — the same reasoning that already lets two accounts under one OS login share the rest of it. The map is bounded oldest-first, because this file is written for the life of the install.
- **`reapplyRate` is the single writer of the rate, under a lock.** Two paths resolve one concurrently — the preference collector and a queue being loaded — and unserialised they interleave as *compute, then write*: a collector that resolved the rate before a queue arrived lands its stale answer after the queue applied the serial's own, leaving the engine on one rate and the UI showing another until the next preference change. **This is not hypothetical** — it showed up as a flaky test the first time both paths existed, and the lock is what fixed it.

## Coverage

- `PlaybackPreferencesTest` — fallback to the default, set/clear leaving others alone, out-of-range rates snapped, the oldest-first bound, and a file round trip including a nonsense key being dropped rather than fatal.
- `PlaybackPreferencesApplyTest` — changing speed mid-serial stores it under that serial and *not* as the default; opening a different serial returns to the default; clearing restores it; with nothing loaded the control still sets the default.
- `PlayerScreenUiTest` — the way-back entry appears only with an override, and drives the controller.

## Validation

```
xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail -Pttsroad.warningsAsErrors=true
```

`BUILD SUCCESSFUL`, plus three repeat runs of `PlaybackPreferencesApplyTest` to confirm the race is gone.