### PR TITLE
Add listening statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ All notable changes to TTSRoad Desktop are recorded here. The format follows
 
 ### Added
 
+- Listening statistics, in a Settings pane of their own: total hours, chapters finished, the last
+  seven and thirty days, a current and longest streak, days with any listening, and the best day.
+  Computed locally from a bounded two-year file, kept per account on a shared machine, and never
+  sent anywhere.
 - Per-book playback speed. Changing speed in the player now sets it for the serial that is playing,
   since different narrators want different paces; Settings owns the default every book starts at,
   and a book with its own rate offers a one-click way back to that default.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,13 @@ apply to audio.
   criterion. Fade gain is published as a multiplier and combined with the volume boost in one place,
   so cancelling a fade restores the boost rather than unity. End-of-chapter is checked *before* the
   auto-advance and disarms itself.
+- `data/ListeningStats.kt` — day totals in `listening.json`, bounded to 730 rows and keyed by the
+  same hashed owner key the history uses, so two accounts on one machine never pool their hours.
+  The controller banks *playing* ticks — never wall time, so a suspended laptop is not a night of
+  listening — batched to once a minute and flushed at every transition. A chapter counts finished
+  only when it ran to its end; marking one played by hand does not. Nothing is sent to the server.
+  `summarise` takes `today` as an argument because a streak is the one number that changes without
+  anyone listening.
 - `data/PlaybackHistory.kt` — a bounded local-first fallback, 60 entries and one per chapter;
   `SyncedPlaybackHistoryStore` writes the same `kind=auto` bookmarks as the web and merges a full
   server pull without replacing newer offline work. The controller records at transitions and

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ full evidence table is in [`docs/QUALITY-GATE.md`](docs/QUALITY-GATE.md).
 | Playback preferences — default + per-book speed, skip interval, skip silence, volume boost | ✅ |
 | Sleep timer — 5/15/30/45/60 min or end of chapter, with a fade and "+5 min" | ✅ |
 | Cross-device listening history — local-first "Jump back in", dismissible per snapshot | ✅ |
+| Listening statistics — hours, chapters finished, streaks, computed locally | ✅ |
 | MPRIS over D-Bus — Cinnamon applet, lock screen, hardware media keys | ✅ Linux |
 | System tray transport, and an optional keep-playing-on-close | ✅ where the desktop has a tray |
 | App shortcuts — Space, arrows, Ctrl+arrows, Ctrl+L, Ctrl+, plus an F1 list | ✅ |

--- a/docs/adr/0006-listening-preferences-and-desktop-integration.md
+++ b/docs/adr/0006-listening-preferences-and-desktop-integration.md
@@ -307,6 +307,33 @@ wholesale, which would silently revert a setting changed five minutes earlier.
 MPRIS `Raise` un-hides as well as raising, since after a close-to-tray the window is not merely
 behind something, and `Quit` from a shell quits rather than hiding: a client asking a player to quit
 is not asking it to get out of the way.
+### Listening statistics are days, not sessions
+
+`listening.json` holds one row per account per calendar day: seconds and chapters finished. A day
+is the coarsest unit that still answers all three questions worth asking — hours, chapters, a
+streak — and storing sessions instead would mean keeping a minute-resolution record of *when*
+somebody listened, for years, to answer questions that never needed it.
+
+- **Per account, on a shared machine.** Rows carry the same hashed owner key the history uses.
+  "You have listened for 300 hours" is a claim about a person; pooling two accounts would be wrong
+  in the direction that flatters.
+- **Playing ticks, never wall time.** The controller counts the same 250 ms tick the rest of the
+  loop runs on, and only while playing — a laptop suspended mid-chapter must not wake up having
+  listened for five hours, and a player left paused overnight has listened for nothing.
+- **Batched, but not much.** Flushed once a minute of playing time and at every transition, so four
+  writes a second are avoided while a crash can lose under a minute of a total measured in hours.
+- **Finished means finished.** A chapter counts when it ran to its end. Marking one played by hand
+  says the listener is done with it, not that they heard it.
+- **Bounded at two years**, oldest first, because this file is appended to for the life of the
+  install.
+- `summarise` takes `today` as an argument. A streak is the one number here that changes without
+  anyone listening — it has to reach zero the day after it lapses — and a function that read the
+  clock could not be asserted on that at all. Today *or yesterday* keeps a streak alive: counting
+  only from today would report a broken streak every morning until the first chapter of the day,
+  which is both wrong and demoralising in a feature whose purpose is encouragement.
+
+Nothing here is sent to the server, and there is no account contract for it. It is local
+computation over local facts, and the file has nowhere to put a title, a chapter id or a URL.
 
 ## Consequences
 

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -548,6 +548,8 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                     closeToTray = closeToTray,
                                     onCloseToTrayChange = container::setCloseToTray,
                                     traySupported = traySupported,
+                                    listeningStats = container.listeningStats,
+                                    historyOwnerKey = container.historyOwnerKey(),
                                     updates = updates,
                                     // Keeps the destination and the open pane in step, so the
                                     // Devices deep link and the in-screen pane list are the same

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ListeningStats.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ListeningStats.kt
@@ -1,0 +1,244 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dk.perspektiva.ttsroad.desktop.security.SecureFiles
+import java.io.File
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * One account's listening on one calendar day.
+ *
+ * A day rather than a session, because every question worth answering here — hours, chapters, a
+ * streak — is a question about days, and storing sessions would mean storing *when* somebody
+ * listened at minute resolution for years. A day is the coarsest unit that still answers all three.
+ *
+ * [ownerKey] is the same hashed server-plus-account key `PlaybackHistory` uses. Two accounts on one
+ * machine keep separate totals: "you have listened for 300 hours" is a claim about a person, and
+ * pooling it across accounts would be wrong in the direction that flatters.
+ */
+data class ListeningDay(
+    val ownerKey: String = "",
+    /** ISO-8601 local date, `2026-08-14`. Local, because a listener's "day" is their own. */
+    val date: String = "",
+    val seconds: Double = 0.0,
+    val chaptersFinished: Int = 0,
+) {
+    val key: String get() = "$ownerKey@$date"
+}
+
+/** What the Listening pane shows, derived rather than stored — see [ListeningStats.summarise]. */
+data class ListeningSummary(
+    val seconds: Double = 0.0,
+    val chaptersFinished: Int = 0,
+    val daysListened: Int = 0,
+    /** Consecutive days ending today or yesterday; 0 once a day has been missed. */
+    val currentStreakDays: Int = 0,
+    val longestStreakDays: Int = 0,
+    val bestDaySeconds: Double = 0.0,
+    val last7DaysSeconds: Double = 0.0,
+    val last30DaysSeconds: Double = 0.0,
+) {
+    val hasAnything: Boolean get() = seconds > 0.0 || chaptersFinished > 0
+}
+
+object ListeningStats {
+    /**
+     * How many day rows are kept.
+     *
+     * Two years of daily listening, and a hard bound on a file that is otherwise appended to for
+     * the life of the install. Trimmed oldest-first, which is also the order in which a total stops
+     * being interesting.
+     */
+    const val MaxDays: Int = 730
+
+    /** The local date [millis] falls on, in [zone]. */
+    fun dateOf(millis: Long, zone: ZoneId = ZoneId.systemDefault()): String =
+        Instant.ofEpochMilli(millis).atZone(zone).toLocalDate().toString()
+
+    /**
+     * Adds listening to one account's day, creating the row if this is the first of it.
+     *
+     * Negative or non-finite input is dropped rather than clamped to zero: it can only come from a
+     * clock that moved, and a wrong number is worse here than a missing one — these totals are only
+     * ever read by the person they are about, who will notice an afternoon that never happened.
+     */
+    fun record(
+        days: List<ListeningDay>,
+        ownerKey: String,
+        date: String,
+        seconds: Double = 0.0,
+        chaptersFinished: Int = 0,
+    ): List<ListeningDay> {
+        if (ownerKey.isBlank() || date.isBlank()) return days
+        val added = seconds.takeIf { it.isFinite() && it > 0.0 } ?: 0.0
+        val finished = chaptersFinished.coerceAtLeast(0)
+        if (added == 0.0 && finished == 0) return days
+
+        val key = "$ownerKey@$date"
+        val existing = days.firstOrNull { it.key == key }
+        val updated = (existing ?: ListeningDay(ownerKey = ownerKey, date = date)).let {
+            it.copy(seconds = it.seconds + added, chaptersFinished = it.chaptersFinished + finished)
+        }
+        // Sorted by date so the bound trims the oldest, and so streaks read a sequence rather than
+        // whatever order the file happened to be written in.
+        return (days.filterNot { it.key == key } + updated)
+            .sortedBy { it.date }
+            .let { if (it.size <= MaxDays) it else it.takeLast(MaxDays) }
+    }
+
+    /**
+     * Totals for one account.
+     *
+     * `today` is passed in rather than read, because a streak is the one number here that changes
+     * without anyone listening: it has to become 0 the day after it lapses, and a test that cannot
+     * choose "today" cannot assert that at all.
+     */
+    fun summarise(days: List<ListeningDay>, ownerKey: String, today: LocalDate): ListeningSummary {
+        val mine = days.filter { it.ownerKey == ownerKey }
+        if (mine.isEmpty()) return ListeningSummary()
+
+        val dates = mine.mapNotNull { day ->
+            runCatching { LocalDate.parse(day.date) }.getOrNull()?.let { it to day }
+        }.sortedBy { it.first }
+
+        val listened = dates.filter { it.second.seconds > 0.0 }.map { it.first }.toSet()
+        return ListeningSummary(
+            seconds = mine.sumOf { it.seconds },
+            chaptersFinished = mine.sumOf { it.chaptersFinished },
+            daysListened = listened.size,
+            currentStreakDays = currentStreak(listened, today),
+            longestStreakDays = longestStreak(listened),
+            bestDaySeconds = mine.maxOf { it.seconds },
+            last7DaysSeconds = sumSince(dates, today.minusDays(6)),
+            last30DaysSeconds = sumSince(dates, today.minusDays(29)),
+        )
+    }
+
+    private fun sumSince(dates: List<Pair<LocalDate, ListeningDay>>, from: LocalDate): Double =
+        dates.filter { !it.first.isBefore(from) }.sumOf { it.second.seconds }
+
+    /**
+     * Today counts, and so does yesterday.
+     *
+     * Counting only from today would report a broken streak every morning until the first chapter
+     * of the day, which is both wrong and demoralising in a feature whose entire purpose is
+     * encouragement.
+     */
+    private fun currentStreak(listened: Set<LocalDate>, today: LocalDate): Int {
+        var cursor = when {
+            today in listened -> today
+            today.minusDays(1) in listened -> today.minusDays(1)
+            else -> return 0
+        }
+        var streak = 0
+        while (cursor in listened) {
+            streak++
+            cursor = cursor.minusDays(1)
+        }
+        return streak
+    }
+
+    private fun longestStreak(listened: Set<LocalDate>): Int {
+        var longest = 0
+        listened.forEach { day ->
+            // Only count from the *start* of a run, so an n-day run is walked once rather than n
+            // times — the difference between linear and quadratic over two years of rows.
+            if (day.minusDays(1) in listened) return@forEach
+            var streak = 0
+            var cursor = day
+            while (cursor in listened) {
+                streak++
+                cursor = cursor.plusDays(1)
+            }
+            longest = maxOf(longest, streak)
+        }
+        return longest
+    }
+}
+
+/** Seam so tests never touch the real user config directory. */
+interface ListeningStatsStore {
+    val days: StateFlow<List<ListeningDay>>
+
+    fun record(ownerKey: String, date: String, seconds: Double = 0.0, chaptersFinished: Int = 0)
+
+    fun clear()
+}
+
+class InMemoryListeningStatsStore(
+    initial: List<ListeningDay> = emptyList(),
+) : ListeningStatsStore {
+    private val _days = MutableStateFlow(initial)
+    override val days: StateFlow<List<ListeningDay>> = _days.asStateFlow()
+
+    @Synchronized
+    override fun record(ownerKey: String, date: String, seconds: Double, chaptersFinished: Int) {
+        _days.value = ListeningStats.record(_days.value, ownerKey, date, seconds, chaptersFinished)
+    }
+
+    @Synchronized
+    override fun clear() {
+        _days.value = emptyList()
+    }
+}
+
+/**
+ * `listening.json` beside the other non-secret local files, written owner-only.
+ *
+ * Machine-local for the same reason the history is: these are totals about listening *done here*,
+ * they must survive a sign-out, and there is no server contract for them. The account key inside
+ * each row is what keeps two accounts on one machine apart; it is the same hashed key the history
+ * uses, so nothing here names a server or a person either.
+ */
+class FileListeningStatsStore(
+    private val file: File = defaultFile(),
+) : ListeningStatsStore {
+    private val adapter = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+        .adapter<List<ListeningDay>>(
+            Types.newParameterizedType(List::class.java, ListeningDay::class.java),
+        )
+
+    private val _days = MutableStateFlow(read())
+    override val days: StateFlow<List<ListeningDay>> = _days.asStateFlow()
+
+    @Synchronized
+    override fun record(ownerKey: String, date: String, seconds: Double, chaptersFinished: Int) {
+        val next = ListeningStats.record(_days.value, ownerKey, date, seconds, chaptersFinished)
+        if (next == _days.value) return
+        _days.value = next
+        write(next)
+    }
+
+    @Synchronized
+    override fun clear() {
+        _days.value = emptyList()
+        write(emptyList())
+    }
+
+    private fun write(days: List<ListeningDay>) {
+        runCatching { SecureFiles.writeAtomically(file, adapter.toJson(days)) }
+            .onFailure { AppLog.warn("could not write the listening statistics file", it) }
+    }
+
+    private fun read(): List<ListeningDay> =
+        runCatching { if (file.isFile) adapter.fromJson(file.readText()) else null }
+            .onFailure { AppLog.warn("could not read the listening statistics file", it) }
+            .getOrNull()
+            ?.filter { it.ownerKey.isNotBlank() && it.date.isNotBlank() }
+            ?.sortedBy { it.date }
+            ?.takeLast(ListeningStats.MaxDays)
+            ?: emptyList()
+
+    companion object {
+        fun defaultFile(): File = FileSessionStore.configDir().resolve("listening.json")
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/di/AppContainer.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/di/AppContainer.kt
@@ -5,7 +5,9 @@ import dk.perspektiva.ttsroad.desktop.data.FilePlaybackHistoryStore
 import dk.perspektiva.ttsroad.desktop.data.FilePlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.FileSessionStore
 import dk.perspektiva.ttsroad.desktop.data.FileWindowPreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.FileListeningStatsStore
 import dk.perspektiva.ttsroad.desktop.data.LibraryCache
+import dk.perspektiva.ttsroad.desktop.data.ListeningStatsStore
 import dk.perspektiva.ttsroad.desktop.data.FileReaderPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.PlaybackHistory
 import dk.perspektiva.ttsroad.desktop.data.PlaybackHistoryStore
@@ -103,6 +105,8 @@ class AppContainer(
     // Null selects the production local-plus-server store. Supplying a store keeps UI tests wholly
     // in memory and avoids making a fake repository call just because the library was composed.
     playbackHistory: PlaybackHistoryStore? = null,
+    /** Day totals for the Listening pane. In-memory in a test, so no screen writes to a real home. */
+    val listeningStats: ListeningStatsStore = FileListeningStatsStore(),
     playbackFactory: (
         TtsRoadRepository,
         MediaSourceFactory,
@@ -110,10 +114,20 @@ class AppContainer(
         AppDispatchers,
         PlaybackPreferencesStore,
         PlaybackHistoryStore,
+        ListeningStatsStore,
         () -> String,
     ) -> PlaybackController =
-        { repo, mediaSources, engine, d, prefs, history, owner ->
-            QueuePlaybackController(repo, mediaSources, engine, d.io, prefs, history, ownerKey = owner)
+        { repo, mediaSources, engine, d, prefs, history, stats, owner ->
+            QueuePlaybackController(
+                repo,
+                mediaSources,
+                engine,
+                d.io,
+                prefs,
+                history,
+                stats,
+                ownerKey = owner,
+            )
         },
     libraryCacheFactory: (TtsRoadRepository, AppDispatchers, () -> Long) -> LibraryCache =
         { repo, d, now -> LibraryCache(repo, d.main, now) },
@@ -194,6 +208,7 @@ class AppContainer(
         dispatchers,
         playbackPreferences,
         this.playbackHistory,
+        listeningStats,
         historyOwnerKey,
     )
 

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/player/QueuePlaybackController.kt
@@ -2,7 +2,10 @@ package dk.perspektiva.ttsroad.desktop.player
 
 import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.InMemoryListeningStatsStore
 import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackHistoryStore
+import dk.perspektiva.ttsroad.desktop.data.ListeningStats
+import dk.perspektiva.ttsroad.desktop.data.ListeningStatsStore
 import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.PlaybackHistoryStore
 import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferencesStore
@@ -71,6 +74,11 @@ class QueuePlaybackController(
      */
     private val preferencesStore: PlaybackPreferencesStore = InMemoryPlaybackPreferencesStore(),
     private val historyStore: PlaybackHistoryStore = InMemoryPlaybackHistoryStore(),
+    /**
+     * Day totals for the Listening pane. Fed from the same tick as everything else, because the
+     * controller is the only thing that knows the difference between playing and merely loaded.
+     */
+    private val statsStore: ListeningStatsStore = InMemoryListeningStatsStore(),
     private val sleepTimer: SleepTimer = SleepTimer(),
     private val clock: () -> Long = System::currentTimeMillis,
     /**
@@ -83,6 +91,7 @@ class QueuePlaybackController(
     private val tickIntervalMs: Long = 250,
     private val progressIntervalMs: Long = 10_000,
     private val historyRecordIntervalMs: Long = 5 * 60_000L,
+    private val listeningFlushIntervalMs: Long = 60_000L,
 ) : PlaybackController {
 
     private val _state = MutableStateFlow(emptyState())
@@ -133,6 +142,15 @@ class QueuePlaybackController(
 
     /** Playing time since the last cross-device jump-back breadcrumb. Pauses add nothing. */
     private var playedSinceHistoryRecordMs = 0L
+
+    /**
+     * Playing time not yet added to the day total.
+     *
+     * Batched rather than written per tick: four writes a second to a JSON file for a number nobody
+     * reads more than once a week would be absurd. Flushed on the interval below and at every
+     * transition, so the most a crash can lose is under a minute of a total measured in hours.
+     */
+    private var unflushedListeningMs = 0L
 
     /**
      * Engine events, queued for the attempt loop to consume.
@@ -484,6 +502,10 @@ class QueuePlaybackController(
                 // Reaching here means the chapter ended on its own.
                 val duration = _state.value.durationMs
                 saveProgress(chapter, duration.takeIf { it > 0 } ?: lastKnownPositionMs, isPlayed = true)
+                // A chapter that ran to its end is the only thing this client can honestly call
+                // "finished": marking one played by hand says the listener is done with it, not
+                // that they heard it.
+                flushListening(chaptersFinished = 1)
 
                 // Checked before the advance, which is the whole requirement: "end of current
                 // chapter" has to prevent auto-advance, not stop the next one a moment after it
@@ -629,6 +651,10 @@ class QueuePlaybackController(
                     playedSinceHistoryRecordMs = 0L
                     recordHistory()
                 }
+                // Counted from ticks rather than from the clock for the same reason: a laptop
+                // suspended mid-chapter must not wake up having "listened" for five hours.
+                unflushedListeningMs += tickIntervalMs
+                if (unflushedListeningMs >= listeningFlushIntervalMs) flushListening()
             }
 
             if (lastKnownPositionMs - lastSavedMs >= progressIntervalMs) {
@@ -714,6 +740,8 @@ class QueuePlaybackController(
      * the user making it.
      */
     private fun recordHistory() {
+        // Every transition that files a snapshot is also a good moment to bank the minutes.
+        flushListening()
         val chapter = queue.getOrNull(queueIndex) ?: return
         val current = _state.value
         if (!current.hasMedia) return
@@ -733,6 +761,25 @@ class QueuePlaybackController(
                 recordedAtMs = clock(),
                 ownerKey = queueOwnerKey,
             ),
+        )
+    }
+
+    /**
+     * Adds the playing time accumulated since the last flush to today's total.
+     *
+     * Attributed to [queueOwnerKey] rather than to whoever is signed in *now*, for the reason the
+     * history snapshot is: a sign-out while a flush is pending must not file one account's evening
+     * under another's name.
+     */
+    private fun flushListening(chaptersFinished: Int = 0) {
+        val seconds = unflushedListeningMs / 1000.0
+        unflushedListeningMs = 0L
+        if (seconds <= 0.0 && chaptersFinished == 0) return
+        statsStore.record(
+            ownerKey = queueOwnerKey,
+            date = ListeningStats.dateOf(clock()),
+            seconds = seconds,
+            chaptersFinished = chaptersFinished,
         )
     }
 

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
@@ -65,11 +65,16 @@ import dk.perspektiva.ttsroad.desktop.BuildInfo
 import dk.perspektiva.ttsroad.desktop.data.DeviceSession
 import dk.perspektiva.ttsroad.desktop.data.AudiobookExport
 import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.InMemoryListeningStatsStore
+import dk.perspektiva.ttsroad.desktop.data.ListeningStats
+import dk.perspektiva.ttsroad.desktop.data.ListeningStatsStore
 import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferences
+import dk.perspektiva.ttsroad.desktop.data.formatListeningSpan
 import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
 import dk.perspektiva.ttsroad.desktop.data.AppDirectories
 import dk.perspektiva.ttsroad.desktop.update.UpdateStatus
+import java.time.LocalDate
 import dk.perspektiva.ttsroad.desktop.data.SessionState
 import dk.perspektiva.ttsroad.desktop.data.SessionStore
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
@@ -128,6 +133,14 @@ fun SettingsScreen(
     onCloseToTrayChange: (Boolean) -> Unit = {},
     /** False on a desktop session with no system tray, where the control would promise nothing. */
     traySupported: Boolean = true,
+    /**
+     * Day totals for the Listening pane, and whose they are.
+     *
+     * Defaulted to an in-memory store for the same reason the preferences are: rendering a pane in
+     * a test must not read or write the user's real `listening.json`.
+     */
+    listeningStats: ListeningStatsStore = remember { InMemoryListeningStatsStore() },
+    historyOwnerKey: String = "",
     // Injected so "expires in 42 days" can be asserted without the test depending on wall time.
     nowMs: () -> Long = System::currentTimeMillis,
     /**
@@ -185,6 +198,7 @@ fun SettingsScreen(
                             onCloseToTrayChange,
                             traySupported,
                         )
+                        SettingsSection.Listening -> ListeningPane(listeningStats, historyOwnerKey, nowMs)
                         SettingsSection.Offline -> OfflinePane(ui.offline, holder)
                         SettingsSection.Audiobooks -> AudiobookPane(ui.audiobooks, holder)
                         SettingsSection.About -> AboutPane(session, capabilities, sessionStore, updates)
@@ -866,6 +880,59 @@ private fun ChoiceChip(label: String, selected: Boolean, onClick: () -> Unit) {
         MetaText(label, color = if (selected || hovered || focused) AarisColor.Ink else AarisColor.Muted)
     }
 }
+
+/**
+ * Hours, chapters and a streak, computed locally from `listening.json`.
+ *
+ * Nothing here is sent anywhere or read from the server: the totals are about time spent on *this*
+ * machine, they have to survive a sign-out, and there is no account contract for them.
+ */
+@Composable
+private fun ListeningPane(
+    stats: ListeningStatsStore,
+    ownerKey: String,
+    nowMs: () -> Long,
+) {
+    val days by stats.days.collectAsState()
+    // Keyed on the rows and the account, not on the clock: a pane that recomputed on every frame
+    // would walk two years of history for a number that changes at midnight.
+    val summary = remember(days, ownerKey) {
+        ListeningStats.summarise(days, ownerKey, LocalDate.parse(ListeningStats.dateOf(nowMs())))
+    }
+
+    PaneTitle("Listening", "Counted on this computer, for this account")
+
+    SettingsCard {
+        if (!summary.hasAnything) {
+            SettingRow("SO FAR", "Nothing yet")
+            MetaText(
+                "Totals start the first time a chapter plays. They are computed here from a local " +
+                    "file and are never sent to the server.",
+            )
+            return@SettingsCard
+        }
+
+        SettingRow("TOTAL", formatListeningSpan(summary.seconds))
+        RowDivider()
+        SettingRow("CHAPTERS FINISHED", "${summary.chaptersFinished}")
+        MetaText("A chapter counts once it has played to its end — marking one played by hand does not.")
+        RowDivider()
+        SettingRow("LAST 7 DAYS", formatListeningSpan(summary.last7DaysSeconds))
+        RowDivider()
+        SettingRow("LAST 30 DAYS", formatListeningSpan(summary.last30DaysSeconds))
+        RowDivider()
+        SettingRow("CURRENT STREAK", plural(summary.currentStreakDays, "day"))
+        MetaText("Today or yesterday keeps a streak alive; a whole day missed ends it.")
+        RowDivider()
+        SettingRow("LONGEST STREAK", plural(summary.longestStreakDays, "day"))
+        RowDivider()
+        SettingRow("DAYS WITH ANY LISTENING", plural(summary.daysListened, "day"))
+        RowDivider()
+        SettingRow("BEST DAY", formatListeningSpan(summary.bestDaySeconds))
+    }
+}
+
+private fun plural(count: Int, noun: String): String = if (count == 1) "1 $noun" else "$count ${noun}s"
 
 @Composable
 private fun ToggleRow(

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsStateHolder.kt
@@ -30,6 +30,7 @@ enum class SettingsSection(val label: String) {
     Account("Account"),
     Devices("Device sessions"),
     Playback("Playback"),
+    Listening("Listening"),
     Offline("Offline"),
     Audiobooks("Audiobooks"),
     About("Updates & About"),

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ListeningStatsTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ListeningStatsTest.kt
@@ -1,0 +1,188 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import java.io.File
+import java.time.LocalDate
+import java.time.ZoneId
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Listening totals, which are read by exactly one person: the one they are about. Every rule here
+ * exists because a wrong number would be noticed and a missing one would not.
+ */
+class ListeningStatsTest {
+
+    private val alice = PlaybackHistory.ownerKeyFor("https://ttsroad.example", "alice")
+    private val bob = PlaybackHistory.ownerKeyFor("https://ttsroad.example", "bob")
+    private val today = LocalDate.parse("2026-08-14")
+
+    private fun days(vararg rows: Pair<String, Double>, ownerKey: String = alice) =
+        rows.map { (date, seconds) -> ListeningDay(ownerKey, date, seconds) }
+
+    // --- Recording --------------------------------------------------------------------------------
+
+    @Test
+    fun `listening on the same day accumulates instead of stacking rows`() {
+        var rows = ListeningStats.record(emptyList(), alice, "2026-08-14", seconds = 600.0)
+        rows = ListeningStats.record(rows, alice, "2026-08-14", seconds = 300.0, chaptersFinished = 1)
+
+        val day = rows.single()
+        assertEquals(900.0, day.seconds)
+        assertEquals(1, day.chaptersFinished)
+    }
+
+    @Test
+    fun `two accounts on one machine keep separate totals`() {
+        // "You have listened for 300 hours" is a claim about a person; pooling it would be wrong in
+        // the direction that flatters.
+        var rows = ListeningStats.record(emptyList(), alice, "2026-08-14", seconds = 600.0)
+        rows = ListeningStats.record(rows, bob, "2026-08-14", seconds = 60.0)
+
+        assertEquals(600.0, ListeningStats.summarise(rows, alice, today).seconds)
+        assertEquals(60.0, ListeningStats.summarise(rows, bob, today).seconds)
+    }
+
+    @Test
+    fun `a nonsense duration is dropped rather than banked`() {
+        // It can only come from a clock that moved, and an afternoon that never happened is worse
+        // than a minute that goes unrecorded.
+        val rows = ListeningStats.record(emptyList(), alice, "2026-08-14", seconds = -400.0)
+        assertTrue(rows.isEmpty())
+        assertTrue(ListeningStats.record(rows, alice, "2026-08-14", seconds = Double.NaN).isEmpty())
+        assertTrue(ListeningStats.record(rows, "", "2026-08-14", seconds = 60.0).isEmpty())
+    }
+
+    @Test
+    fun `the day list is bounded, oldest first`() {
+        val start = LocalDate.parse("2020-01-01")
+        val rows = (0 until ListeningStats.MaxDays + 40).fold(emptyList<ListeningDay>()) { acc, offset ->
+            ListeningStats.record(acc, alice, start.plusDays(offset.toLong()).toString(), seconds = 60.0)
+        }
+
+        assertEquals(ListeningStats.MaxDays, rows.size)
+        assertEquals(start.plusDays(40).toString(), rows.first().date)
+    }
+
+    // --- Summaries --------------------------------------------------------------------------------
+
+    @Test
+    fun `nothing recorded is an empty summary rather than a pile of zeroes to render`() {
+        assertFalse(ListeningStats.summarise(emptyList(), alice, today).hasAnything)
+        assertFalse(ListeningStats.summarise(days("2026-08-14" to 0.0), alice, today).hasAnything)
+    }
+
+    @Test
+    fun `a streak counts back from today`() {
+        val rows = days("2026-08-12" to 600.0, "2026-08-13" to 600.0, "2026-08-14" to 600.0)
+
+        assertEquals(3, ListeningStats.summarise(rows, alice, today).currentStreakDays)
+    }
+
+    @Test
+    fun `yesterday keeps a streak alive, because mornings exist`() {
+        // Counting only from today would report a broken streak every morning until the first
+        // chapter of the day — wrong, and demoralising in a feature meant to encourage.
+        val rows = days("2026-08-12" to 600.0, "2026-08-13" to 600.0)
+
+        assertEquals(2, ListeningStats.summarise(rows, alice, today).currentStreakDays)
+    }
+
+    @Test
+    fun `a whole day missed ends the streak but not the record`() {
+        val rows = days("2026-08-01" to 600.0, "2026-08-02" to 600.0, "2026-08-03" to 600.0, "2026-08-12" to 600.0)
+
+        val summary = ListeningStats.summarise(rows, alice, today)
+
+        assertEquals(0, summary.currentStreakDays, "the 12th is two days ago")
+        assertEquals(3, summary.longestStreakDays)
+    }
+
+    @Test
+    fun `the windows are inclusive of today and of the seventh day back`() {
+        val rows = days(
+            "2026-08-08" to 100.0, // seven days back, inclusive
+            "2026-08-07" to 999.0, // eight days back, outside the week
+            "2026-08-14" to 200.0,
+        )
+
+        val summary = ListeningStats.summarise(rows, alice, today)
+
+        assertEquals(300.0, summary.last7DaysSeconds)
+        assertEquals(1299.0, summary.last30DaysSeconds)
+        assertEquals(999.0, summary.bestDaySeconds)
+        assertEquals(3, summary.daysListened)
+    }
+
+    @Test
+    fun `a day with only a finished chapter does not count as a day of listening`() {
+        // A chapter can finish on its last second; the streak is about time spent, and a row with
+        // no seconds in it is not an evening.
+        val rows = listOf(ListeningDay(alice, "2026-08-14", seconds = 0.0, chaptersFinished = 1))
+
+        val summary = ListeningStats.summarise(rows, alice, today)
+
+        assertEquals(0, summary.daysListened)
+        assertEquals(0, summary.currentStreakDays)
+        assertTrue(summary.hasAnything)
+    }
+
+    @Test
+    fun `an unparseable date cannot take the whole summary down`() {
+        val rows = days("2026-08-14" to 600.0) + ListeningDay(alice, "not-a-date", 60.0)
+
+        val summary = ListeningStats.summarise(rows, alice, today)
+
+        assertEquals(660.0, summary.seconds, "the total still sums every row")
+        assertEquals(1, summary.daysListened, "but only a real date can be part of a streak")
+    }
+
+    // --- Persistence ------------------------------------------------------------------------------
+
+    @Test
+    fun `days round-trip through the file store`(@TempDir dir: File) {
+        val file = dir.resolve("listening.json")
+        FileListeningStatsStore(file).record(alice, "2026-08-14", seconds = 600.0, chaptersFinished = 2)
+
+        val reloaded = FileListeningStatsStore(file).days.value.single()
+        assertEquals(600.0, reloaded.seconds)
+        assertEquals(2, reloaded.chaptersFinished)
+        assertEquals(alice, reloaded.ownerKey)
+    }
+
+    @Test
+    fun `the file names no server, no account and nothing that was read`(@TempDir dir: File) {
+        // The type has nowhere to put a title, a chapter id or a URL, and this pins that the file
+        // it produces carries none of them either. `chaptersFinished` is a count, not an id.
+        val file = dir.resolve("listening.json")
+        FileListeningStatsStore(file).record(alice, "2026-08-14", seconds = 600.0, chaptersFinished = 2)
+
+        val text = file.readText()
+        listOf("http", "alice", "ttsroad.example", "token", "title", "fiction").forEach {
+            assertFalse(text.contains(it, ignoreCase = true), "listening.json must not carry '$it': $text")
+        }
+    }
+
+    @Test
+    fun `an unreadable or half-written file is no statistics, not a crash`(@TempDir dir: File) {
+        val corrupt = dir.resolve("corrupt.json")
+        corrupt.writeText("[{ this is not json")
+        assertTrue(FileListeningStatsStore(corrupt).days.value.isEmpty())
+
+        // A row with no owner cannot be attributed to anyone, so it is dropped on read.
+        val ownerless = dir.resolve("ownerless.json")
+        ownerless.writeText("""[{"ownerKey":"","date":"2026-08-14","seconds":60.0,"chaptersFinished":0}]""")
+        assertTrue(FileListeningStatsStore(ownerless).days.value.isEmpty())
+    }
+
+    @Test
+    fun `a day is the listener's own local day`() {
+        // 00:30 UTC on the 15th is still the evening of the 14th in New York.
+        val millis = java.time.Instant.parse("2026-08-15T00:30:00Z").toEpochMilli()
+
+        assertEquals("2026-08-15", ListeningStats.dateOf(millis, ZoneId.of("UTC")))
+        assertEquals("2026-08-14", ListeningStats.dateOf(millis, ZoneId.of("America/New_York")))
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackPreferencesApplyTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/player/PlaybackPreferencesApplyTest.kt
@@ -3,7 +3,9 @@ package dk.perspektiva.ttsroad.desktop.player
 import dk.perspektiva.ttsroad.desktop.FakeRepository
 import dk.perspektiva.ttsroad.desktop.data.AudioInfo
 import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
+import dk.perspektiva.ttsroad.desktop.data.InMemoryListeningStatsStore
 import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackHistoryStore
+import dk.perspektiva.ttsroad.desktop.data.ListeningStats
 import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.PlaybackInfo
 import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferences
@@ -219,6 +221,88 @@ class PlaybackPreferencesApplyTest {
 
         awaitCondition("the default to move") { preferences.preferences.value.speed == 1.75f }
         assertTrue(preferences.preferences.value.fictionSpeeds.isEmpty())
+    }
+
+    // --- Listening statistics ---------------------------------------------------------------------
+
+    @Test
+    fun `playing time is banked against the account and the day, not against the clock`() = runBlocking {
+        val engine = FakePlaybackEngine()
+        val stats = InMemoryListeningStatsStore()
+        val clock = FakeClock(java.time.Instant.parse("2026-08-14T20:00:00Z").toEpochMilli())
+        val playback = QueuePlaybackController(
+            repository = FakeRepository(),
+            sources = FakeMediaSourceFactory(),
+            engine = engine,
+            ioDispatcher = Dispatchers.Default,
+            statsStore = stats,
+            clock = clock,
+            ownerKey = { "owner-a" },
+            tickIntervalMs = 5,
+            // Twenty milliseconds of ticks stands in for the production one-minute flush.
+            listeningFlushIntervalMs = 20,
+        )
+
+        playback.playQueue(listOf(chapter(1)), startChapterId = 1, fiction = null)
+        awaitCondition("a flushed day total") { stats.days.value.isNotEmpty() }
+
+        val day = stats.days.value.single()
+        assertEquals("owner-a", day.ownerKey)
+        assertEquals(ListeningStats.dateOf(clock()), day.date)
+        assertTrue(day.seconds > 0.0, "was ${day.seconds}")
+        playback.release()
+    }
+
+    @Test
+    fun `a paused player banks nothing at all`() = runBlocking {
+        // The tick loop keeps running through a pause — it is what notices the engine's events — so
+        // counting ticks rather than playing ticks would turn an overnight pause into a night of
+        // listening.
+        val engine = FakePlaybackEngine()
+        val stats = InMemoryListeningStatsStore()
+        val playback = QueuePlaybackController(
+            repository = FakeRepository(),
+            sources = FakeMediaSourceFactory(),
+            engine = engine,
+            ioDispatcher = Dispatchers.Default,
+            statsStore = stats,
+            ownerKey = { "owner-a" },
+            tickIntervalMs = 5,
+            listeningFlushIntervalMs = 20,
+        )
+
+        playback.playQueue(listOf(chapter(1)), startChapterId = 1, fiction = null)
+        awaitCondition("playback to start") { playback.state.value.isPlaying }
+        playback.togglePlayPause()
+        awaitCondition("the pause") { !playback.state.value.isPlaying }
+        val bankedAtPause = stats.days.value.sumOf { it.seconds }
+
+        delay(120)
+
+        assertEquals(bankedAtPause, stats.days.value.sumOf { it.seconds })
+        playback.release()
+    }
+
+    @Test
+    fun `a chapter that runs to its end counts as finished`() = runBlocking {
+        val engine = FakePlaybackEngine(completeOnPlay = true)
+        val stats = InMemoryListeningStatsStore()
+        val playback = QueuePlaybackController(
+            repository = FakeRepository(),
+            sources = FakeMediaSourceFactory(),
+            engine = engine,
+            ioDispatcher = Dispatchers.Default,
+            statsStore = stats,
+            ownerKey = { "owner-a" },
+            tickIntervalMs = 5,
+        )
+
+        playback.playQueue(listOf(chapter(1)), startChapterId = 1, fiction = null)
+
+        awaitCondition("the finished chapter to be counted") {
+            stats.days.value.sumOf { it.chaptersFinished } == 1
+        }
+        playback.release()
     }
 
     // --- Skip interval --------------------------------------------------------------------------

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/NavigationUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/NavigationUiTest.kt
@@ -96,7 +96,7 @@ class NavigationUiTest {
             SessionState(serverUrl = "https://x/", token = "t", username = "admin", serverName = "Perspektiva"),
         ),
         repositoryFactory = { _, _, _ -> repository },
-        playbackFactory = { _, _, _, _, _, _, _ -> playback },
+        playbackFactory = { _, _, _, _, _, _, _, _ -> playback },
         // In-memory, so rendering a screen in a test never touches the real
         // ~/.config/TTSRoad files the production stores default to.
         playbackPreferences = InMemoryPlaybackPreferencesStore(),

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ScreensUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ScreensUiTest.kt
@@ -70,7 +70,7 @@ class ScreensUiTest {
     ) = AppContainer(
         sessionStore = InMemorySessionStore(session),
         repositoryFactory = { _, _, _ -> repository },
-        playbackFactory = { _, _, _, _, _, _, _ -> playback },
+        playbackFactory = { _, _, _, _, _, _, _, _ -> playback },
         // In-memory, so rendering a screen in a test never touches the real
         // ~/.config/TTSRoad files the production stores default to.
         playbackPreferences = InMemoryPlaybackPreferencesStore(),
@@ -171,7 +171,7 @@ class ScreensUiTest {
         val app = AppContainer(
             sessionStore = store,
             repositoryFactory = { _, _, _ -> repository },
-            playbackFactory = { _, _, _, _, _, _, _ -> playback },
+            playbackFactory = { _, _, _, _, _, _, _, _ -> playback },
             // In-memory, so rendering a screen in a test never touches the real
             // ~/.config/TTSRoad files the production stores default to.
             playbackPreferences = InMemoryPlaybackPreferencesStore(),
@@ -250,7 +250,7 @@ class ScreensUiTest {
         val app = AppContainer(
             sessionStore = store,
             repositoryFactory = { _, _, _ -> repository },
-            playbackFactory = { _, _, _, _, _, _, _ -> FakePlaybackController() },
+            playbackFactory = { _, _, _, _, _, _, _, _ -> FakePlaybackController() },
             // In-memory, so rendering a screen in a test never touches the real
             // ~/.config/TTSRoad files the production stores default to.
             playbackPreferences = InMemoryPlaybackPreferencesStore(),

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreenUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreenUiTest.kt
@@ -3,6 +3,7 @@ package dk.perspektiva.ttsroad.desktop.ui
 import androidx.compose.foundation.layout.width
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertCountEquals
@@ -26,7 +27,10 @@ import androidx.compose.ui.unit.dp
 import dk.perspektiva.ttsroad.desktop.FakeRepository
 import dk.perspektiva.ttsroad.desktop.ParsedFixtures
 import dk.perspektiva.ttsroad.desktop.ServerFixtures
+import dk.perspektiva.ttsroad.desktop.data.InMemoryListeningStatsStore
 import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.ListeningDay
+import dk.perspektiva.ttsroad.desktop.data.ListeningStats
 import dk.perspektiva.ttsroad.desktop.data.AudiobookExport
 import dk.perspektiva.ttsroad.desktop.data.AudiobookExportsResponse
 import dk.perspektiva.ttsroad.desktop.data.MobileUser
@@ -120,6 +124,8 @@ class SettingsScreenUiTest {
         closeToTray: Boolean = false,
         onCloseToTrayChange: (Boolean) -> Unit = {},
         traySupported: Boolean = true,
+        listeningStats: InMemoryListeningStatsStore = InMemoryListeningStatsStore(),
+        historyOwnerKey: String = "owner-a",
     ) {
         val store = InMemorySessionStore(session)
         repository.capabilitiesResult = capabilities
@@ -136,6 +142,8 @@ class SettingsScreenUiTest {
                     closeToTray = closeToTray,
                     onCloseToTrayChange = onCloseToTrayChange,
                     traySupported = traySupported,
+                    listeningStats = listeningStats,
+                    historyOwnerKey = historyOwnerKey,
                     nowMs = { now },
                 )
             }
@@ -398,6 +406,35 @@ class SettingsScreenUiTest {
 
         compose.onAllNodesWithContentDescription("KEEP PLAYING WHEN THE WINDOW CLOSES").assertCountEquals(0)
         compose.onNodeWithText("No system tray on this desktop", ignoreCase = true).assertExists()
+    }
+
+    @Test
+    fun `the listening pane says so plainly when there is nothing yet`() {
+        setContent(FakeRepository())
+        navEntry("LISTENING").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("Nothing yet", ignoreCase = true).assertExists()
+        compose.onNodeWithText("never sent to the server", substring = true, ignoreCase = true).assertExists()
+    }
+
+    @Test
+    fun `the listening pane totals this account's days and not another's`() {
+        val stats = InMemoryListeningStatsStore(
+            listOf(
+                ListeningDay("owner-a", ListeningStats.dateOf(now), seconds = 3_660.0, chaptersFinished = 2),
+                ListeningDay("owner-b", ListeningStats.dateOf(now), seconds = 99_999.0, chaptersFinished = 40),
+            ),
+        )
+        setContent(FakeRepository(), listeningStats = stats, historyOwnerKey = "owner-a")
+        navEntry("LISTENING").performClick()
+        compose.waitForIdle()
+
+        compose.onAllNodesWithText("1h 1m").onFirst().assertExists()
+        // Streak, longest streak and days-with-listening are all one day here.
+        compose.onAllNodesWithText("1 day", substring = true).assertCountEquals(3)
+        // The other account's evening must not appear anywhere on this pane.
+        compose.onAllNodesWithText("27h", substring = true).assertCountEquals(0)
     }
 
     @Test


### PR DESCRIPTION
Addresses the **listening statistics** item (§6) in #41.

Hours, chapters finished and a streak, in a Settings pane of their own, computed locally from a bounded `listening.json`.

## Why a new store

The idea in #41 assumed `PlaybackHistory` could back this. It cannot: that store is 60 entries and one per chapter, so it knows the last few dozen chapters and nothing at all about how long anyone has been listening. This adds the store the question actually needs — one row per account per calendar day, holding seconds and chapters finished. A day is the coarsest unit that still answers all three questions worth asking, and storing sessions instead would mean keeping a minute-resolution record of *when* somebody listened, for years, to answer questions that never needed it.

## The rules that matter, recorded in ADR 0006

- **Per account on a shared machine.** Rows carry the same hashed owner key the history uses. "You have listened for 300 hours" is a claim about a person; pooling two accounts would be wrong in the direction that flatters.
- **Playing ticks, never wall time.** A laptop suspended mid-chapter must not wake up having listened for five hours, and a player left paused overnight has listened for nothing.
- **Batched to once a minute** and flushed at every transition, so four writes a second are avoided while a crash can lose under a minute of a total measured in hours.
- **Finished means finished** — a chapter that ran to its end. Marking one played by hand says the listener is done with it, not that they heard it.
- **Today *or yesterday* keeps a streak alive.** Counting only from today would report a broken streak every morning until the first chapter of the day, which is both wrong and demoralising in a feature whose purpose is encouragement. `summarise` takes `today` as an argument because a streak is the one number here that changes without anyone listening, and a function that read the clock could not be asserted on that at all.
- **Bounded at two years**, oldest first, because the file is appended to for the life of the install.

Nothing is sent to the server and there is no account contract for it. The type has nowhere to put a title, a chapter id or a URL — and a test pins that against the file it actually produces.

## Coverage

- `ListeningStatsTest` — accumulation, two accounts kept apart, nonsense durations dropped rather than banked, the oldest-first bound, streak rules including the morning case and the lapsed case, inclusive 7/30-day windows, a day with only a finished chapter, an unparseable date not taking the summary down, file round trip, the leak assertion, corrupt/ownerless files, and local-day resolution across time zones.
- `PlaybackPreferencesApplyTest` — playing time is banked against the account and the day; a paused player banks nothing; a chapter that runs to its end counts as finished.
- `SettingsScreenUiTest` — the empty pane says so plainly, and a populated one totals this account's days and not another's.

## Validation

```
xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail -Pttsroad.warningsAsErrors=true
```

`BUILD SUCCESSFUL`.