### PR TITLE
Upload an EPUB from the desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ All notable changes to TTSRoad Desktop are recorded here. The format follows
 
 ### Added
 
+- EPUB upload, from the Add fiction dialog. The desktop is the client with a real filesystem and a
+  real file picker, so this is where whole-book import belongs. Shown only where the server
+  advertises `epub_upload`, which the backend publishes separately from add/edit/delete because a
+  deployment can accept the one without the other. The extension, emptiness and the server's
+  published byte ceiling are checked before anything is sent.
 - Listening statistics, in a Settings pane of their own: total hours, chapters finished, the last
   seven and thirty days, a current and longest streak, days with any listening, and the best day.
   Computed locally from a bounded two-year file, kept per account on a shared machine, and never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,18 @@ apply to audio.
   `/api/me/preferences` keys. PATCH must never echo unrelated account settings. Preserve the server
   ranges (font 14–30, line height 1.3–2.4) and dark/sepia/light + sentence/word/off vocabularies.
 
+### Admin fiction management and EPUB upload
+
+Two independent gates, always: the advertised `fiction_management` capability *and* the authoritative
+`is_admin` from `/api/mobile/me`. A visible button is never authorization — the server is the gate,
+and the client only decides what to draw. `epub_upload` is a **separate** capability and is never
+inferred from `fiction_management`; the backend states that a deployment can accept JSON CRUD
+without accepting files. `FictionManagementStateHolder.epubProblem` checks extension, emptiness and
+`limits.max_epub_bytes` *before* the upload, because every one of those is a 400 that would otherwise
+arrive after the whole file went over the wire — and AWT's filename filter is a hint several Linux
+window managers ignore. The upload streams from the file; only the filename leaf is sent, because
+the server checks the extension and a local path is not its business.
+
 ### The server queue, which is not the player's queue
 
 `data/ServerQueue.kt` + `ui/ServerQueueStateHolder.kt` model the account's cross-library queue

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ full evidence table is in [`docs/QUALITY-GATE.md`](docs/QUALITY-GATE.md).
 | Offline downloads — per chapter, next 10, restart-safe queue, storage controls | ✅ |
 | Bounded streaming cache and previously loaded library browsing while offline | ✅ |
 | Timestamped delta refresh for cached library and chapter metadata | ✅ |
+| Admin fiction management — add by URL/id, EPUB upload, edit, confirmed delete | ✅ |
 | Admin audiobook exports — resumable M4B save to a user-selected file | ✅ |
 | Audio-synchronized read-along — offline text, word seek, find, themes and zoom | ✅ |
 | Distraction-free reading — F11 hides every frame, hover brings the transport back | ✅ |

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -63,6 +63,7 @@ endpoint 404 becomes a concise unsupported state. Never infer a feature from `ap
 | `queue` | cross-library server queue | queue destination hidden |
 | `delta_sync` | cursor-driven library/chapter metadata refresh | ordinary full refresh of both resources |
 | `fiction_management` | admin add/edit/delete, gated *again* by `/me`'s `is_admin` | management controls hidden |
+| `epub_upload` | multipart EPUB import, **never** inferred from `fiction_management` | the upload control is hidden; add-by-URL still works |
 | `audiobook_export` | read-only M4B export shelf and resumable save | Audiobooks pane hidden |
 | `audio_content_hash` | reserved/parsed contract flag | no UI is promised merely by parsing |
 

--- a/docs/adr/0012-admin-fiction-management.md
+++ b/docs/adr/0012-admin-fiction-management.md
@@ -38,6 +38,32 @@ acknowledgement is not success.
 EPUB upload remains unavailable until TTSRoad #122 supplies a separately advertised mobile
 multipart contract. The desktop does not call `/api/fictions/upload-epub` as a fallback.
 
+### EPUB upload waited for a mobile contract of its own
+
+The web has had an EPUB import route for as long as it has had fictions, and it was reachable with
+the bearer token this client already holds. It was still not used, for the reason the rest of this
+ADR gives: the web surface carries no add-don't-rename guarantee, no contract test, and no capability
+flag, so a client built on it would break silently on a server upgrade. `jonarihen/TTSRoad#122` asked
+for the mirror; `TTSRoad#124` shipped it, and this is built on that.
+
+Three details are worth recording:
+
+- **`epub_upload` is a separate capability, never inferred from `fiction_management`.** The backend
+  is explicit that a deployment can accept JSON fiction CRUD without accepting files, so the control
+  is drawn from its own flag or not at all.
+- **Validation happens before the upload, not only on the server.** Extension, emptiness and
+  `limits.max_epub_bytes` are all 400s or 413s that would otherwise arrive *after* a forty-megabyte
+  file had gone over the wire, which is the worst possible order to tell someone. The extension
+  check is not redundant with the picker's filter either: AWT's `setFilenameFilter` is a hint that
+  several Linux window managers ignore outright.
+- **One dialog, two paths.** "Add a fiction" is one intention; making the user choose which *kind*
+  of add they meant before showing them either form asks them to know the implementation. Choosing
+  a file disables the URL field and says why, rather than hiding it out from under the cursor.
+
+`rate` and `enabled` exist on the server contract and are deliberately left at their defaults: the
+desktop has no per-fiction rate control, and uploading a fiction in order to disable it is not
+something anyone asked for.
+
 ## Consequences
 
 Older servers and non-admin accounts see no dead controls. A stale admin claim cannot expose the

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -170,8 +170,14 @@ fun App(container: AppContainer = remember { AppContainer() }) {
 
     val scope = rememberCoroutineScope()
 
-    LaunchedEffect(session.isLoggedIn, capabilities.fictionManagement) {
-        if (session.isLoggedIn) fictionManagement.ensureAccess(capabilities.fictionManagement)
+    LaunchedEffect(session.isLoggedIn, capabilities.fictionManagement, capabilities.epubUpload) {
+        if (session.isLoggedIn) {
+            fictionManagement.ensureAccess(
+                capabilities.fictionManagement,
+                epubUpload = capabilities.epubUpload,
+                maxEpubBytes = capabilities.maxEpubBytes,
+            )
+        }
     }
 
     LaunchedEffect(fictionManagementState.deletedFictionId) {
@@ -185,11 +191,21 @@ fun App(container: AppContainer = remember { AppContainer() }) {
         when (val destination = nav.current) {
             Destination.Library -> {
                 cache.refreshLibrary()
-                fictionManagement.ensureAccess(capabilities.fictionManagement, forceRefresh = true)
+                fictionManagement.ensureAccess(
+                    capabilities.fictionManagement,
+                    epubUpload = capabilities.epubUpload,
+                    maxEpubBytes = capabilities.maxEpubBytes,
+                    forceRefresh = true,
+                )
             }
             is Destination.Fiction -> {
                 cache.refreshChapters(destination.fiction.id)
-                fictionManagement.ensureAccess(capabilities.fictionManagement, forceRefresh = true)
+                fictionManagement.ensureAccess(
+                    capabilities.fictionManagement,
+                    epubUpload = capabilities.epubUpload,
+                    maxEpubBytes = capabilities.maxEpubBytes,
+                    forceRefresh = true,
+                )
             }
             Destination.Settings, Destination.Devices -> settings.refreshCurrentSection()
             Destination.Search -> search.refresh()

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -2,6 +2,7 @@ package dk.perspektiva.ttsroad.desktop.data
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.io.File
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -9,7 +10,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import retrofit2.HttpException
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -27,6 +32,10 @@ private val CapabilityTtlMillis = TimeUnit.HOURS.toMillis(6)
  * than allowed only costs an extra round trip, while sending more loses the whole batch to a 400.
  */
 private const val DefaultMaxPlaybackSyncItems = 500
+
+/** What an EPUB is. The server checks the *filename*, but a correct type costs nothing. */
+private val EpubMediaType = "application/epub+zip".toMediaType()
+private val TextMediaType = "text/plain".toMediaType()
 
 /** Outcome of a login attempt. */
 sealed interface LoginResult {
@@ -121,6 +130,10 @@ interface TtsRoadRepository {
         error("fiction management is not implemented")
 
     suspend fun deleteFiction(fictionId: Int): Boolean = false
+
+    /** Uploads one EPUB and answers the fiction the server created from it. */
+    suspend fun uploadEpub(file: File, voice: String? = null): FictionSummary =
+        error("EPUB upload is not implemented")
 
     /**
      * Follows or unfollows a fiction, answering the state **the server now holds**, or null when it
@@ -440,6 +453,21 @@ class RetrofitTtsRoadRepository(
 
     override suspend fun deleteFiction(fictionId: Int): Boolean =
         withAuthorizedApi { it.deleteFiction(fictionId) }.let { it.deleted && it.fictionId == fictionId }
+
+    override suspend fun uploadEpub(file: File, voice: String?): FictionSummary = withAuthorizedApi { api ->
+        // Streamed from the file rather than read into a byte array: an EPUB is allowed to be tens
+        // of megabytes, and buffering one in the heap to hand it to OkHttp — which will only write
+        // it to a socket — is a copy nobody needs.
+        val part = MultipartBody.Part.createFormData(
+            "file",
+            // The server rejects anything without a `.epub` extension, so the *name* is part of
+            // the request rather than decoration. Only the leaf is sent; a path is not the
+            // server's business.
+            file.name,
+            file.asRequestBody(EpubMediaType),
+        )
+        api.uploadEpub(part, voice?.takeIf(String::isNotBlank)?.toRequestBody(TextMediaType)).fiction
+    }
 
     override suspend fun setFollowing(fictionId: Int, following: Boolean): Boolean? =
         ifEndpointExists {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
@@ -46,6 +46,13 @@ data class ServerCapabilities(
     /** Admin add/edit/delete routes. Account permission is verified separately through `/me`. */
     val fictionManagement: Boolean = false,
     /**
+     * Multipart EPUB import, advertised separately from JSON fiction CRUD.
+     *
+     * The backend is explicit that a deployment can support add/edit/delete without accepting
+     * files, so this is never inferred from [fictionManagement].
+     */
+    val epubUpload: Boolean = false,
+    /**
      * Per-user libraries.
      *
      * False means `/api/mobile/library` is still the whole shared list on that server, so this
@@ -73,6 +80,8 @@ data class ServerCapabilities(
      * batch rather than part of it.
      */
     val maxPlaybackSyncItems: Int? = null,
+    /** The server's EPUB ceiling. A `Long`, because a byte count is not an item count. */
+    val maxEpubBytes: Long? = null,
 ) {
     /** True once discovery has actually reached a TTSRoad server (only it reports a version). */
     val isDiscovered: Boolean get() = serverVersion != null
@@ -93,12 +102,14 @@ data class ServerCapabilities(
             batchProgress = response.capabilities.flag("batch_progress"),
             audioContentHash = response.capabilities.flag("audio_content_hash"),
             fictionManagement = response.capabilities.flag("fiction_management"),
+            epubUpload = response.capabilities.flag("epub_upload"),
             follows = response.capabilities.flag("follows"),
             deviceManagement = response.capabilities.flag("device_management"),
             queue = response.capabilities.flag("queue"),
             audiobookExport = response.capabilities.flag("audiobook_export"),
             maxChaptersPerPage = response.limits.intLimit("max_chapters_per_page"),
             maxPlaybackSyncItems = response.limits.intLimit("max_playback_sync_items"),
+            maxEpubBytes = response.limits.longLimit("max_epub_bytes"),
         )
 
         /**
@@ -110,5 +121,7 @@ data class ServerCapabilities(
 
         /** Moshi parses every JSON number as a Double, so accept any [Number] and drop the rest. */
         private fun Map<String, Any?>.intLimit(key: String): Int? = (this[key] as? Number)?.toInt()
+
+        private fun Map<String, Any?>.longLimit(key: String): Long? = (this[key] as? Number)?.toLong()
     }
 }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -1,12 +1,16 @@
 package dk.perspektiva.ttsroad.desktop.data
 
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Headers
 import retrofit2.http.PATCH
+import retrofit2.http.Multipart
 import retrofit2.http.POST
+import retrofit2.http.Part
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -83,6 +87,21 @@ interface TtsRoadApi {
     /** Adds one shared fiction. Advertised by `fiction_management` and admin-gated by the server. */
     @POST("api/mobile/fictions")
     suspend fun createFiction(@Body request: FictionCreateRequest): FictionMutationResponse
+
+    /**
+     * Uploads one EPUB. Advertised by `epub_upload`, separately from JSON fiction CRUD, because a
+     * deployment can accept the latter without accepting files.
+     *
+     * `voice` is the only optional field this client sends. `rate` and `enabled` exist on the
+     * server contract and are deliberately left at their defaults — the desktop has no UI for a
+     * per-fiction rate, and uploading a fiction while disabling it is not a thing anyone asked for.
+     */
+    @Multipart
+    @POST("api/mobile/fictions/upload-epub")
+    suspend fun uploadEpub(
+        @Part file: MultipartBody.Part,
+        @Part("voice") voice: RequestBody? = null,
+    ): FictionMutationResponse
 
     /** Edits shared fiction metadata. The slug is deliberately not part of the request model. */
     @PATCH("api/mobile/fictions/{fiction_id}")

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/EpubFilePicker.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/EpubFilePicker.kt
@@ -1,0 +1,37 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import java.awt.FileDialog
+import java.awt.Frame
+import java.awt.GraphicsEnvironment
+import java.io.File
+
+/**
+ * The native "choose an EPUB" dialog, behind a seam.
+ *
+ * A `fun interface` for the same reason `AudiobookSavePicker` is one: a real `FileDialog` needs a
+ * display and a person, and every rule worth testing about an upload — the extension, the size
+ * ceiling, what happens to the URL field — is about the file that comes *back*.
+ */
+fun interface EpubFilePicker {
+    /** Null means the user cancelled the native dialog, which is not an error. */
+    fun choose(): File?
+}
+
+object DesktopEpubFilePicker : EpubFilePicker {
+    override fun choose(): File? {
+        if (GraphicsEnvironment.isHeadless()) return null
+        val dialog = FileDialog(null as Frame?, "Choose an EPUB", FileDialog.LOAD)
+        // A hint, not a guarantee: several Linux window managers ignore AWT's filter entirely,
+        // which is exactly why the extension is checked again once a file comes back.
+        dialog.setFilenameFilter { _, name -> name.endsWith(".epub", ignoreCase = true) }
+        dialog.isVisible = true
+        val directory = dialog.directory ?: return null
+        val filename = dialog.file ?: return null
+        return File(directory, filename)
+    }
+}
+
+/** No picker at all — a test, a preview, or a headless run. */
+object UnavailableEpubFilePicker : EpubFilePicker {
+    override fun choose(): File? = null
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementDialogs.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementDialogs.kt
@@ -2,6 +2,7 @@ package dk.perspektiva.ttsroad.desktop.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -12,12 +13,15 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 
 const val AddFictionDialogTestTag: String = "addFictionDialog"
+const val ChooseEpubButtonTestTag: String = "chooseEpubButton"
+const val ChosenEpubNameTestTag: String = "chosenEpubName"
 const val EditFictionDialogTestTag: String = "editFictionDialog"
 
 /** The holder owns the answers; this composable only renders its one active question. */
@@ -29,8 +33,11 @@ fun FictionManagementDialogs(holder: FictionManagementStateHolder) {
             editor = editor,
             isBusy = state.isBusy,
             error = state.error,
+            epubUploadAvailable = state.epubUploadAvailable,
             onUpdateAdd = holder::updateAdd,
             onUpdateEdit = holder::updateEdit,
+            onChooseEpub = holder::chooseEpub,
+            onClearEpub = holder::clearEpub,
             onSubmit = holder::submitEditor,
             onDismiss = holder::dismissOverlay,
         )
@@ -52,8 +59,11 @@ private fun FictionEditorDialog(
     editor: FictionEditor,
     isBusy: Boolean,
     error: String?,
+    epubUploadAvailable: Boolean,
     onUpdateAdd: (String?, String?) -> Unit,
     onUpdateEdit: (String?, String?, String?) -> Unit,
+    onChooseEpub: () -> Unit,
+    onClearEpub: () -> Unit,
     onSubmit: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -73,14 +83,45 @@ private fun FictionEditorDialog(
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 when (editor) {
                     is FictionEditor.Add -> {
+                        val epub = editor.epubFile
                         OutlinedTextField(
                             value = editor.fictionUrl,
                             onValueChange = { onUpdateAdd(it, null) },
                             label = { Text("ROYAL ROAD URL OR FICTION ID") },
-                            enabled = !isBusy,
+                            supportingText = if (epub != null) {
+                                { Text("Not used while an EPUB is chosen") }
+                            } else {
+                                null
+                            },
+                            // Disabled rather than hidden: the field disappearing under the
+                            // cursor after a file picker closes is disorienting, and the reason
+                            // it is inert is worth saying rather than implying.
+                            enabled = !isBusy && epub == null,
                             singleLine = true,
                             modifier = Modifier.fillMaxWidth(),
                         )
+                        if (epubUploadAvailable) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                TextButton(
+                                    onClick = if (epub == null) onChooseEpub else onClearEpub,
+                                    enabled = !isBusy,
+                                    shape = RectangleShape,
+                                    modifier = Modifier.testTag(ChooseEpubButtonTestTag),
+                                ) { Text(if (epub == null) "OR UPLOAD AN EPUB…" else "REMOVE EPUB") }
+                                epub?.let {
+                                    Text(
+                                        it.name,
+                                        color = AarisColor.Ink,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        modifier = Modifier.testTag(ChosenEpubNameTestTag),
+                                    )
+                                }
+                            }
+                        }
                         OutlinedTextField(
                             value = editor.voice,
                             onValueChange = { onUpdateAdd(null, it) },
@@ -128,7 +169,18 @@ private fun FictionEditorDialog(
                 onClick = onSubmit,
                 enabled = !isBusy,
                 shape = RectangleShape,
-            ) { Text(if (isBusy) "SAVING…" else if (adding) "ADD FICTION" else "SAVE CHANGES") }
+            ) {
+                val uploading = editor is FictionEditor.Add && editor.epubFile != null
+                Text(
+                    when {
+                        isBusy && uploading -> "UPLOADING…"
+                        isBusy -> "SAVING…"
+                        uploading -> "UPLOAD EPUB"
+                        adding -> "ADD FICTION"
+                        else -> "SAVE CHANGES"
+                    },
+                )
+            }
         },
         dismissButton = {
             TextButton(onClick = onDismiss, enabled = !isBusy, shape = RectangleShape) {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolder.kt
@@ -6,6 +6,7 @@ import dk.perspektiva.ttsroad.desktop.data.FictionUpdateRequest
 import dk.perspektiva.ttsroad.desktop.data.LibraryCache
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
+import java.io.File
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -27,6 +28,14 @@ sealed interface FictionEditor {
     data class Add(
         val fictionUrl: String = "",
         val voice: String = "",
+        /**
+         * A chosen EPUB, which makes this an *upload* rather than a Royal Road add.
+         *
+         * One editor with two paths rather than two dialogs: "add a fiction" is one intention, and
+         * making the user pick which kind of add they wanted before showing them either form is
+         * asking them to know the implementation.
+         */
+        val epubFile: File? = null,
     ) : FictionEditor
 
     data class Edit(
@@ -41,6 +50,10 @@ data class FictionDeleteConfirmation(val fictionId: Int, val title: String)
 
 data class FictionManagementUiState(
     val access: FictionManagementAccess = FictionManagementAccess.Unsupported,
+    /** Whether this server accepts multipart EPUB uploads at all — advertised separately. */
+    val epubUploadAvailable: Boolean = false,
+    /** The server's byte ceiling, when it published one. */
+    val maxEpubBytes: Long? = null,
     val editor: FictionEditor? = null,
     val deleteConfirmation: FictionDeleteConfirmation? = null,
     val isBusy: Boolean = false,
@@ -63,6 +76,8 @@ data class FictionManagementUiState(
 class FictionManagementStateHolder(
     private val repository: TtsRoadRepository,
     private val cache: LibraryCache,
+    /** The native EPUB chooser. Substituted in a test, which has neither a display nor a person. */
+    private val picker: EpubFilePicker = DesktopEpubFilePicker,
     dispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) : StateHolder(dispatcher) {
     private val _state = MutableStateFlow(FictionManagementUiState())
@@ -72,7 +87,12 @@ class FictionManagementStateHolder(
     private var mutationJob: Job? = null
     private var lastSupported: Boolean? = null
 
-    fun ensureAccess(supported: Boolean, forceRefresh: Boolean = false) {
+    fun ensureAccess(
+        supported: Boolean,
+        epubUpload: Boolean = false,
+        maxEpubBytes: Long? = null,
+        forceRefresh: Boolean = false,
+    ) {
         if (!supported) {
             lastSupported = false
             accessJob?.cancel()
@@ -81,6 +101,10 @@ class FictionManagementStateHolder(
             }
             return
         }
+        // Refreshed on every call rather than only on the first: capability discovery can land
+        // after the first access check, and a server upgraded under a running desktop is noticed
+        // the same day.
+        _state.update { it.copy(epubUploadAvailable = epubUpload, maxEpubBytes = maxEpubBytes) }
         val newlySupported = lastSupported != true
         lastSupported = true
         if (accessJob?.isActive == true || (!forceRefresh && !newlySupported && _state.value.access in VerifiedAccess)) {
@@ -140,6 +164,36 @@ class FictionManagementStateHolder(
         }
     }
 
+    /**
+     * Opens the native picker and validates what comes back.
+     *
+     * Checked here rather than only on the server, because every one of these produces a 400 that
+     * arrives after the whole file has been uploaded — and telling somebody their 40 MB book was
+     * the wrong kind of file *after* sending it is the worst possible order to do it in.
+     */
+    fun chooseEpub() {
+        val state = _state.value
+        if (state.editor !is FictionEditor.Add || state.isBusy || !state.epubUploadAvailable) return
+        val chosen = picker.choose() ?: return
+        val problem = epubProblem(chosen, state.maxEpubBytes)
+        _state.update { current ->
+            val editor = current.editor as? FictionEditor.Add ?: return@update current
+            if (problem != null) {
+                current.copy(error = problem)
+            } else {
+                current.copy(editor = editor.copy(epubFile = chosen), error = null, notice = null)
+            }
+        }
+    }
+
+    /** Puts the dialog back on the Royal Road path without closing it. */
+    fun clearEpub() {
+        _state.update { current ->
+            val editor = current.editor as? FictionEditor.Add ?: return@update current
+            current.copy(editor = editor.copy(epubFile = null), error = null)
+        }
+    }
+
     fun updateEdit(title: String? = null, author: String? = null, voice: String? = null) {
         _state.update { current ->
             val editor = current.editor as? FictionEditor.Edit ?: return@update current
@@ -157,8 +211,11 @@ class FictionManagementStateHolder(
         val editor = _state.value.editor ?: return
         if (!_state.value.canManage || _state.value.isBusy) return
         val validation = when (editor) {
-            is FictionEditor.Add -> "A Royal Road URL or fiction id is required".takeIf {
-                editor.fictionUrl.isBlank()
+            // A chosen EPUB *is* the answer to "which fiction", so the URL is not also required.
+            is FictionEditor.Add -> when {
+                editor.epubFile != null -> epubProblem(editor.epubFile, _state.value.maxEpubBytes)
+                editor.fictionUrl.isBlank() -> "A Royal Road URL, a fiction id, or an EPUB is required"
+                else -> null
             }
 
             is FictionEditor.Edit -> when {
@@ -176,7 +233,9 @@ class FictionManagementStateHolder(
             _state.update { it.copy(isBusy = true, error = null, notice = null) }
             val outcome = runCatching {
                 when (editor) {
-                    is FictionEditor.Add -> repository.createFiction(
+                    is FictionEditor.Add -> editor.epubFile?.let { epub ->
+                        repository.uploadEpub(epub, editor.voice.trim().takeIf(String::isNotEmpty))
+                    } ?: repository.createFiction(
                         FictionCreateRequest(
                             fictionUrl = editor.fictionUrl.trim(),
                             voice = editor.voice.trim().takeIf(String::isNotEmpty),
@@ -286,6 +345,26 @@ class FictionManagementStateHolder(
     }
 
     companion object {
+        /**
+         * What is wrong with this file, or null when nothing is.
+         *
+         * Pure and internal so the three rules can be asserted without a picker, a server or a
+         * dialog. The extension check is not belt-and-braces: AWT's filename filter is a *hint*
+         * that several Linux window managers ignore outright.
+         */
+        internal fun epubProblem(file: File, maxBytes: Long?): String? = when {
+            !file.isFile -> "That file could not be read"
+            !file.name.endsWith(".epub", ignoreCase = true) -> "Only .epub files can be uploaded"
+            file.length() == 0L -> "That file is empty"
+            maxBytes != null && file.length() > maxBytes ->
+                "That file is ${formatMegabytes(file.length())}; this server accepts up to " +
+                    formatMegabytes(maxBytes)
+            else -> null
+        }
+
+        private fun formatMegabytes(bytes: Long): String =
+            String.format(java.util.Locale.ROOT, "%.1f MB", bytes / (1024.0 * 1024.0))
+
         private val VerifiedAccess = setOf(
             FictionManagementAccess.Admin,
             FictionManagementAccess.NotAdmin,

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -70,6 +70,7 @@ open class FakeRepository(
     var createFictionResult: Result<FictionSummary> = Result.success(FictionSummary(id = 101, title = "Added")),
     var updateFictionResult: Result<FictionSummary> = Result.success(FictionSummary(id = 1, title = "Updated")),
     var deleteFictionResult: Result<Boolean> = Result.success(true),
+    var uploadEpubResult: Result<FictionSummary> = Result.success(FictionSummary(id = 202, title = "Uploaded")),
     var audiobookExportsResult: Result<AudiobookExportsResponse?> = Result.success(null),
 ) : TtsRoadRepository {
     var loginCalls: Int = 0
@@ -128,6 +129,7 @@ open class FakeRepository(
     val createdFictions: MutableList<FictionCreateRequest> = mutableListOf()
     val updatedFictions: MutableList<Pair<Int, FictionUpdateRequest>> = mutableListOf()
     val deletedFictions: MutableList<Int> = mutableListOf()
+    val uploadedEpubs: MutableList<Pair<java.io.File, String?>> = mutableListOf()
 
     private val _currentCapabilities = MutableStateFlow(ServerCapabilities.Baseline)
     override val currentCapabilities: StateFlow<ServerCapabilities> = _currentCapabilities.asStateFlow()
@@ -207,6 +209,11 @@ open class FakeRepository(
     override suspend fun deleteFiction(fictionId: Int): Boolean {
         deletedFictions += fictionId
         return deleteFictionResult.getOrThrow()
+    }
+
+    override suspend fun uploadEpub(file: java.io.File, voice: String?): FictionSummary {
+        uploadedEpubs += file to voice
+        return uploadEpubResult.getOrThrow()
     }
 
     override suspend fun currentUser(): MobileUser? {

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/CapabilityDiscoveryTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/CapabilityDiscoveryTest.kt
@@ -69,6 +69,36 @@ class CapabilityDiscoveryTest {
     }
 
     @Test
+    fun `EPUB upload is advertised separately from fiction management`() {
+        // The backend is explicit that a deployment can support add/edit/delete without accepting
+        // files, so the file control must never be inferred from the CRUD flag.
+        val crudOnly = ServerCapabilities.from(
+            CapabilitiesResponse(capabilities = mapOf("fiction_management" to true)),
+        )
+        val both = ServerCapabilities.from(
+            CapabilitiesResponse(
+                capabilities = mapOf("fiction_management" to true, "epub_upload" to true),
+                limits = mapOf("max_epub_bytes" to 52_428_800),
+            ),
+        )
+
+        assertFalse(crudOnly.epubUpload)
+        assertNull(crudOnly.maxEpubBytes)
+        assertTrue(both.epubUpload)
+        assertEquals(52_428_800L, both.maxEpubBytes)
+    }
+
+    @Test
+    fun `an EPUB ceiling larger than an Int survives as a byte count`() {
+        // `max_epub_bytes` is a byte count, not an item count, and JSON has no integer width.
+        val capabilities = ServerCapabilities.from(
+            CapabilitiesResponse(limits = mapOf("max_epub_bytes" to 3_221_225_472L)),
+        )
+
+        assertEquals(3_221_225_472L, capabilities.maxEpubBytes)
+    }
+
+    @Test
     fun `discovery is unauthenticated and the marker header never reaches the wire`() = runTest {
         // A stale session for the very origin being probed: without the no-auth marker this is
         // exactly when a previous server's token would be handed to whatever is listening.

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/FictionManagementRepositoryTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/FictionManagementRepositoryTest.kt
@@ -103,6 +103,44 @@ class FictionManagementRepositoryTest {
         assertFalse(repository.deleteFiction(7), "a mismatched acknowledgement cannot confirm deletion")
     }
 
+    @Test
+    fun `an EPUB is sent as multipart with its filename and an optional voice`() = runTest {
+        val epub = java.nio.file.Files.createTempDirectory("ttsroad-epub").resolve("A Book.epub").toFile()
+        epub.writeBytes(byteArrayOf(0x50, 0x4B, 0x03, 0x04))
+        enqueue(mutationBody(202, "A Book", "en-US-AriaNeural"))
+
+        val fiction = repository.uploadEpub(epub, voice = "en-US-AriaNeural")
+
+        assertEquals(202, fiction.id)
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/api/mobile/fictions/upload-epub", request.url.encodedPath)
+        assertTrue(
+            request.headers["Content-Type"].orEmpty().startsWith("multipart/form-data"),
+            request.headers["Content-Type"].orEmpty(),
+        )
+        val body = request.bodyText()
+        // The server checks the *filename* for a `.epub` extension, so the name is part of the
+        // request rather than decoration — and only the leaf is sent, never a path.
+        assertTrue(body.contains("""filename="A Book.epub""""), body)
+        assertFalse(body.contains(epub.parent), "a local path is not the server's business")
+        assertTrue(body.contains("""name="voice""""), body)
+        assertTrue(body.contains("en-US-AriaNeural"), body)
+    }
+
+    @Test
+    fun `an upload without a voice sends no voice part at all`() = runTest {
+        val epub = java.nio.file.Files.createTempDirectory("ttsroad-epub").resolve("Plain.epub").toFile()
+        epub.writeBytes(byteArrayOf(0x50, 0x4B))
+        enqueue(mutationBody(203, "Plain", "default"))
+
+        repository.uploadEpub(epub, voice = "   ")
+
+        // Blank is "did not choose", not "choose the empty voice": the server's own default is a
+        // better answer than an empty string it would have to interpret.
+        assertFalse(server.takeRequest().bodyText().contains("""name="voice""""))
+    }
+
     private fun mutationBody(id: Int, title: String, voice: String): String =
         """{"api_version":1,"status":"ok","fiction":{"id":$id,"title":"$title","voice":"$voice"}}"""
 }

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolderTest.kt
@@ -25,7 +25,7 @@ class FictionManagementStateHolderTest {
             currentUserResult = Result.success(MobileUser(1, "boss", isAdmin = true)),
         )
         val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
-        val holder = FictionManagementStateHolder(repository, cache, UnconfinedTestDispatcher(testScheduler))
+        val holder = FictionManagementStateHolder(repository, cache, dispatcher = UnconfinedTestDispatcher(testScheduler))
 
         holder.ensureAccess(supported = false)
         assertEquals(FictionManagementAccess.Unsupported, holder.state.value.access)
@@ -52,7 +52,7 @@ class FictionManagementStateHolderTest {
             currentUserResult = Result.success(MobileUser(2, "listener", isAdmin = false)),
         )
         val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
-        val holder = FictionManagementStateHolder(repository, cache, UnconfinedTestDispatcher(testScheduler))
+        val holder = FictionManagementStateHolder(repository, cache, dispatcher = UnconfinedTestDispatcher(testScheduler))
 
         holder.ensureAccess(supported = true)
         runCurrent()
@@ -147,9 +147,146 @@ class FictionManagementStateHolderTest {
         repository: FakeRepository,
         cache: LibraryCache,
     ): FictionManagementStateHolder =
-        FictionManagementStateHolder(repository, cache, UnconfinedTestDispatcher(testScheduler)).also {
+        FictionManagementStateHolder(repository, cache, dispatcher = UnconfinedTestDispatcher(testScheduler)).also {
             it.ensureAccess(supported = true)
             runCurrent()
             assertEquals(FictionManagementAccess.Admin, it.state.value.access)
         }
+
+    // --- EPUB upload ------------------------------------------------------------------------------
+
+    private class EpubFixture(
+        val repository: FakeRepository,
+        val cache: LibraryCache,
+        val holder: FictionManagementStateHolder,
+    )
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun TestScope.adminFixture(
+        picker: EpubFilePicker,
+        epubUpload: Boolean = true,
+        maxEpubBytes: Long? = 50L * 1024 * 1024,
+    ): EpubFixture {
+        val repository = FakeRepository(
+            currentUserResult = Result.success(MobileUser(1, "boss", isAdmin = true)),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        val holder = FictionManagementStateHolder(
+            repository,
+            cache,
+            picker = picker,
+            dispatcher = UnconfinedTestDispatcher(testScheduler),
+        )
+        holder.ensureAccess(supported = true, epubUpload = epubUpload, maxEpubBytes = maxEpubBytes)
+        runCurrent()
+        return EpubFixture(repository, cache, holder)
+    }
+
+    private fun epubFile(name: String, bytes: Int): java.io.File =
+        java.nio.file.Files.createTempDirectory("ttsroad-epub").resolve(name).toFile()
+            .also { it.writeBytes(ByteArray(bytes)) }
+
+    @Test
+    fun `a chosen EPUB is uploaded instead of an added URL`() = runTest {
+        val epub = epubFile("A Book.epub", bytes = 4)
+        val fixture = adminFixture(picker = { epub })
+
+        fixture.holder.openAdd()
+        fixture.holder.chooseEpub()
+        fixture.holder.updateAdd(voice = "en-US-AriaNeural")
+        fixture.holder.submitEditor()
+        runCurrent()
+
+        assertEquals(listOf<Pair<java.io.File, String?>>(epub to "en-US-AriaNeural"), fixture.repository.uploadedEpubs)
+        assertTrue(fixture.repository.createdFictions.isEmpty(), "the Royal Road path must not also run")
+        assertNull(fixture.holder.state.value.editor, "a successful upload closes the dialog")
+        fixture.cache.close()
+    }
+
+    @Test
+    fun `an EPUB removes the requirement for a URL`() = runTest {
+        val epub = epubFile("A Book.epub", bytes = 4)
+        val fixture = adminFixture(picker = { epub })
+        fixture.holder.openAdd()
+
+        // Without a file this fails validation before any request is made.
+        fixture.holder.submitEditor()
+        runCurrent()
+        assertEquals(
+            "A Royal Road URL, a fiction id, or an EPUB is required",
+            fixture.holder.state.value.error,
+        )
+
+        fixture.holder.chooseEpub()
+        fixture.holder.submitEditor()
+        runCurrent()
+
+        assertNull(fixture.holder.state.value.error)
+        assertEquals(1, fixture.repository.uploadedEpubs.size)
+        fixture.cache.close()
+    }
+
+    @Test
+    fun `the wrong kind of file is refused before it is uploaded`() = runTest {
+        // Telling somebody their 40 MB book was the wrong kind of file *after* sending it is the
+        // worst possible order to do it in — and AWT's filename filter is only a hint anyway.
+        val fixture = adminFixture(picker = { epubFile("notes.txt", bytes = 4) })
+        fixture.holder.openAdd()
+
+        fixture.holder.chooseEpub()
+
+        assertEquals("Only .epub files can be uploaded", fixture.holder.state.value.error)
+        assertNull(assertIs<FictionEditor.Add>(fixture.holder.state.value.editor).epubFile)
+        fixture.cache.close()
+    }
+
+    @Test
+    fun `a file over the server's published ceiling is refused with both numbers`() = runTest {
+        val fixture = adminFixture(
+            picker = { epubFile("Huge.epub", bytes = 3 * 1024 * 1024) },
+            maxEpubBytes = 1024L * 1024,
+        )
+        fixture.holder.openAdd()
+
+        fixture.holder.chooseEpub()
+
+        val error = fixture.holder.state.value.error.orEmpty()
+        assertTrue(error.contains("3.0 MB"), error)
+        assertTrue(error.contains("1.0 MB"), error)
+        fixture.cache.close()
+    }
+
+    @Test
+    fun `a server that does not accept files offers no way to choose one`() = runTest {
+        var asked = false
+        val fixture = adminFixture(
+            picker = {
+                asked = true
+                null
+            },
+            epubUpload = false,
+        )
+        fixture.holder.openAdd()
+
+        fixture.holder.chooseEpub()
+
+        assertFalse(asked, "the picker must not open where the server cannot accept the result")
+        assertFalse(fixture.holder.state.value.epubUploadAvailable)
+        fixture.cache.close()
+    }
+
+    @Test
+    fun `cancelling the picker changes nothing`() = runTest {
+        val fixture = adminFixture(picker = { null })
+        fixture.holder.openAdd()
+        fixture.holder.updateAdd(fictionUrl = "12345")
+
+        fixture.holder.chooseEpub()
+
+        val editor = assertIs<FictionEditor.Add>(fixture.holder.state.value.editor)
+        assertNull(editor.epubFile)
+        assertNull(fixture.holder.state.value.error, "cancelling is not an error")
+        assertEquals("12345", editor.fictionUrl)
+        fixture.cache.close()
+    }
 }


### PR DESCRIPTION
Fixes #52 — the last part of it, now that the upstream dependency has landed.

`jonarihen/TTSRoad#124` shipped the mirrored `POST /api/mobile/fictions/upload-epub` that #52 (and #60's `Addresses`, rather than `Fixes`) was waiting on. This builds on that contract.

The desktop is the client with a real filesystem, a real file picker and a window big enough for the form — the argument #52 makes for putting whole-book import here rather than on a phone. It lives in the existing **Add fiction** dialog: "add a fiction" is one intention, and making the user choose which *kind* of add they meant before showing them either form asks them to know the implementation. Choosing a file disables the URL field and says why, rather than hiding it out from under the cursor.

## Three decisions, recorded in ADR 0012

- **`epub_upload` is a capability of its own, never inferred from `fiction_management`.** The backend is explicit that a deployment can accept JSON fiction CRUD without accepting files.
- **Validation happens before the upload.** A wrong extension, an empty file, and a file over `limits.max_epub_bytes` are all rejections that would otherwise arrive *after* forty megabytes had gone over the wire — the worst possible order to tell someone. The extension check is not redundant with the picker's own filter either: AWT's `setFilenameFilter` is a hint several Linux window managers ignore outright.
- **Only the filename leaf is sent.** The server checks the extension, so the name is part of the request rather than decoration; the directory it came from is not the server's business. The body streams from the file rather than being read into the heap first.

`rate` and `enabled` exist on the contract and are left at their defaults: there is no per-fiction rate control here, and uploading a fiction in order to disable it is not something anyone asked for.

## Coverage

- `FictionManagementRepositoryTest` — the multipart request against MockWebServer: path, `multipart/form-data`, the `filename=` leaf, no local path in the body, the voice part, and no voice part at all for a blank voice.
- `FictionManagementStateHolderTest` — an EPUB uploads instead of adding a URL and closes the dialog; a file removes the URL requirement; the wrong extension is refused before sending; an oversized file is refused naming *both* numbers; a server without the capability never opens the picker; cancelling is not an error.
- `CapabilityDiscoveryTest` — `epub_upload` is not implied by `fiction_management`, and a ceiling larger than an `Int` survives as a byte count.

## Validation

```
xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail -Pttsroad.warningsAsErrors=true
```

`BUILD SUCCESSFUL`.