### PR TITLE
Document binding global skip keys over MPRIS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to TTSRoad Desktop are recorded here. The format follows
 
 ### Changed
 
+- The README now shows how to bind global skip-back and skip-forward keys yourself, over the MPRIS
+  `Seek` method the app already implements. TTSRoad still registers no global hotkeys of its own.
 - Completed the release quality gate with a documented accessibility/performance/compatibility
   matrix, maintainer architecture/API/release runbook, 200% text-scale and long-session/navigation
   soak coverage, and automated WCAG AA contrast checks. Secondary/error/sepia text tokens now meet

--- a/README.md
+++ b/README.md
@@ -582,6 +582,33 @@ still refreshes from inside the search box, while Space, the arrows and Ctrl+arr
 the ordinary handler, which a focused text field has already consumed them from. No global hotkeys
 are registered — media keys reach the app through the desktop's own MPRIS routing instead.
 
+### Skipping without leaving the window you are in
+
+Play/pause, next and previous already work with no focus: they are media keys, and the desktop
+routes them over MPRIS. Skip back and forward are the two controls with **no media key of their
+own**, which makes them the ones a listener actually misses while working in another window.
+
+TTSRoad deliberately grabs no keys system-wide — taking a combination away from every other
+application without being asked is hostile, and doing it portably across X11 and Wayland is not
+possible today anyway. What it does instead is implement MPRIS `Seek`, so **you** can bind the keys,
+in your own desktop's keyboard settings, and keep the choice of which ones:
+
+```bash
+# Back 30 seconds. MPRIS offsets are microseconds, and negative means backwards.
+gdbus call --session --dest org.mpris.MediaPlayer2.TTSRoad \
+  --object-path /org/mpris/MediaPlayer2 \
+  --method org.mpris.MediaPlayer2.Player.Seek -- -30000000
+
+# Forward 30 seconds.
+gdbus call --session --dest org.mpris.MediaPlayer2.TTSRoad \
+  --object-path /org/mpris/MediaPlayer2 \
+  --method org.mpris.MediaPlayer2.Player.Seek -- 30000000
+```
+
+In Cinnamon that is *Keyboard → Shortcuts → Custom Shortcuts*; GNOME, KDE and XFCE all have the
+same thing under a different name. The commands do nothing when TTSRoad is not running, which is
+the correct behaviour for a key you bound to a media player.
+
 ## 🧭 Navigation, state and window behaviour
 
 Browsing is a real back stack over destinations (Library, Fiction, Player, Reader, Settings,


### PR DESCRIPTION
Addresses the **global hotkeys** item (§1) in #41, with the version of it that is not hostile.

#41 narrows the ask correctly: play/pause, next and previous already work with no focus, because they are media keys the desktop routes over MPRIS. Skip back and forward have **no media key of their own**, which makes them the two a listener actually misses while working in another window.

Grabbing them system-wide is still the wrong answer. Taking a combination away from every other application without being asked is hostile — ADR 0006 already records that decision — and doing it portably across X11 and Wayland is not possible today regardless.

But the app already implements MPRIS `Seek`, so the capability the issue wants **exists** and simply was not written down. Binding it is a two-line custom shortcut in any desktop's keyboard settings, and doing it that way leaves the choice of *which* keys with the person whose keyboard it is:

```bash
gdbus call --session --dest org.mpris.MediaPlayer2.TTSRoad \
  --object-path /org/mpris/MediaPlayer2 \
  --method org.mpris.MediaPlayer2.Player.Seek -- -30000000
```

Documentation only — no behaviour change, no new keys registered.