### PR TITLE
release: 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,17 +18,11 @@ All notable changes to TTSRoad Desktop are recorded here. The format follows
 
 ## [Unreleased]
 
-### Changed
+## [1.1.0] - 2026-08-17
 
-- The README now shows how to bind global skip-back and skip-forward keys yourself, over the MPRIS
-  `Seek` method the app already implements. TTSRoad still registers no global hotkeys of its own.
-- Completed the release quality gate with a documented accessibility/performance/compatibility
-  matrix, maintainer architecture/API/release runbook, 200% text-scale and long-session/navigation
-  soak coverage, and automated WCAG AA contrast checks. Secondary/error/sepia text tokens now meet
-  the 4.5:1 normal-text threshold on their supported surfaces.
-- The README now states the platform support policy once and plainly: Linux is supported and proven
-  by a clean-container install/upgrade/uninstall run, while the Windows and macOS installers are
-  built and smoke-launched but have no clean-machine lifecycle coverage.
+Three-client parity and the desktop-native features that follow from having a real filesystem, a
+real window manager and a real keyboard. Every server-dependent feature here is capability-gated,
+so an older server keeps its existing login, library and playback behaviour unchanged.
 
 ### Added
 
@@ -75,6 +69,18 @@ All notable changes to TTSRoad Desktop are recorded here. The format follows
   container validation, fsync, atomic promotion, and resumable partials. Export creation/deletion
   remains in the web admin and saved files stay outside TTSRoad-managed offline storage.
 
+### Changed
+
+- Completed the release quality gate with a documented accessibility/performance/compatibility
+  matrix, maintainer architecture/API/release runbook, 200% text-scale and long-session/navigation
+  soak coverage, and automated WCAG AA contrast checks. Secondary/error/sepia text tokens now meet
+  the 4.5:1 normal-text threshold on their supported surfaces.
+- The README now shows how to bind global skip-back and skip-forward keys yourself, over the MPRIS
+  `Seek` method the app already implements. TTSRoad still registers no global hotkeys of its own.
+- The README now states the platform support policy once and plainly: Linux is supported and proven
+  by a clean-container install/upgrade/uninstall run, while the Windows and macOS installers are
+  built and smoke-launched but have no clean-machine lifecycle coverage.
+
 ## [1.0.2] - 2026-08-10
 
 ### Fixed
@@ -109,6 +115,7 @@ server.
 - A Debian package with a bundled JDK 25 runtime, desktop entry, upgrade-safe revisioning and XDG
   rotating logs, plus credential-safe `--version` and `--diagnostics` commands.
 
-[Unreleased]: https://github.com/jonarihen/TTSRoad-Desktop/compare/v1.0.2...HEAD
+[Unreleased]: https://github.com/jonarihen/TTSRoad-Desktop/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/jonarihen/TTSRoad-Desktop/releases/tag/v1.1.0
 [1.0.2]: https://github.com/jonarihen/TTSRoad-Desktop/releases/tag/v1.0.2
 [1.0.1]: https://github.com/jonarihen/TTSRoad-Desktop/releases/tag/v1.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.configuration-cache=true
 #   - BuildInfo.VERSION, which the runtime About text renders
 #   - release automation / CI artifact names
 # jpackage rejects MAJOR 0, so this must stay >= 1.0.0.
-ttsroad.version=1.0.2
+ttsroad.version=1.1.0
 
 # Debian revision, deliberately separate from the application version. A packaging-only fix can
 # move 1.0.1-1 to 1.0.1-2 without making the About screen claim the application itself changed.


### PR DESCRIPTION
Cuts the accumulated `[Unreleased]` work as **1.1.0**.

## Why MINOR, not PATCH

The Unreleased section is almost entirely new, backward-compatible features, which is a MINOR bump under the SemVer policy recorded at the top of `CHANGELOG.md`:

- **Parity work:** timestamp delta sync, bookmarks-backed cross-device jump-back history, the cross-library server queue, admin fiction management, EPUB upload, M4B export downloads.
- **Desktop-native work:** system tray with transport, distraction-free reading, per-book playback speed, local listening statistics.
- **Changed:** the release quality gate completion (accessibility/performance/compatibility matrix, WCAG AA contrast checks) and two README clarifications.

`ttsroad.debRevision` stays at `1` on purpose — it is Debian's revision for a packaging-only rebuild, and the application version genuinely changed here, so it resets rather than increments.

## Changelog restructuring

`[Unreleased]` became `## [1.1.0] - 2026-08-17` with a short lead paragraph matching the house style of the `1.0.1` section, and the sub-sections were put into Keep a Changelog order (Added before Changed). A fresh empty `[Unreleased]` and the `[1.1.0]` link reference were added.

## Verification

- `./packaging/release/changelog-section.sh 1.1.0` extracts 60 lines of notes — this is the same script `release.yml` uses as both the notes extractor and the publish gate.
- The same script correctly **fails** on the now-empty `Unreleased`, confirming an empty section is treated as no section.
- `xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail -Pttsroad.warningsAsErrors=true` → **BUILD SUCCESSFUL** (6m39s). Only skips are the two Windows Credential Manager tests, expected on Linux.
- Generated `BuildInfo.VERSION` confirmed as `1.1.0`, so the About text, diagnostics and window title all follow.

Remaining `1.0.2` strings in the tree are update-checker test fixtures and historical references in `docs/QUALITY-GATE.md` / ADR 0011; none of them are the application version and all are correctly untouched. The QUALITY-GATE release-evidence row gets its `1.1.0` entry once the tagged release run produces a run id.

Tagging `v1.1.0` after this merges is what triggers `release.yml` to build all three installers, run the clean-container .deb lifecycle, checksum and attest them, and create the **draft** release.