### PR TITLE
Correct a fiction's description, tags and cover art

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,26 @@ arrive after the whole file went over the wire — and AWT's filename filter is 
 window managers ignore. The upload streams from the file; only the filename leaf is sent, because
 the server checks the extension and a local path is not its business.
 
+**Adding is a dialog; editing is a screen.** `FictionManagementStateHolder` owns add and delete —
+a question and an answer. `FictionMetadataStateHolder` owns editing, and it is a screen because its
+fields are shared with every account: on a server that tracks hand edits, **writing a metadata field
+takes ownership of it**, and the field stops being refreshed from the source until somebody hands it
+back. So the editor sends only fields whose value actually *changed* — a request carrying a title
+nobody touched freezes it forever — and "use source values" sends `clear_overrides` **without** the
+values, since sending one would re-claim the field the same instant it was released. The server is
+the authority on what it stored: `ignoredFields` reads the response rather than assuming the write
+landed, so an older server that drops `description`/`tags` is reported instead of reported as saved.
+Voice is deliberately outside all of this — it is a conversion setting, not metadata, and changing
+it claims nothing.
+
+Cover art is an **upload, not a URL field**: the server only embeds art it holds itself, so a pasted
+link renders in a browser and then silently fails to reach the MP3s. `POST /fictions/{id}/cover` has
+no capability flag — it is additive, so a **404 is the only signal** that a server predates it, and
+that 404 is indistinguishable from "no such fiction". Both mean the cover did not change, which is
+all a caller has to be told, and it retires the control rather than offering a retry. The metadata
+patch is sent *before* the image so a save that worked is kept and published even when the image is
+refused afterwards.
+
 ### The server queue, which is not the player's queue
 
 `data/ServerQueue.kt` + `ui/ServerQueueStateHolder.kt` model the account's cross-library queue

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -64,6 +64,7 @@ endpoint 404 becomes a concise unsupported state. Never infer a feature from `ap
 | `delta_sync` | cursor-driven library/chapter metadata refresh | ordinary full refresh of both resources |
 | `fiction_management` | admin add/edit/delete, gated *again* by `/me`'s `is_admin` | management controls hidden |
 | `epub_upload` | multipart EPUB import, **never** inferred from `fiction_management` | the upload control is hidden; add-by-URL still works |
+| *(no flag)* `POST /fictions/{id}/cover` | cover-art replacement from the metadata editor | additive route — a **404 is the only signal**, and it stops the control being offered |
 | `audiobook_export` | read-only M4B export shelf and resumable save | Audiobooks pane hidden |
 | `audio_content_hash` | reserved/parsed contract flag | no UI is promised merely by parsing |
 

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -78,6 +78,8 @@ import dk.perspektiva.ttsroad.desktop.ui.ContentMaxWidth
 import dk.perspektiva.ttsroad.desktop.ui.FictionDetailScreen
 import dk.perspektiva.ttsroad.desktop.ui.FictionManagementDialogs
 import dk.perspektiva.ttsroad.desktop.ui.FictionManagementStateHolder
+import dk.perspektiva.ttsroad.desktop.ui.FictionMetadataScreen
+import dk.perspektiva.ttsroad.desktop.ui.FictionMetadataStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.LibraryScreen
 import dk.perspektiva.ttsroad.desktop.ui.LoginStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.MetaText
@@ -153,6 +155,11 @@ fun App(container: AppContainer = remember { AppContainer() }) {
         FictionManagementStateHolder(repository, cache)
     }
     val fictionManagementState by fictionManagement.state.collectAsState()
+    // Hoisted for the same reason the management holder is: the editor is a form, a save is a
+    // request, and neither may be lost because the user glanced at the library mid-edit.
+    val fictionMetadata = rememberStateHolder(repository, cache) {
+        FictionMetadataStateHolder(repository, cache)
+    }
 
     // Capability discovery is the only source of the server's stable advertised identity. Feed it
     // into the download namespace as soon as it arrives; using it only for feature flags would
@@ -183,7 +190,8 @@ fun App(container: AppContainer = remember { AppContainer() }) {
     LaunchedEffect(fictionManagementState.deletedFictionId) {
         val deleted = fictionManagementState.deletedFictionId ?: return@LaunchedEffect
         val current = nav.current
-        if (current is Destination.Fiction && current.fiction.id == deleted) nav.back()
+        val editingDeleted = current is Destination.FictionMetadata && current.fiction.id == deleted
+        if (current is Destination.Fiction && current.fiction.id == deleted || editingDeleted) nav.back()
         fictionManagement.consumeDeletedFiction()
     }
 
@@ -211,7 +219,8 @@ fun App(container: AppContainer = remember { AppContainer() }) {
             Destination.Search -> search.refresh()
             Destination.Bookmarks -> bookmarks.refresh()
             Destination.Queue -> serverQueue.refresh()
-            Destination.Player, is Destination.Reader -> Unit
+            // A form and a player have nothing a refresh could improve; see `isRefreshable`.
+            Destination.Player, is Destination.Reader, is Destination.FictionMetadata -> Unit
         }
     }
 
@@ -370,6 +379,7 @@ fun App(container: AppContainer = remember { AppContainer() }) {
             bookmarks.sessionEnded()
             serverQueue.sessionEnded()
             fictionManagement.sessionEnded()
+            fictionMetadata.sessionEnded()
         } else {
             // Cheap, and it is what makes optional UI correct after a restart, where login did
             // not run but a keyring-backed session was restored.
@@ -528,9 +538,27 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                         fictionId = destination.fiction.id,
                                     ),
                                     fictionManagement = fictionManagementState,
-                                    onEditFiction = fictionManagement::openEdit,
+                                    onEditFiction = { nav.open(Destination.FictionMetadata(it)) },
                                     onDeleteFiction = fictionManagement::askDelete,
                                 )
+
+                                is Destination.FictionMetadata -> {
+                                    // Re-pointed on every fresher copy the cache publishes, and on
+                                    // the destination's own payload before one has arrived. The
+                                    // holder keeps whatever is typed across both.
+                                    val cached by cache.chapters(destination.fiction.id).collectAsState()
+                                    LaunchedEffect(cached.value?.fiction, destination.fiction) {
+                                        fictionMetadata.load(
+                                            cached.value?.fiction ?: destination.fiction,
+                                            maxCoverBytes = capabilities.maxCoverBytes,
+                                        )
+                                    }
+                                    FictionMetadataScreen(
+                                        holder = fictionMetadata,
+                                        repository = repository,
+                                        onBack = { nav.back() },
+                                    )
+                                }
 
                                 Destination.Player -> PlayerScreen(
                                     playback = playback,
@@ -648,6 +676,9 @@ private val Destination.isRefreshable: Boolean
         Destination.Library, is Destination.Fiction, Destination.Settings, Destination.Devices,
         Destination.Bookmarks, Destination.Queue,
         -> true
+        // A form has nothing to refresh into: the fields hold what somebody is halfway through
+        // typing, and replacing them with the server's copy is the opposite of what F5 promises.
+        is Destination.FictionMetadata -> false
         // Refresh re-runs the query the results belong to; it is dead until one has been run, but
         // enabling it is cheaper to reason about than a state-dependent header button.
         Destination.Search -> true
@@ -716,7 +747,8 @@ private fun HeaderBar(
             Spacer(Modifier.weight(1f))
             NavItem(
                 "Library",
-                active = current == Destination.Library || current is Destination.Fiction,
+                active = current == Destination.Library || current is Destination.Fiction ||
+                    current is Destination.FictionMetadata,
             ) { onSelect(Destination.Library) }
             if (showBookmarks) {
                 NavItem("Bookmarks", active = current == Destination.Bookmarks) {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
@@ -115,6 +115,15 @@ data class FictionSummary(
     val tags: List<String> = emptyList(),
     val rating: Double? = null,
     @param:Json(name = "rating_count") val ratingCount: Int? = null,
+    /**
+     * Which metadata fields a person edited, and which the server therefore stops refreshing from
+     * the source. The names are the server's own — see [FictionMetadataFields].
+     *
+     * Defaults to empty rather than to null, because "this server has never heard of hand edits"
+     * and "nothing here is hand-edited" want exactly the same screen: no ownership markers, every
+     * field still the source's. A server that supports them says so by listing names.
+     */
+    @param:Json(name = "metadata_overrides") val metadataOverrides: List<String> = emptyList(),
     @param:Json(name = "total_chapters") val totalChapters: Int = 0,
     @param:Json(name = "done_chapters") val doneChapters: Int = 0,
     @param:Json(name = "pending_chapters") val pendingChapters: Int = 0,
@@ -141,12 +150,115 @@ data class FictionCreateRequest(
     val voice: String? = null,
 )
 
-/** Admin-only fields intentionally exposed by the desktop editor. */
+/**
+ * Admin-only fields intentionally exposed by the desktop editor.
+ *
+ * Every field is nullable and Moshi omits a null rather than writing one, which is what makes the
+ * server's "absent means leave this alone" reachable from here. That distinction is load-bearing
+ * now that editing a metadata field also *claims* it: sending a title the user never touched would
+ * quietly freeze it against every future refresh of the source. The editor therefore sends the
+ * fields somebody actually changed, and nothing else.
+ */
 data class FictionUpdateRequest(
     val title: String? = null,
+    /** Empty string clears the author. */
     val author: String? = null,
+    /** Empty string clears the description. Ignored by a server that predates hand-edited metadata. */
+    val description: String? = null,
+    /** Empty list clears the tags. The server trims, de-duplicates and caps whatever it is sent. */
+    val tags: List<String>? = null,
     val voice: String? = null,
+    /**
+     * Metadata field names to hand back to the source, so the next poll may overwrite them again.
+     *
+     * It does **not** restore the value the source last had — nothing keeps a copy of it — and the
+     * server applies this after the field assignments above, so releasing a field wins over having
+     * just set it in the same request. Unknown names are ignored rather than rejected.
+     */
+    @param:Json(name = "clear_overrides") val clearOverrides: List<String>? = null,
 )
+
+/**
+ * The metadata fields a person can take ownership of, named exactly as the server names them.
+ *
+ * String constants rather than an enum because these names travel on the wire in both directions:
+ * a server newer than this build may protect a field this client has never heard of, and an
+ * unknown name has to survive being read and echoed rather than failing to parse.
+ */
+object FictionMetadataFields {
+    const val Title: String = "title"
+    const val Author: String = "author"
+    const val Description: String = "description"
+    const val Tags: String = "tags"
+    const val CoverImage: String = "cover_image_url"
+
+    /** Ordered the way the editor lays the fields out, which is also how they are listed to a user. */
+    val All: List<String> = listOf(Title, Author, Description, Tags, CoverImage)
+
+    /** Sentence-case label for one field name, including one this build does not know. */
+    fun labelOf(field: String): String = when (field) {
+        Title -> "Title"
+        Author -> "Author"
+        Description -> "Description"
+        Tags -> "Tags"
+        CoverImage -> "Cover art"
+        else -> field.replace('_', ' ')
+    }
+}
+
+/** What the server will store for a hand-typed tag list (`_clean_tags` in `app/routers/fictions.py`). */
+object FictionTagLimits {
+    const val MaxTags: Int = 50
+    const val MaxTagChars: Int = 100
+}
+
+/**
+ * Normalise a tag list the way the server will.
+ *
+ * Mirrored rather than left to the backend so the editor can show what is actually going to be
+ * stored: a round trip that silently drops the third spelling of "LitRPG" reads as the save having
+ * failed. De-duplication is case-insensitive and keeps the first spelling, so typing "litrpg" after
+ * "LitRPG" does not restyle the tag that is already there.
+ */
+fun cleanFictionTags(values: List<String>): List<String> {
+    val cleaned = mutableListOf<String>()
+    val seen = mutableSetOf<String>()
+    for (raw in values) {
+        val tag = raw.split(WhitespaceRun).filter(String::isNotEmpty).joinToString(" ")
+            .take(FictionTagLimits.MaxTagChars)
+        if (tag.isEmpty() || !seen.add(tag.lowercase())) continue
+        cleaned += tag
+        if (cleaned.size >= FictionTagLimits.MaxTags) break
+    }
+    return cleaned
+}
+
+private val WhitespaceRun = Regex("\\s+")
+
+/**
+ * Cover art formats the server stores, and what to call an upload on the wire.
+ *
+ * The server decides from the decoded bytes rather than from the filename or the declared type, so
+ * this is a courtesy — but it is also what the native picker filters on, and telling somebody their
+ * TIFF is unsupported before it uploads is better than a 400 afterwards.
+ */
+object CoverImageFormats {
+    val Extensions: List<String> = listOf("jpg", "jpeg", "png", "webp", "gif")
+
+    /** "JPEG, PNG, WEBP or GIF", for a supporting line under the cover control. */
+    val Description: String = "JPEG, PNG, WEBP or GIF"
+
+    fun isSupported(fileName: String): Boolean = extensionOf(fileName) in Extensions
+
+    fun mediaTypeOf(fileName: String): String = when (extensionOf(fileName)) {
+        "png" -> "image/png"
+        "webp" -> "image/webp"
+        "gif" -> "image/gif"
+        else -> "image/jpeg"
+    }
+
+    private fun extensionOf(fileName: String): String = fileName.substringAfterLast('.', "").lowercase()
+}
 
 data class FictionMutationResponse(
     @param:Json(name = "api_version") val apiVersion: Int = 1,

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -57,6 +57,37 @@ sealed interface LoginResult {
 }
 
 /**
+ * What a cover upload did.
+ *
+ * Typed rather than thrown for the same reason [LoginResult] is: "the server read this request and
+ * said no" is not a failed request, and the three answers below want three different sentences on
+ * screen. Anything else — a 500, a dropped connection, an expired session — still propagates as an
+ * exception, because none of those say anything about the image.
+ */
+sealed interface CoverUploadResult {
+    /** The server accepted it and answered the fiction as it now stands. */
+    data class Saved(val fiction: FictionSummary) : CoverUploadResult
+
+    /**
+     * The route answered 404.
+     *
+     * Deliberately one case for two causes: a server older than cover upload and a fiction that is
+     * no longer there are indistinguishable on the wire, and both mean the cover did not change.
+     */
+    data object Unsupported : CoverUploadResult
+
+    /** The server refused the image itself — too large, not an image, not this account's to change. */
+    data class Rejected(val message: String) : CoverUploadResult
+}
+
+/** Said only where the server refused without explaining itself, which older proxies manage to do. */
+private fun coverRejectionFor(code: Int): String = when (code) {
+    413 -> "That image is larger than this server accepts"
+    403 -> "This account may not change cover art"
+    else -> "The server did not accept that image"
+}
+
+/**
  * Seam for everything the UI needs from the TTSRoad server. [RetrofitTtsRoadRepository] is the
  * production implementation; tests either drive that one against a MockWebServer or substitute a
  * hand-written fake.
@@ -134,6 +165,15 @@ interface TtsRoadRepository {
     /** Uploads one EPUB and answers the fiction the server created from it. */
     suspend fun uploadEpub(file: File, voice: String? = null): FictionSummary =
         error("EPUB upload is not implemented")
+
+    /**
+     * Replaces a fiction's cover art with a local image file.
+     *
+     * Defaults to [CoverUploadResult.Unsupported] so a substituted repository that has never heard
+     * of the route behaves like a server that has never heard of it either.
+     */
+    suspend fun uploadFictionCover(fictionId: Int, file: File): CoverUploadResult =
+        CoverUploadResult.Unsupported
 
     /**
      * Follows or unfollows a fiction, answering the state **the server now holds**, or null when it
@@ -467,6 +507,30 @@ class RetrofitTtsRoadRepository(
             file.asRequestBody(EpubMediaType),
         )
         api.uploadEpub(part, voice?.takeIf(String::isNotBlank)?.toRequestBody(TextMediaType)).fiction
+    }
+
+    override suspend fun uploadFictionCover(fictionId: Int, file: File): CoverUploadResult = try {
+        // Streamed from the file like an EPUB is, and named `file` because that is the one part
+        // name the route accepts. The media type is derived from the extension as a courtesy —
+        // the server decides from the decoded bytes, not from what the client claims.
+        val part = MultipartBody.Part.createFormData(
+            "file",
+            file.name,
+            file.asRequestBody(CoverImageFormats.mediaTypeOf(file.name).toMediaType()),
+        )
+        CoverUploadResult.Saved(withAuthorizedApi { it.uploadFictionCover(fictionId, part).fiction })
+    } catch (e: HttpException) {
+        when (e.code()) {
+            404 -> CoverUploadResult.Unsupported
+            // The server's own words where it has them: "Cover too large; limit is 10 MB" is worth
+            // more to the person holding the file than any sentence this client could invent.
+            400, 403, 413, 415, 422 -> CoverUploadResult.Rejected(
+                redactSecrets(detailMessage(e.response()?.errorBody()?.string()))
+                    .takeIf { it.isNotBlank() }
+                    ?: coverRejectionFor(e.code()),
+            )
+            else -> throw e
+        }
     }
 
     override suspend fun setFollowing(fictionId: Int, following: Boolean): Boolean? =

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
@@ -82,6 +82,15 @@ data class ServerCapabilities(
     val maxPlaybackSyncItems: Int? = null,
     /** The server's EPUB ceiling. A `Long`, because a byte count is not an item count. */
     val maxEpubBytes: Long? = null,
+    /**
+     * The server's cover-art ceiling, when it publishes one.
+     *
+     * Null on every server built so far: cover upload is an additive route with no advertised
+     * limit yet, so the editor checks what it can locally (format, emptiness) and lets a 413 speak
+     * for the rest. Parsed anyway because the day a server does publish it, the pre-upload check
+     * should start working without a client release.
+     */
+    val maxCoverBytes: Long? = null,
 ) {
     /** True once discovery has actually reached a TTSRoad server (only it reports a version). */
     val isDiscovered: Boolean get() = serverVersion != null
@@ -110,6 +119,7 @@ data class ServerCapabilities(
             maxChaptersPerPage = response.limits.intLimit("max_chapters_per_page"),
             maxPlaybackSyncItems = response.limits.intLimit("max_playback_sync_items"),
             maxEpubBytes = response.limits.longLimit("max_epub_bytes"),
+            maxCoverBytes = response.limits.longLimit("max_cover_bytes"),
         )
 
         /**

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -110,6 +110,22 @@ interface TtsRoadApi {
         @Body request: FictionUpdateRequest,
     ): FictionMutationResponse
 
+    /**
+     * Replaces a fiction's cover art with an uploaded image.
+     *
+     * An upload rather than a URL field because the server only embeds cover art it holds itself —
+     * a pasted link renders in a browser and then silently fails to reach the MP3s. There is no
+     * capability flag for this route: it is additive, so a **404 is the only signal** that a server
+     * predates it, and that 404 is indistinguishable from "no such fiction". Both mean the cover
+     * did not change, which is all a caller has to be told.
+     */
+    @Multipart
+    @POST("api/mobile/fictions/{fiction_id}/cover")
+    suspend fun uploadFictionCover(
+        @Path("fiction_id") fictionId: Int,
+        @Part file: MultipartBody.Part,
+    ): FictionMutationResponse
+
     /** Deletes the shared fiction and every account's dependent progress. */
     @DELETE("api/mobile/fictions/{fiction_id}")
     suspend fun deleteFiction(@Path("fiction_id") fictionId: Int): FictionDeleteResponse

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/nav/AppNavigation.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/nav/AppNavigation.kt
@@ -21,6 +21,15 @@ sealed interface Destination {
 
     data class Fiction(val fiction: FictionSummary) : Destination
 
+    /**
+     * The admin editor for one fiction's metadata.
+     *
+     * Distinct from [Fiction] with the same id, and keyed separately, because it is a form: leaving
+     * it and coming back is a different act from scrolling a chapter list, and the two must not
+     * share a retained-state slot or a place in the back stack.
+     */
+    data class FictionMetadata(val fiction: FictionSummary) : Destination
+
     data object Player : Destination
 
     /**
@@ -79,6 +88,7 @@ val Destination.key: String
     get() = when (this) {
         Destination.Library -> "Library"
         is Destination.Fiction -> "Fiction:${fiction.id}"
+        is Destination.FictionMetadata -> "FictionMetadata:${fiction.id}"
         Destination.Player -> "Player"
         is Destination.Reader -> "Reader:$chapterId"
         Destination.Search -> "Search"

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/CoverImagePicker.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/CoverImagePicker.kt
@@ -1,0 +1,38 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.data.CoverImageFormats
+import java.awt.FileDialog
+import java.awt.Frame
+import java.awt.GraphicsEnvironment
+import java.io.File
+
+/**
+ * The native "choose a cover image" dialog, behind a seam.
+ *
+ * The same shape as [EpubFilePicker] and for the same reason: a real `FileDialog` needs a display
+ * and a person, while every rule worth testing about a cover — the format, the size ceiling, what
+ * the form does with the file afterwards — is about the file that comes *back*.
+ */
+fun interface CoverImagePicker {
+    /** Null means the user cancelled the native dialog, which is not an error. */
+    fun choose(): File?
+}
+
+object DesktopCoverImagePicker : CoverImagePicker {
+    override fun choose(): File? {
+        if (GraphicsEnvironment.isHeadless()) return null
+        val dialog = FileDialog(null as Frame?, "Choose cover art", FileDialog.LOAD)
+        // A hint, not a guarantee — several Linux window managers ignore AWT's filter outright,
+        // which is why the format is checked again once a file comes back.
+        dialog.setFilenameFilter { _, name -> CoverImageFormats.isSupported(name) }
+        dialog.isVisible = true
+        val directory = dialog.directory ?: return null
+        val filename = dialog.file ?: return null
+        return File(directory, filename)
+    }
+}
+
+/** No picker at all — a test, a preview, or a headless run. */
+object UnavailableCoverImagePicker : CoverImagePicker {
+    override fun choose(): File? = null
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionDetailScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionDetailScreen.kt
@@ -593,6 +593,13 @@ private fun resumeTarget(chapters: List<ChapterSummary>): ChapterSummary? =
 /** The follow control's whole state, or null where the server has no per-user library. */
 data class FollowUi(val following: Boolean, val busy: Boolean, val onToggle: () -> Unit)
 
+/**
+ * The two admin controls on a fiction header.
+ *
+ * `onEdit` **opens the editor screen** rather than a dialog: the fields it changes are shared with
+ * every account, and on a server that tracks hand edits saving one takes it away from the source
+ * permanently — which is more than a header button should be able to do in passing.
+ */
 data class FictionManagementActions(
     val busy: Boolean,
     val onEdit: () -> Unit,
@@ -703,7 +710,7 @@ private fun FictionHeader(
                             modifier = Modifier
                                 .pointerHoverIcon(PointerIcon.Hand)
                                 .testTag(EditFictionButtonTestTag),
-                        ) { Text("EDIT") }
+                        ) { Text("EDIT METADATA") }
                         OutlinedButton(
                             onClick = actions.onDelete,
                             enabled = !actions.busy,

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementDialogs.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementDialogs.kt
@@ -22,23 +22,28 @@ import androidx.compose.ui.unit.dp
 const val AddFictionDialogTestTag: String = "addFictionDialog"
 const val ChooseEpubButtonTestTag: String = "chooseEpubButton"
 const val ChosenEpubNameTestTag: String = "chosenEpubName"
-const val EditFictionDialogTestTag: String = "editFictionDialog"
 
-/** The holder owns the answers; this composable only renders its one active question. */
+/**
+ * The holder owns the answers; this composable only renders its one active question.
+ *
+ * Two questions are left here, and both are one-shot: which fiction to add, and whether the user
+ * really means to delete one. Editing an existing fiction moved to a screen of its own — a dialog
+ * is the wrong shape for a form whose every field is shared with every account, and whose cover
+ * control needs a native file picker.
+ */
 @Composable
 fun FictionManagementDialogs(holder: FictionManagementStateHolder) {
     val state by holder.state.collectAsState()
     state.editor?.let { editor ->
-        FictionEditorDialog(
+        AddFictionDialog(
             editor = editor,
             isBusy = state.isBusy,
             error = state.error,
             epubUploadAvailable = state.epubUploadAvailable,
             onUpdateAdd = holder::updateAdd,
-            onUpdateEdit = holder::updateEdit,
             onChooseEpub = holder::chooseEpub,
             onClearEpub = holder::clearEpub,
-            onSubmit = holder::submitEditor,
+            onSubmit = holder::submitAdd,
             onDismiss = holder::dismissOverlay,
         )
     }
@@ -55,112 +60,78 @@ fun FictionManagementDialogs(holder: FictionManagementStateHolder) {
 }
 
 @Composable
-private fun FictionEditorDialog(
-    editor: FictionEditor,
+private fun AddFictionDialog(
+    editor: FictionAddDraft,
     isBusy: Boolean,
     error: String?,
     epubUploadAvailable: Boolean,
     onUpdateAdd: (String?, String?) -> Unit,
-    onUpdateEdit: (String?, String?, String?) -> Unit,
     onChooseEpub: () -> Unit,
     onClearEpub: () -> Unit,
     onSubmit: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val adding = editor is FictionEditor.Add
+    val epub = editor.epubFile
     AlertDialog(
         onDismissRequest = { if (!isBusy) onDismiss() },
-        modifier = Modifier.testTag(if (adding) AddFictionDialogTestTag else EditFictionDialogTestTag),
+        modifier = Modifier.testTag(AddFictionDialogTestTag),
         containerColor = AarisColor.BgRaise,
         title = {
             Text(
-                if (adding) "ADD FICTION" else "EDIT FICTION",
+                "ADD FICTION",
                 style = MaterialTheme.typography.titleLarge,
                 color = AarisColor.Ink,
             )
         },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                when (editor) {
-                    is FictionEditor.Add -> {
-                        val epub = editor.epubFile
-                        OutlinedTextField(
-                            value = editor.fictionUrl,
-                            onValueChange = { onUpdateAdd(it, null) },
-                            label = { Text("ROYAL ROAD URL OR FICTION ID") },
-                            supportingText = if (epub != null) {
-                                { Text("Not used while an EPUB is chosen") }
-                            } else {
-                                null
-                            },
-                            // Disabled rather than hidden: the field disappearing under the
-                            // cursor after a file picker closes is disorienting, and the reason
-                            // it is inert is worth saying rather than implying.
-                            enabled = !isBusy && epub == null,
-                            singleLine = true,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                        if (epubUploadAvailable) {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                modifier = Modifier.fillMaxWidth(),
-                            ) {
-                                TextButton(
-                                    onClick = if (epub == null) onChooseEpub else onClearEpub,
-                                    enabled = !isBusy,
-                                    shape = RectangleShape,
-                                    modifier = Modifier.testTag(ChooseEpubButtonTestTag),
-                                ) { Text(if (epub == null) "OR UPLOAD AN EPUB…" else "REMOVE EPUB") }
-                                epub?.let {
-                                    Text(
-                                        it.name,
-                                        color = AarisColor.Ink,
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        modifier = Modifier.testTag(ChosenEpubNameTestTag),
-                                    )
-                                }
-                            }
+                OutlinedTextField(
+                    value = editor.fictionUrl,
+                    onValueChange = { onUpdateAdd(it, null) },
+                    label = { Text("ROYAL ROAD URL OR FICTION ID") },
+                    supportingText = if (epub != null) {
+                        { Text("Not used while an EPUB is chosen") }
+                    } else {
+                        null
+                    },
+                    // Disabled rather than hidden: the field disappearing under the cursor after a
+                    // file picker closes is disorienting, and the reason it is inert is worth
+                    // saying rather than implying.
+                    enabled = !isBusy && epub == null,
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                if (epubUploadAvailable) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        TextButton(
+                            onClick = if (epub == null) onChooseEpub else onClearEpub,
+                            enabled = !isBusy,
+                            shape = RectangleShape,
+                            modifier = Modifier.testTag(ChooseEpubButtonTestTag),
+                        ) { Text(if (epub == null) "OR UPLOAD AN EPUB…" else "REMOVE EPUB") }
+                        epub?.let {
+                            Text(
+                                it.name,
+                                color = AarisColor.Ink,
+                                style = MaterialTheme.typography.bodyMedium,
+                                modifier = Modifier.testTag(ChosenEpubNameTestTag),
+                            )
                         }
-                        OutlinedTextField(
-                            value = editor.voice,
-                            onValueChange = { onUpdateAdd(null, it) },
-                            label = { Text("VOICE (OPTIONAL)") },
-                            supportingText = { Text("Blank uses the server default") },
-                            enabled = !isBusy,
-                            singleLine = true,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                    }
-
-                    is FictionEditor.Edit -> {
-                        OutlinedTextField(
-                            value = editor.title,
-                            onValueChange = { onUpdateEdit(it, null, null) },
-                            label = { Text("TITLE") },
-                            enabled = !isBusy,
-                            singleLine = true,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                        OutlinedTextField(
-                            value = editor.author,
-                            onValueChange = { onUpdateEdit(null, it, null) },
-                            label = { Text("AUTHOR") },
-                            supportingText = { Text("Blank clears the author") },
-                            enabled = !isBusy,
-                            singleLine = true,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                        OutlinedTextField(
-                            value = editor.voice,
-                            onValueChange = { onUpdateEdit(null, null, it) },
-                            label = { Text("VOICE") },
-                            enabled = !isBusy,
-                            singleLine = true,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
                     }
                 }
+                OutlinedTextField(
+                    value = editor.voice,
+                    onValueChange = { onUpdateAdd(null, it) },
+                    label = { Text("VOICE (OPTIONAL)") },
+                    supportingText = { Text("Blank uses the server default") },
+                    enabled = !isBusy,
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
                 error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
             }
         },
@@ -170,14 +141,12 @@ private fun FictionEditorDialog(
                 enabled = !isBusy,
                 shape = RectangleShape,
             ) {
-                val uploading = editor is FictionEditor.Add && editor.epubFile != null
                 Text(
                     when {
-                        isBusy && uploading -> "UPLOADING…"
-                        isBusy -> "SAVING…"
-                        uploading -> "UPLOAD EPUB"
-                        adding -> "ADD FICTION"
-                        else -> "SAVE CHANGES"
+                        isBusy && epub != null -> "UPLOADING…"
+                        isBusy -> "ADDING…"
+                        epub != null -> "UPLOAD EPUB"
+                        else -> "ADD FICTION"
                     },
                 )
             }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolder.kt
@@ -2,7 +2,6 @@ package dk.perspektiva.ttsroad.desktop.ui
 
 import dk.perspektiva.ttsroad.desktop.data.FictionCreateRequest
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
-import dk.perspektiva.ttsroad.desktop.data.FictionUpdateRequest
 import dk.perspektiva.ttsroad.desktop.data.LibraryCache
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
@@ -24,27 +23,26 @@ enum class FictionManagementAccess {
     Unavailable,
 }
 
-sealed interface FictionEditor {
-    data class Add(
-        val fictionUrl: String = "",
-        val voice: String = "",
-        /**
-         * A chosen EPUB, which makes this an *upload* rather than a Royal Road add.
-         *
-         * One editor with two paths rather than two dialogs: "add a fiction" is one intention, and
-         * making the user pick which kind of add they wanted before showing them either form is
-         * asking them to know the implementation.
-         */
-        val epubFile: File? = null,
-    ) : FictionEditor
-
-    data class Edit(
-        val fictionId: Int,
-        val title: String,
-        val author: String,
-        val voice: String,
-    ) : FictionEditor
-}
+/**
+ * The "add a fiction" form.
+ *
+ * Adding is the one fiction-shaped action small enough to be a dialog: a source and an optional
+ * voice. Editing an existing fiction is a screen — see [FictionMetadataStateHolder] — because the
+ * fields there are shared with every account and, on a server that tracks hand edits, saving one
+ * takes it away from the source permanently.
+ */
+data class FictionAddDraft(
+    val fictionUrl: String = "",
+    val voice: String = "",
+    /**
+     * A chosen EPUB, which makes this an *upload* rather than a Royal Road add.
+     *
+     * One form with two paths rather than two dialogs: "add a fiction" is one intention, and making
+     * the user pick which kind of add they wanted before showing them either form is asking them to
+     * know the implementation.
+     */
+    val epubFile: File? = null,
+)
 
 data class FictionDeleteConfirmation(val fictionId: Int, val title: String)
 
@@ -54,7 +52,7 @@ data class FictionManagementUiState(
     val epubUploadAvailable: Boolean = false,
     /** The server's byte ceiling, when it published one. */
     val maxEpubBytes: Long? = null,
-    val editor: FictionEditor? = null,
+    val editor: FictionAddDraft? = null,
     val deleteConfirmation: FictionDeleteConfirmation? = null,
     val isBusy: Boolean = false,
     val error: String? = null,
@@ -72,6 +70,11 @@ data class FictionManagementUiState(
  * Capability discovery says whether the stable routes exist; `/api/mobile/me` independently says
  * whether this account may use them. Neither the login-time role nor a visible button is treated
  * as authorization — the server remains the final gate for every write.
+ *
+ * This holder owns adding and deleting: the two actions that are a question and an answer. Editing
+ * an existing fiction is [FictionMetadataStateHolder]'s, and it is a screen, because its fields are
+ * shared with every account and a metadata edit takes the field away from the source for good.
+ * [canManage] is the gate for all three.
  */
 class FictionManagementStateHolder(
     private val repository: TtsRoadRepository,
@@ -138,29 +141,18 @@ class FictionManagementStateHolder(
 
     fun openAdd() {
         if (!_state.value.canManage || _state.value.isBusy) return
-        _state.update { it.copy(editor = FictionEditor.Add(), error = null, notice = null) }
-    }
-
-    fun openEdit(fiction: FictionSummary) {
-        if (!_state.value.canManage || _state.value.isBusy || fiction.id <= 0) return
-        _state.update {
-            it.copy(
-                editor = FictionEditor.Edit(
-                    fictionId = fiction.id,
-                    title = fiction.title,
-                    author = fiction.author.orEmpty(),
-                    voice = fiction.voice.orEmpty(),
-                ),
-                error = null,
-                notice = null,
-            )
-        }
+        _state.update { it.copy(editor = FictionAddDraft(), error = null, notice = null) }
     }
 
     fun updateAdd(fictionUrl: String? = null, voice: String? = null) {
         _state.update { current ->
-            val editor = current.editor as? FictionEditor.Add ?: return@update current
-            current.copy(editor = editor.copy(fictionUrl = fictionUrl ?: editor.fictionUrl, voice = voice ?: editor.voice))
+            val editor = current.editor ?: return@update current
+            current.copy(
+                editor = editor.copy(
+                    fictionUrl = fictionUrl ?: editor.fictionUrl,
+                    voice = voice ?: editor.voice,
+                ),
+            )
         }
     }
 
@@ -173,11 +165,11 @@ class FictionManagementStateHolder(
      */
     fun chooseEpub() {
         val state = _state.value
-        if (state.editor !is FictionEditor.Add || state.isBusy || !state.epubUploadAvailable) return
+        if (state.editor == null || state.isBusy || !state.epubUploadAvailable) return
         val chosen = picker.choose() ?: return
         val problem = epubProblem(chosen, state.maxEpubBytes)
         _state.update { current ->
-            val editor = current.editor as? FictionEditor.Add ?: return@update current
+            val editor = current.editor ?: return@update current
             if (problem != null) {
                 current.copy(error = problem)
             } else {
@@ -189,40 +181,19 @@ class FictionManagementStateHolder(
     /** Puts the dialog back on the Royal Road path without closing it. */
     fun clearEpub() {
         _state.update { current ->
-            val editor = current.editor as? FictionEditor.Add ?: return@update current
+            val editor = current.editor ?: return@update current
             current.copy(editor = editor.copy(epubFile = null), error = null)
         }
     }
 
-    fun updateEdit(title: String? = null, author: String? = null, voice: String? = null) {
-        _state.update { current ->
-            val editor = current.editor as? FictionEditor.Edit ?: return@update current
-            current.copy(
-                editor = editor.copy(
-                    title = title ?: editor.title,
-                    author = author ?: editor.author,
-                    voice = voice ?: editor.voice,
-                ),
-            )
-        }
-    }
-
-    fun submitEditor() {
+    fun submitAdd() {
         val editor = _state.value.editor ?: return
         if (!_state.value.canManage || _state.value.isBusy) return
-        val validation = when (editor) {
-            // A chosen EPUB *is* the answer to "which fiction", so the URL is not also required.
-            is FictionEditor.Add -> when {
-                editor.epubFile != null -> epubProblem(editor.epubFile, _state.value.maxEpubBytes)
-                editor.fictionUrl.isBlank() -> "A Royal Road URL, a fiction id, or an EPUB is required"
-                else -> null
-            }
-
-            is FictionEditor.Edit -> when {
-                editor.title.isBlank() -> "Title cannot be empty"
-                editor.voice.isBlank() -> "Voice cannot be empty"
-                else -> null
-            }
+        // A chosen EPUB *is* the answer to "which fiction", so the URL is not also required.
+        val validation = when {
+            editor.epubFile != null -> epubProblem(editor.epubFile, _state.value.maxEpubBytes)
+            editor.fictionUrl.isBlank() -> "A Royal Road URL, a fiction id, or an EPUB is required"
+            else -> null
         }
         if (validation != null) {
             _state.update { it.copy(error = validation) }
@@ -231,43 +202,26 @@ class FictionManagementStateHolder(
         mutationJob?.cancel()
         mutationJob = scope.launch {
             _state.update { it.copy(isBusy = true, error = null, notice = null) }
-            val outcome = runCatching {
-                when (editor) {
-                    is FictionEditor.Add -> editor.epubFile?.let { epub ->
-                        repository.uploadEpub(epub, editor.voice.trim().takeIf(String::isNotEmpty))
-                    } ?: repository.createFiction(
-                        FictionCreateRequest(
-                            fictionUrl = editor.fictionUrl.trim(),
-                            voice = editor.voice.trim().takeIf(String::isNotEmpty),
-                        ),
-                    )
-
-                    is FictionEditor.Edit -> repository.updateFiction(
-                        editor.fictionId,
-                        FictionUpdateRequest(
-                            title = editor.title.trim(),
-                            author = editor.author.trim(),
-                            voice = editor.voice.trim(),
-                        ),
-                    )
-                }
+            runCatching {
+                editor.epubFile?.let { epub ->
+                    repository.uploadEpub(epub, editor.voice.trim().takeIf(String::isNotEmpty))
+                } ?: repository.createFiction(
+                    FictionCreateRequest(
+                        fictionUrl = editor.fictionUrl.trim(),
+                        voice = editor.voice.trim().takeIf(String::isNotEmpty),
+                    ),
+                )
             }
-            outcome
                 .onSuccess { fiction ->
                     cache.patchFiction(fiction)
                     cache.refreshLibrary()
                     cache.refreshBrowseAll()
-                    if (editor is FictionEditor.Edit) cache.refreshChapters(editor.fictionId)
                     _state.update {
                         it.copy(
                             editor = null,
                             isBusy = false,
                             error = null,
-                            notice = if (editor is FictionEditor.Add) {
-                                "Added ${fiction.title}; chapter discovery is running on the server"
-                            } else {
-                                "Saved ${fiction.title}"
-                            },
+                            notice = "Added ${fiction.title}; chapter discovery is running on the server",
                         )
                     }
                 }
@@ -275,7 +229,7 @@ class FictionManagementStateHolder(
                     _state.update {
                         it.copy(
                             isBusy = false,
-                            error = userFacingMessage(failure, "Could not save fiction"),
+                            error = userFacingMessage(failure, "Could not add fiction"),
                         )
                     }
                 }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionMetadataScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionMetadataScreen.kt
@@ -1,0 +1,457 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.data.CoverImageFormats
+import dk.perspektiva.ttsroad.desktop.data.FictionMetadataFields
+import dk.perspektiva.ttsroad.desktop.data.FictionTagLimits
+import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
+
+const val FictionMetadataScreenTestTag: String = "fictionMetadataScreen"
+const val ChooseCoverButtonTestTag: String = "chooseCoverButton"
+const val ChosenCoverNameTestTag: String = "chosenCoverName"
+const val SaveMetadataButtonTestTag: String = "saveMetadataButton"
+const val UseSourceValuesButtonTestTag: String = "useSourceValuesButton"
+const val TagDraftFieldTestTag: String = "tagDraftField"
+
+/** How many characters of tag text fit on one row before the next chip wraps. */
+private const val TagRowBudget = 46
+
+/**
+ * The fiction editor — a form, not a dialog.
+ *
+ * This is the screen the desktop client exists to have: a real window, a real file picker for cover
+ * art, and enough room to show what a metadata edit *costs*. Every field here is shared: it is the
+ * title in everybody's podcast feed, and on a server that tracks hand edits, saving one also stops
+ * the server refreshing it from the source for good. So the ownership state is drawn next to the
+ * field it belongs to rather than buried in a legend, and handing a field back is one click from
+ * the same place.
+ *
+ * Reached only from the fiction screen's Edit control, which exists only for an account the server
+ * confirms is an administrator. That is presentation; the server is still the gate.
+ */
+@Composable
+fun FictionMetadataScreen(
+    holder: FictionMetadataStateHolder,
+    repository: TtsRoadRepository,
+    onBack: () -> Unit,
+) {
+    val s by holder.state.collectAsState()
+    val fiction = s.fiction
+
+    BoxWithConstraints(Modifier.fillMaxSize()) {
+        val stacked = windowSizeClassFor(maxWidth).isCompact
+        Box(Modifier.fillMaxSize()) {
+            Column(
+                Modifier
+                    .align(Alignment.TopCenter)
+                    .widthIn(max = ContentMaxWidth)
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(PageGutter)
+                    .testTag(FictionMetadataScreenTestTag)
+                    .semantics { paneTitle = "Edit fiction" },
+            ) {
+                BackLink("Back", onBack)
+                Spacer(Modifier.height(20.dp))
+                if (fiction == null) {
+                    EmptyState(
+                        "Nothing to edit",
+                        "Open a fiction and choose Edit to change what the library shows for it.",
+                    )
+                    return@Column
+                }
+
+                SectionTitle("01", "Edit ${fiction.title}")
+                Spacer(Modifier.height(12.dp))
+                MetaText(
+                    "These values are shared: every account sees them, and they name the podcast feed.",
+                )
+                Spacer(Modifier.height(20.dp))
+
+                OwnershipBanner(s, holder)
+
+                if (stacked) {
+                    CoverPanel(s, holder, repository, Modifier.fillMaxWidth())
+                    Spacer(Modifier.height(24.dp))
+                    MetadataForm(s, holder, Modifier.fillMaxWidth())
+                } else {
+                    Row(Modifier.fillMaxWidth()) {
+                        CoverPanel(s, holder, repository, Modifier.width(220.dp))
+                        Spacer(Modifier.width(28.dp))
+                        MetadataForm(s, holder, Modifier.weight(1f))
+                    }
+                }
+
+                Spacer(Modifier.height(24.dp))
+                HorizontalDivider(thickness = 1.dp, color = AarisColor.Line)
+                Spacer(Modifier.height(16.dp))
+
+                s.error?.let {
+                    Text(it, color = MaterialTheme.colorScheme.error)
+                    Spacer(Modifier.height(12.dp))
+                }
+                s.notice?.let {
+                    MetaText(it, color = AarisColor.Ok)
+                    Spacer(Modifier.height(12.dp))
+                }
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Button(
+                        onClick = holder::save,
+                        enabled = s.canSave,
+                        shape = RectangleShape,
+                        modifier = Modifier
+                            .pointerHoverIcon(PointerIcon.Hand)
+                            .testTag(SaveMetadataButtonTestTag),
+                    ) { Text(if (s.isBusy) "SAVING…" else "SAVE CHANGES") }
+                    TextButton(
+                        onClick = holder::revertEdits,
+                        enabled = s.hasChanges && !s.isBusy,
+                        shape = RectangleShape,
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                    ) { Text("DISCARD CHANGES") }
+                }
+                Spacer(Modifier.height(24.dp))
+            }
+        }
+    }
+}
+
+/**
+ * What this server has been told belongs to a person, and the way back out of it.
+ *
+ * Absent entirely where nothing is hand-edited — including on a server that has never heard of the
+ * idea, which reports no names and therefore gets no banner and no release control it could not
+ * honour.
+ */
+@Composable
+private fun OwnershipBanner(state: FictionMetadataUiState, holder: FictionMetadataStateHolder) {
+    val overridden = state.overrides
+    if (overridden.isEmpty()) return
+    AarisCard(modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
+            MetaText("Hand-edited", color = AarisColor.Warning)
+            Spacer(Modifier.height(8.dp))
+            Text(
+                FictionMetadataStateHolder.humanList(
+                    overridden.map(FictionMetadataFields::labelOf).sorted(),
+                ) + " no longer follow the source: refreshing this fiction leaves them alone. " +
+                    "Handing them back does not restore the old text — it lets the next refresh " +
+                    "write over what is here.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = AarisColor.Muted,
+            )
+            Spacer(Modifier.height(12.dp))
+            OutlinedButton(
+                onClick = { holder.useSourceValues() },
+                enabled = !state.isBusy,
+                shape = RectangleShape,
+                modifier = Modifier
+                    .pointerHoverIcon(PointerIcon.Hand)
+                    .testTag(UseSourceValuesButtonTestTag),
+            ) { Text("USE SOURCE VALUES") }
+        }
+    }
+    Spacer(Modifier.height(24.dp))
+}
+
+@Composable
+private fun MetadataForm(
+    state: FictionMetadataUiState,
+    holder: FictionMetadataStateHolder,
+    modifier: Modifier = Modifier,
+) {
+    val draft = state.draft
+    Column(modifier, verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        EditorField(
+            value = draft.title,
+            onValueChange = holder::setTitle,
+            label = "TITLE",
+            enabled = !state.isBusy,
+            supporting = "The name in the library and in the podcast feed",
+            field = FictionMetadataFields.Title,
+            state = state,
+            holder = holder,
+        )
+        EditorField(
+            value = draft.author,
+            onValueChange = holder::setAuthor,
+            label = "AUTHOR",
+            enabled = !state.isBusy,
+            supporting = "Blank clears the author",
+            field = FictionMetadataFields.Author,
+            state = state,
+            holder = holder,
+        )
+        EditorField(
+            value = draft.description,
+            onValueChange = holder::setDescription,
+            label = "DESCRIPTION",
+            enabled = !state.isBusy,
+            supporting = "Blank clears the description",
+            field = FictionMetadataFields.Description,
+            state = state,
+            holder = holder,
+            singleLine = false,
+            minLines = 4,
+        )
+        TagEditor(state, holder)
+        HorizontalDivider(thickness = 1.dp, color = AarisColor.Line)
+        MetaText("Narration")
+        // Deliberately outside the metadata block above: the voice is a conversion setting, not a
+        // description of the book, so changing it claims nothing and no refresh would overwrite it.
+        OutlinedTextField(
+            value = draft.voice,
+            onValueChange = holder::setVoice,
+            label = { Text("VOICE") },
+            supportingText = { Text("The edge-tts voice new chapters are narrated with") },
+            enabled = !state.isBusy,
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+/** One text field plus the ownership line that belongs to it. */
+@Composable
+private fun EditorField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    enabled: Boolean,
+    supporting: String,
+    field: String,
+    state: FictionMetadataUiState,
+    holder: FictionMetadataStateHolder,
+    singleLine: Boolean = true,
+    minLines: Int = 1,
+) {
+    Column(Modifier.fillMaxWidth()) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = { Text(label) },
+            supportingText = { Text(supporting) },
+            enabled = enabled,
+            singleLine = singleLine,
+            minLines = minLines,
+            modifier = Modifier.fillMaxWidth().testTag(fieldTestTag(field)),
+        )
+        FieldOwnership(field, state, holder)
+    }
+}
+
+/** Test tag for the field editing [field], so a test names the field rather than its position. */
+fun fieldTestTag(field: String): String = "metadataField_$field"
+
+@Composable
+private fun FieldOwnership(
+    field: String,
+    state: FictionMetadataUiState,
+    holder: FictionMetadataStateHolder,
+) {
+    if (field !in state.overrides) return
+    Row(
+        Modifier.fillMaxWidth().padding(top = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        MetaText("Hand-edited — not refreshed", color = AarisColor.Warning)
+        TextButton(
+            onClick = { holder.useSourceValues(setOf(field)) },
+            enabled = !state.isBusy,
+            shape = RectangleShape,
+            modifier = Modifier
+                .pointerHoverIcon(PointerIcon.Hand)
+                .testTag("useSource_$field"),
+        ) { Text("USE SOURCE") }
+    }
+}
+
+@Composable
+private fun TagEditor(state: FictionMetadataUiState, holder: FictionMetadataStateHolder) {
+    val draft = state.draft
+    Column(Modifier.fillMaxWidth()) {
+        MetaText("Tags  ·  ${FictionMetadataStateHolder.tagLimitLabel(draft.tags.size)}")
+        Spacer(Modifier.height(8.dp))
+        val rows = remember(draft.tags) { wrapTags(draft.tags, TagRowBudget) }
+        rows.forEach { row ->
+            Row(
+                Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                row.forEach { tag ->
+                    TagChip(tag, enabled = !state.isBusy, onRemove = { holder.removeTag(tag) })
+                }
+            }
+        }
+        if (draft.tags.isEmpty()) {
+            MetaText("None", color = AarisColor.Dim)
+            Spacer(Modifier.height(8.dp))
+        }
+        OutlinedTextField(
+            value = draft.tagDraft,
+            onValueChange = holder::setTagDraft,
+            label = { Text("ADD A TAG") },
+            supportingText = { Text("Enter adds it; duplicates are ignored") },
+            enabled = !state.isBusy && draft.tags.size < FictionTagLimits.MaxTags,
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(TagDraftFieldTestTag)
+                // Preview, so the key is claimed before the field's own editor sees it: Enter in a
+                // single-line field otherwise does nothing at all, and a tag typed and left behind
+                // is the commonest way to lose one.
+                .onPreviewKeyEvent { event ->
+                    if (event.type == KeyEventType.KeyDown && event.key == Key.Enter) {
+                        holder.commitTagDraft()
+                        true
+                    } else {
+                        false
+                    }
+                },
+        )
+        FieldOwnership(FictionMetadataFields.Tags, state, holder)
+    }
+}
+
+@Composable
+private fun TagChip(tag: String, enabled: Boolean, onRemove: () -> Unit) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        AarisTag(tag)
+        RowIconAction(
+            icon = Icons.Default.Close,
+            contentDescription = "Remove tag $tag",
+            tint = AarisColor.Muted,
+            onClick = onRemove,
+            enabled = enabled,
+        )
+    }
+}
+
+/**
+ * The cover, and the one way to change it.
+ *
+ * An upload rather than a URL field because that is what the server accepts, and because cover art
+ * it does not hold is art it cannot embed in the MP3s. A server without the route says so here
+ * instead of failing on save.
+ */
+@Composable
+private fun CoverPanel(
+    state: FictionMetadataUiState,
+    holder: FictionMetadataStateHolder,
+    repository: TtsRoadRepository,
+    modifier: Modifier = Modifier,
+) {
+    val fiction = state.fiction ?: return
+    val chosen = state.chosenCover
+    Column(modifier) {
+        MetaText("Cover art")
+        Spacer(Modifier.height(8.dp))
+        CoverImage(
+            fiction.title,
+            fiction.coverImageUrl?.let(repository::resolveUrl),
+            Modifier.fillMaxWidth().aspectRatio(2f / 3f),
+        )
+        Spacer(Modifier.height(12.dp))
+        if (!state.coverUploadSupported) {
+            MetaText("This server cannot replace cover art from a client", color = AarisColor.Warning)
+        } else {
+            OutlinedButton(
+                onClick = if (chosen == null) holder::chooseCover else holder::clearChosenCover,
+                enabled = !state.isBusy,
+                shape = RectangleShape,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .pointerHoverIcon(PointerIcon.Hand)
+                    .testTag(ChooseCoverButtonTestTag),
+            ) { Text(if (chosen == null) "CHOOSE AN IMAGE…" else "REMOVE") }
+            Spacer(Modifier.height(8.dp))
+            if (chosen == null) {
+                MetaText("${CoverImageFormats.Description}, uploaded when you save", color = AarisColor.Dim)
+            } else {
+                Text(
+                    chosen.name,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = AarisColor.Ink,
+                    modifier = Modifier.testTag(ChosenCoverNameTestTag),
+                )
+                Spacer(Modifier.height(4.dp))
+                MetaText("Uploaded when you save", color = AarisColor.Dim)
+            }
+            FieldOwnership(FictionMetadataFields.CoverImage, state, holder)
+        }
+    }
+}
+
+/**
+ * Split tags into rows that will roughly fit, by counting characters.
+ *
+ * Compose's wrapping row layout is still an opt-in experimental API, and a form that fails the
+ * build's warnings-as-errors gate to avoid four lines of arithmetic is a poor trade. Counting
+ * characters is an approximation, deliberately: the cost of getting it slightly wrong is one short
+ * row, and being pure is what lets it be tested at all.
+ */
+internal fun wrapTags(tags: List<String>, budget: Int): List<List<String>> {
+    val rows = mutableListOf<List<String>>()
+    var row = mutableListOf<String>()
+    var used = 0
+    for (tag in tags) {
+        // The chip's border, padding and remove control are worth roughly this many characters.
+        val cost = tag.length + 6
+        if (row.isNotEmpty() && used + cost > budget) {
+            rows += row
+            row = mutableListOf()
+            used = 0
+        }
+        row += tag
+        used += cost
+    }
+    if (row.isNotEmpty()) rows += row
+    return rows
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionMetadataStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionMetadataStateHolder.kt
@@ -1,0 +1,422 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.data.CoverImageFormats
+import dk.perspektiva.ttsroad.desktop.data.CoverUploadResult
+import dk.perspektiva.ttsroad.desktop.data.FictionMetadataFields
+import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.FictionTagLimits
+import dk.perspektiva.ttsroad.desktop.data.FictionUpdateRequest
+import dk.perspektiva.ttsroad.desktop.data.LibraryCache
+import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
+import dk.perspektiva.ttsroad.desktop.data.cleanFictionTags
+import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
+import java.io.File
+import java.util.Locale
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/** What is currently typed into the form. Separate from the fiction, which is what the server holds. */
+data class FictionMetadataDraft(
+    val title: String = "",
+    val author: String = "",
+    val description: String = "",
+    val tags: List<String> = emptyList(),
+    /** The half-typed tag in the "add a tag" field, which is not a tag until it is committed. */
+    val tagDraft: String = "",
+    val voice: String = "",
+)
+
+data class FictionMetadataUiState(
+    /** The fiction as the server last confirmed it — the baseline every "changed?" answer is against. */
+    val fiction: FictionSummary? = null,
+    val draft: FictionMetadataDraft = FictionMetadataDraft(),
+    /** A picked image that has not been uploaded yet. */
+    val chosenCover: File? = null,
+    /** The server's cover ceiling if it published one; null means "let the server judge". */
+    val maxCoverBytes: Long? = null,
+    val isBusy: Boolean = false,
+    val error: String? = null,
+    val notice: String? = null,
+    /** Cleared once this server has answered 404 to a cover upload — it predates the route. */
+    val coverUploadSupported: Boolean = true,
+) {
+    /** Which fields a person owns, as the server reports them. Empty on a server without the idea. */
+    val overrides: Set<String> get() = fiction?.metadataOverrides?.toSet().orEmpty()
+
+    /** Which metadata fields the form would send. Sending only these is what stops silent claims. */
+    val changedFields: Set<String>
+        get() {
+            val current = fiction ?: return emptySet()
+            val changed = mutableSetOf<String>()
+            if (draft.title.trim() != current.title.trim()) changed += FictionMetadataFields.Title
+            if (draft.author.trim() != current.author.orEmpty().trim()) changed += FictionMetadataFields.Author
+            if (draft.description.trim() != current.description.orEmpty().trim()) {
+                changed += FictionMetadataFields.Description
+            }
+            if (cleanFictionTags(draft.tags) != cleanFictionTags(current.tags)) {
+                changed += FictionMetadataFields.Tags
+            }
+            return changed
+        }
+
+    /** Narration voice is a conversion setting, not metadata: changing it claims nothing. */
+    val voiceChanged: Boolean get() = fiction != null && draft.voice.trim() != fiction.voice.orEmpty().trim()
+
+    val hasChanges: Boolean
+        get() = changedFields.isNotEmpty() || voiceChanged || chosenCover != null ||
+            draft.tagDraft.isNotBlank()
+
+    val canSave: Boolean get() = fiction != null && !isBusy && hasChanges
+}
+
+/**
+ * The fiction editor: what a person may correct about a shared fiction, and what that costs.
+ *
+ * The costly half is the reason this is a screen with a holder rather than another dialog. On a
+ * server that supports hand-edited metadata, **writing a metadata field takes ownership of it** —
+ * the field stops being refreshed from the source, permanently, until somebody hands it back. So
+ * the editor is careful about what it sends: only fields whose value actually changed go into the
+ * request, and "use source values" sends `clear_overrides` *without* the values, because sending a
+ * value would re-claim the field the same instant it was released.
+ *
+ * Both gates from [FictionManagementStateHolder] still apply above this holder — the advertised
+ * `fiction_management` capability and the authoritative `is_admin` from `/api/mobile/me`. Nothing
+ * here re-decides authorization; the server refuses a non-admin with a 403 regardless.
+ */
+class FictionMetadataStateHolder(
+    private val repository: TtsRoadRepository,
+    private val cache: LibraryCache,
+    /** The native image chooser. Substituted in a test, which has neither a display nor a person. */
+    private val picker: CoverImagePicker = DesktopCoverImagePicker,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : StateHolder(dispatcher) {
+    private val _state = MutableStateFlow(FictionMetadataUiState())
+    val state: StateFlow<FictionMetadataUiState> = _state.asStateFlow()
+
+    private var saveJob: Job? = null
+
+    /**
+     * Points the form at [fiction], or refreshes the baseline of the one already open.
+     *
+     * Re-entering the same fiction keeps whatever is typed: the screen calls this again every time
+     * a fresher copy arrives from the library cache, and a form that reset itself under a poll
+     * would lose an edit somebody was halfway through.
+     */
+    fun load(fiction: FictionSummary, maxCoverBytes: Long? = null) {
+        if (fiction.id <= 0) return
+        _state.update { current ->
+            if (current.fiction?.id == fiction.id) {
+                current.copy(fiction = fiction, maxCoverBytes = maxCoverBytes)
+            } else {
+                FictionMetadataUiState(
+                    fiction = fiction,
+                    draft = draftOf(fiction),
+                    maxCoverBytes = maxCoverBytes,
+                )
+            }
+        }
+    }
+
+    fun setTitle(value: String) = editDraft { it.copy(title = value) }
+
+    fun setAuthor(value: String) = editDraft { it.copy(author = value) }
+
+    fun setDescription(value: String) = editDraft { it.copy(description = value) }
+
+    fun setVoice(value: String) = editDraft { it.copy(voice = value) }
+
+    fun setTagDraft(value: String) = editDraft { it.copy(tagDraft = value) }
+
+    /** Turns the "add a tag" text into a tag. A duplicate or a blank simply clears the field. */
+    fun commitTagDraft() {
+        editDraft { draft ->
+            val merged = cleanFictionTags(draft.tags + draft.tagDraft)
+            draft.copy(tags = merged, tagDraft = "")
+        }
+    }
+
+    fun removeTag(tag: String) = editDraft { draft -> draft.copy(tags = draft.tags - tag) }
+
+    /**
+     * Opens the native picker and checks what comes back before anything is sent.
+     *
+     * The format check is not belt-and-braces: AWT's filename filter is a hint several Linux window
+     * managers ignore, and every problem below is a 400 or a 413 that would otherwise arrive after
+     * the whole image went over the wire.
+     */
+    fun chooseCover() {
+        val current = _state.value
+        if (current.fiction == null || current.isBusy || !current.coverUploadSupported) return
+        val chosen = picker.choose() ?: return
+        val problem = coverProblem(chosen, current.maxCoverBytes)
+        _state.update {
+            if (problem != null) {
+                it.copy(error = problem)
+            } else {
+                it.copy(chosenCover = chosen, error = null, notice = null)
+            }
+        }
+    }
+
+    fun clearChosenCover() {
+        _state.update { it.copy(chosenCover = null, error = null) }
+    }
+
+    /**
+     * Sends the changed fields, then the chosen cover.
+     *
+     * In that order because the cover is a separate request: a metadata edit that succeeded is kept
+     * and published even when the image is refused afterwards, and the screen says which half
+     * happened rather than reporting one failure for both.
+     */
+    fun save() {
+        val start = _state.value.let { it.copy(draft = it.draft.withCommittedTag()) }
+        val fiction = start.fiction ?: return
+        if (start.isBusy) return
+        val validation = when {
+            start.draft.title.isBlank() -> "Title cannot be empty"
+            start.draft.voice.isBlank() -> "Voice cannot be empty"
+            else -> null
+        }
+        if (validation != null) {
+            _state.value = start.copy(error = validation, notice = null)
+            return
+        }
+        val patch = patchOf(start)
+        val cover = start.chosenCover
+        if (patch == null && cover == null) {
+            _state.value = start.copy(error = null, notice = "Nothing to save")
+            return
+        }
+        _state.value = start.copy(isBusy = true, error = null, notice = null)
+        saveJob?.cancel()
+        saveJob = scope.launch {
+            runCatching {
+                var latest = fiction
+                var ignored = emptySet<String>()
+                var coverProblem: String? = null
+                var coverSupported = true
+                if (patch != null) {
+                    latest = repository.updateFiction(fiction.id, patch)
+                    ignored = ignoredFields(patch, latest)
+                }
+                if (cover != null) {
+                    when (val outcome = repository.uploadFictionCover(fiction.id, cover)) {
+                        is CoverUploadResult.Saved -> latest = outcome.fiction
+                        is CoverUploadResult.Rejected -> coverProblem = outcome.message
+                        CoverUploadResult.Unsupported -> {
+                            coverSupported = false
+                            coverProblem = "This server cannot replace cover art from a client"
+                        }
+                    }
+                }
+                SaveOutcome(latest, ignored, coverProblem, coverSupported)
+            }
+                .onSuccess { outcome ->
+                    cache.patchFiction(outcome.fiction)
+                    cache.refreshLibrary()
+                    cache.refreshBrowseAll()
+                    _state.update {
+                        it.copy(
+                            fiction = outcome.fiction,
+                            draft = draftOf(outcome.fiction),
+                            // Kept only where the server refused the image for a reason a person can
+                            // act on; there is nothing to retry against a server without the route.
+                            chosenCover = outcome.chosenCoverToKeep(cover),
+                            coverUploadSupported = outcome.coverSupported,
+                            isBusy = false,
+                            error = outcome.problem(),
+                            notice = outcome.notice(),
+                        )
+                    }
+                }
+                .onFailure { failure ->
+                    _state.update {
+                        it.copy(isBusy = false, error = userFacingMessage(failure, "Could not save this fiction"))
+                    }
+                }
+        }
+    }
+
+    /**
+     * Hands [fields] back to the source, so the next refresh may write over them.
+     *
+     * Sends `clear_overrides` and nothing else. The values on screen do not change — clearing
+     * removes the protection, it does not restore what the source used to say — so the draft is
+     * deliberately left alone, including anything typed but not yet saved.
+     */
+    fun useSourceValues(fields: Set<String> = _state.value.overrides) {
+        val current = _state.value
+        val fiction = current.fiction ?: return
+        val releasing = fields.intersect(current.overrides)
+        if (current.isBusy || releasing.isEmpty()) return
+        _state.update { it.copy(isBusy = true, error = null, notice = null) }
+        saveJob?.cancel()
+        saveJob = scope.launch {
+            runCatching {
+                repository.updateFiction(
+                    fiction.id,
+                    FictionUpdateRequest(clearOverrides = releasing.sorted()),
+                )
+            }
+                .onSuccess { updated ->
+                    cache.patchFiction(updated)
+                    _state.update {
+                        it.copy(
+                            fiction = updated,
+                            isBusy = false,
+                            error = null,
+                            notice = releasedNotice(releasing),
+                        )
+                    }
+                }
+                .onFailure { failure ->
+                    _state.update {
+                        it.copy(
+                            isBusy = false,
+                            error = userFacingMessage(failure, "Could not hand those fields back"),
+                        )
+                    }
+                }
+        }
+    }
+
+    /** Puts the form back to what the server holds, dropping every unsaved edit. */
+    fun revertEdits() {
+        _state.update { current ->
+            val fiction = current.fiction ?: return@update current
+            if (current.isBusy) current else current.copy(
+                draft = draftOf(fiction),
+                chosenCover = null,
+                error = null,
+                notice = null,
+            )
+        }
+    }
+
+    fun sessionEnded() {
+        saveJob?.cancel()
+        _state.value = FictionMetadataUiState()
+    }
+
+    private fun editDraft(edit: (FictionMetadataDraft) -> FictionMetadataDraft) {
+        _state.update { current ->
+            if (current.fiction == null || current.isBusy) current
+            else current.copy(draft = edit(current.draft), error = null, notice = null)
+        }
+    }
+
+    /** What one save actually managed, which is not always all of it. */
+    private data class SaveOutcome(
+        val fiction: FictionSummary,
+        val ignoredFields: Set<String>,
+        val coverProblem: String?,
+        val coverSupported: Boolean,
+    ) {
+        fun chosenCoverToKeep(chosen: File?): File? =
+            chosen?.takeIf { coverProblem != null && coverSupported }
+
+        fun problem(): String? = listOfNotNull(
+            coverProblem,
+            ignoredFields.takeIf { it.isNotEmpty() }?.let {
+                "This server did not store " + humanList(it.map(FictionMetadataFields::labelOf)) +
+                    " — it is older than hand-edited metadata"
+            },
+        ).joinToString(". ").takeIf { it.isNotEmpty() }
+
+        fun notice(): String? =
+            if (coverProblem == null && ignoredFields.isEmpty()) "Saved ${fiction.title}" else null
+    }
+
+    companion object {
+        /** What is wrong with this image, or null when nothing is. Pure, so it needs no picker. */
+        internal fun coverProblem(file: File, maxBytes: Long?): String? = when {
+            !file.isFile -> "That file could not be read"
+            !CoverImageFormats.isSupported(file.name) ->
+                "Cover art has to be a ${CoverImageFormats.Description} image"
+            file.length() == 0L -> "That file is empty"
+            maxBytes != null && file.length() > maxBytes ->
+                "That image is ${formatMegabytes(file.length())}; this server accepts up to " +
+                    formatMegabytes(maxBytes)
+            else -> null
+        }
+
+        /**
+         * Fields the request set that the answer does not show.
+         *
+         * The server is the authority on what it stored, so the editor reads the response rather
+         * than assuming the write landed. On a server that predates hand-edited metadata the
+         * description and tags keys are simply dropped, and this is what notices that instead of
+         * reporting a save that did not happen.
+         */
+        internal fun ignoredFields(sent: FictionUpdateRequest, answer: FictionSummary): Set<String> {
+            val ignored = mutableSetOf<String>()
+            sent.title?.let { if (answer.title.trim() != it.trim()) ignored += FictionMetadataFields.Title }
+            sent.author?.let {
+                if (answer.author.orEmpty().trim() != it.trim()) ignored += FictionMetadataFields.Author
+            }
+            sent.description?.let {
+                if (answer.description.orEmpty().trim() != it.trim()) ignored += FictionMetadataFields.Description
+            }
+            sent.tags?.let {
+                if (cleanFictionTags(answer.tags) != cleanFictionTags(it)) ignored += FictionMetadataFields.Tags
+            }
+            return ignored
+        }
+
+        /** The request for what changed, or null when nothing did. */
+        internal fun patchOf(state: FictionMetadataUiState): FictionUpdateRequest? {
+            val changed = state.changedFields
+            if (changed.isEmpty() && !state.voiceChanged) return null
+            return FictionUpdateRequest(
+                title = state.draft.title.trim().takeIf { FictionMetadataFields.Title in changed },
+                author = state.draft.author.trim().takeIf { FictionMetadataFields.Author in changed },
+                description = state.draft.description.trim()
+                    .takeIf { FictionMetadataFields.Description in changed },
+                tags = cleanFictionTags(state.draft.tags).takeIf { FictionMetadataFields.Tags in changed },
+                voice = state.draft.voice.trim().takeIf { state.voiceChanged },
+            )
+        }
+
+        internal fun draftOf(fiction: FictionSummary): FictionMetadataDraft = FictionMetadataDraft(
+            title = fiction.title,
+            author = fiction.author.orEmpty(),
+            description = fiction.description.orEmpty(),
+            tags = fiction.tags,
+            voice = fiction.voice.orEmpty(),
+        )
+
+        /** Folds a tag typed but never committed into the list, so Save does not silently drop it. */
+        internal fun FictionMetadataDraft.withCommittedTag(): FictionMetadataDraft =
+            if (tagDraft.isBlank()) copy(tagDraft = "") else copy(
+                tags = cleanFictionTags(tags + tagDraft),
+                tagDraft = "",
+            )
+
+        internal fun releasedNotice(released: Set<String>): String {
+            val labels = humanList(released.map(FictionMetadataFields::labelOf).sorted())
+            val verb = if (released.size == 1) "follows" else "follow"
+            return "$labels now $verb the source again; the value here stays until the next refresh"
+        }
+
+        /** "Title", "Title and Tags", "Title, Tags and Cover art". */
+        internal fun humanList(items: List<String>): String = when (items.size) {
+            0 -> ""
+            1 -> items.single()
+            else -> items.dropLast(1).joinToString(", ") + " and " + items.last()
+        }
+
+        /** Tags are capped by the server; the form says so rather than letting a save truncate. */
+        internal fun tagLimitLabel(count: Int): String =
+            "$count/${FictionTagLimits.MaxTags} tags"
+
+        private fun formatMegabytes(bytes: Long): String =
+            String.format(Locale.ROOT, "%.1f MB", bytes / (1024.0 * 1024.0))
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -5,6 +5,7 @@ import dk.perspektiva.ttsroad.desktop.data.BookmarkCreateRequest
 import dk.perspektiva.ttsroad.desktop.data.BookmarkPatchRequest
 import dk.perspektiva.ttsroad.desktop.data.AudiobookExportsResponse
 import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
+import dk.perspektiva.ttsroad.desktop.data.CoverUploadResult
 import dk.perspektiva.ttsroad.desktop.data.ChaptersResponse
 import dk.perspektiva.ttsroad.desktop.data.DeviceSession
 import dk.perspektiva.ttsroad.desktop.data.DeltaSyncResponse
@@ -71,6 +72,9 @@ open class FakeRepository(
     var updateFictionResult: Result<FictionSummary> = Result.success(FictionSummary(id = 1, title = "Updated")),
     var deleteFictionResult: Result<Boolean> = Result.success(true),
     var uploadEpubResult: Result<FictionSummary> = Result.success(FictionSummary(id = 202, title = "Uploaded")),
+    /** Defaults to the server accepting the image and answering the fiction it now holds. */
+    var uploadCoverResult: Result<CoverUploadResult> =
+        Result.success(CoverUploadResult.Saved(FictionSummary(id = 1, title = "Updated"))),
     var audiobookExportsResult: Result<AudiobookExportsResponse?> = Result.success(null),
 ) : TtsRoadRepository {
     var loginCalls: Int = 0
@@ -130,6 +134,9 @@ open class FakeRepository(
     val updatedFictions: MutableList<Pair<Int, FictionUpdateRequest>> = mutableListOf()
     val deletedFictions: MutableList<Int> = mutableListOf()
     val uploadedEpubs: MutableList<Pair<java.io.File, String?>> = mutableListOf()
+
+    /** `(fictionId, file)` pairs passed to [uploadFictionCover], in order. */
+    val uploadedCovers: MutableList<Pair<Int, java.io.File>> = mutableListOf()
 
     private val _currentCapabilities = MutableStateFlow(ServerCapabilities.Baseline)
     override val currentCapabilities: StateFlow<ServerCapabilities> = _currentCapabilities.asStateFlow()
@@ -214,6 +221,11 @@ open class FakeRepository(
     override suspend fun uploadEpub(file: java.io.File, voice: String?): FictionSummary {
         uploadedEpubs += file to voice
         return uploadEpubResult.getOrThrow()
+    }
+
+    override suspend fun uploadFictionCover(fictionId: Int, file: java.io.File): CoverUploadResult {
+        uploadedCovers += fictionId to file
+        return uploadCoverResult.getOrThrow()
     }
 
     override suspend fun currentUser(): MobileUser? {

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolderTest.kt
@@ -57,7 +57,6 @@ class FictionManagementStateHolderTest {
         holder.ensureAccess(supported = true)
         runCurrent()
         holder.openAdd()
-        holder.openEdit(FictionSummary(id = 7, title = "Serial", voice = "voice"))
         holder.askDelete(FictionSummary(id = 7, title = "Serial"))
 
         assertEquals(FictionManagementAccess.NotAdmin, holder.state.value.access)
@@ -76,43 +75,13 @@ class FictionManagementStateHolderTest {
 
         holder.openAdd()
         holder.updateAdd(fictionUrl = "  424242  ", voice = "  ")
-        holder.submitEditor()
+        holder.submitAdd()
         runCurrent()
 
         assertEquals("424242", repository.createdFictions.single().fictionUrl)
         assertNull(repository.createdFictions.single().voice)
         assertNull(holder.state.value.editor)
         assertTrue(holder.state.value.notice.orEmpty().contains("New serial"))
-        holder.clear()
-        cache.close()
-    }
-
-    @Test
-    fun `editing validates title then sends title author and voice`() = runTest {
-        val repository = adminRepository().apply {
-            updateFictionResult = Result.success(
-                FictionSummary(id = 7, title = "Better", author = null, voice = "new-voice"),
-            )
-        }
-        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
-        val holder = adminHolder(repository, cache)
-
-        holder.openEdit(FictionSummary(id = 7, title = "Old", author = "Writer", voice = "old-voice"))
-        holder.updateEdit(title = "   ")
-        holder.submitEditor()
-        assertTrue(holder.state.value.error.orEmpty().contains("Title"))
-        assertTrue(repository.updatedFictions.isEmpty())
-
-        holder.updateEdit(title = " Better ", author = "", voice = " new-voice ")
-        holder.submitEditor()
-        runCurrent()
-
-        val (fictionId, request) = repository.updatedFictions.single()
-        assertEquals(7, fictionId)
-        assertEquals("Better", request.title)
-        assertEquals("", request.author)
-        assertEquals("new-voice", request.voice)
-        assertNull(holder.state.value.editor)
         holder.clear()
         cache.close()
     }
@@ -194,7 +163,7 @@ class FictionManagementStateHolderTest {
         fixture.holder.openAdd()
         fixture.holder.chooseEpub()
         fixture.holder.updateAdd(voice = "en-US-AriaNeural")
-        fixture.holder.submitEditor()
+        fixture.holder.submitAdd()
         runCurrent()
 
         assertEquals(listOf<Pair<java.io.File, String?>>(epub to "en-US-AriaNeural"), fixture.repository.uploadedEpubs)
@@ -210,7 +179,7 @@ class FictionManagementStateHolderTest {
         fixture.holder.openAdd()
 
         // Without a file this fails validation before any request is made.
-        fixture.holder.submitEditor()
+        fixture.holder.submitAdd()
         runCurrent()
         assertEquals(
             "A Royal Road URL, a fiction id, or an EPUB is required",
@@ -218,7 +187,7 @@ class FictionManagementStateHolderTest {
         )
 
         fixture.holder.chooseEpub()
-        fixture.holder.submitEditor()
+        fixture.holder.submitAdd()
         runCurrent()
 
         assertNull(fixture.holder.state.value.error)
@@ -236,7 +205,7 @@ class FictionManagementStateHolderTest {
         fixture.holder.chooseEpub()
 
         assertEquals("Only .epub files can be uploaded", fixture.holder.state.value.error)
-        assertNull(assertIs<FictionEditor.Add>(fixture.holder.state.value.editor).epubFile)
+        assertNull(assertIs<FictionAddDraft>(fixture.holder.state.value.editor).epubFile)
         fixture.cache.close()
     }
 
@@ -283,7 +252,7 @@ class FictionManagementStateHolderTest {
 
         fixture.holder.chooseEpub()
 
-        val editor = assertIs<FictionEditor.Add>(fixture.holder.state.value.editor)
+        val editor = assertIs<FictionAddDraft>(fixture.holder.state.value.editor)
         assertNull(editor.epubFile)
         assertNull(fixture.holder.state.value.error, "cancelling is not an error")
         assertEquals("12345", editor.fictionUrl)

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionMetadataStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionMetadataStateHolderTest.kt
@@ -1,0 +1,378 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.data.CoverUploadResult
+import dk.perspektiva.ttsroad.desktop.data.FictionMetadataFields
+import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.LibraryCache
+import java.io.File
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * The editor's whole job is deciding *what not to send*.
+ *
+ * On a server that tracks hand-edited metadata a write claims the field permanently, so a request
+ * carrying a value nobody typed freezes it against every future refresh of the source. Most of what
+ * is asserted here is therefore an absence: which keys are missing from the patch, and that
+ * releasing a field sends no value alongside the release.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class FictionMetadataStateHolderTest {
+
+    private val serial = FictionSummary(
+        id = 7,
+        title = "Wandering Inn",
+        author = "pirateaba",
+        description = "An inn.",
+        tags = listOf("LitRPG", "Fantasy"),
+        voice = "en-US-AriaNeural",
+    )
+
+    @Test
+    fun `only the fields somebody actually changed are sent`() = runTest {
+        val fixture = fixture()
+        fixture.repository.updateFictionResult = Result.success(serial.copy(title = "The Wandering Inn"))
+        fixture.holder.load(serial)
+
+        fixture.holder.setAuthor("pirateaba ")
+
+        // Author differs only by trailing space, which is not a change once trimmed.
+        assertFalse(fixture.holder.state.value.hasChanges)
+
+        fixture.holder.setTitle("The Wandering Inn")
+        fixture.holder.save()
+        runCurrent()
+
+        val (fictionId, request) = fixture.repository.updatedFictions.single()
+        assertEquals(7, fictionId)
+        assertEquals("The Wandering Inn", request.title)
+        assertNull(request.author, "an untouched author must not be claimed")
+        assertNull(request.description, "an untouched description must not be claimed")
+        assertNull(request.tags, "untouched tags must not be claimed")
+        assertNull(request.voice, "an untouched voice must not be sent")
+        fixture.close()
+    }
+
+    @Test
+    fun `changing only the voice claims no metadata field`() = runTest {
+        val fixture = fixture()
+        fixture.repository.updateFictionResult = Result.success(serial.copy(voice = "en-GB-RyanNeural"))
+        fixture.holder.load(serial)
+
+        fixture.holder.setVoice("en-GB-RyanNeural")
+
+        // Narration voice is a conversion setting, not metadata — it is not an override.
+        assertTrue(fixture.holder.state.value.voiceChanged)
+        assertTrue(fixture.holder.state.value.changedFields.isEmpty())
+
+        fixture.holder.save()
+        runCurrent()
+
+        val request = fixture.repository.updatedFictions.single().second
+        assertEquals("en-GB-RyanNeural", request.voice)
+        assertNull(request.title)
+        assertNull(request.tags)
+        fixture.close()
+    }
+
+    @Test
+    fun `a tag typed but never committed is still saved`() = runTest {
+        val fixture = fixture()
+        fixture.repository.updateFictionResult = Result.success(
+            serial.copy(tags = listOf("LitRPG", "Fantasy", "Progression")),
+        )
+        fixture.holder.load(serial)
+
+        // Pressing Save with a half-typed tag left in the field must not silently drop it.
+        fixture.holder.setTagDraft("Progression")
+        fixture.holder.save()
+        runCurrent()
+
+        val request = fixture.repository.updatedFictions.single().second
+        assertContentEquals(listOf("LitRPG", "Fantasy", "Progression"), request.tags)
+        assertEquals("", fixture.holder.state.value.draft.tagDraft)
+        fixture.close()
+    }
+
+    @Test
+    fun `a duplicate tag is folded rather than added twice`() = runTest {
+        val fixture = fixture()
+        fixture.holder.load(serial)
+
+        fixture.holder.setTagDraft("litrpg")
+        fixture.holder.commitTagDraft()
+
+        assertContentEquals(listOf("LitRPG", "Fantasy"), fixture.holder.state.value.draft.tags)
+        assertFalse(fixture.holder.state.value.hasChanges, "folding a duplicate changes nothing")
+        fixture.close()
+    }
+
+    @Test
+    fun `an empty title or voice is refused before any request`() = runTest {
+        val fixture = fixture()
+        fixture.holder.load(serial)
+
+        fixture.holder.setTitle("   ")
+        fixture.holder.save()
+        runCurrent()
+
+        assertEquals("Title cannot be empty", fixture.holder.state.value.error)
+        assertTrue(fixture.repository.updatedFictions.isEmpty())
+
+        fixture.holder.setTitle("Wandering Inn")
+        fixture.holder.setVoice("")
+        fixture.holder.save()
+        runCurrent()
+
+        assertEquals("Voice cannot be empty", fixture.holder.state.value.error)
+        assertTrue(fixture.repository.updatedFictions.isEmpty())
+        fixture.close()
+    }
+
+    @Test
+    fun `releasing a field sends clear_overrides and no values`() = runTest {
+        val owned = serial.copy(metadataOverrides = listOf("title", "tags"))
+        val fixture = fixture()
+        fixture.repository.updateFictionResult = Result.success(owned.copy(metadataOverrides = emptyList()))
+        fixture.holder.load(owned)
+
+        // Something is typed but unsaved: releasing must not carry it along as a fresh claim.
+        fixture.holder.setTitle("Something Else")
+        fixture.holder.useSourceValues(setOf(FictionMetadataFields.Title))
+        runCurrent()
+
+        val request = fixture.repository.updatedFictions.single().second
+        assertEquals(listOf("title"), request.clearOverrides)
+        assertNull(request.title, "releasing a field must not re-claim it in the same request")
+        assertNull(request.tags)
+        assertEquals(
+            "Something Else",
+            fixture.holder.state.value.draft.title,
+            "clearing removes protection; it does not restore what the source said",
+        )
+        fixture.close()
+    }
+
+    @Test
+    fun `releasing a field the account does not own does nothing`() = runTest {
+        val fixture = fixture()
+        fixture.holder.load(serial)
+
+        fixture.holder.useSourceValues(setOf(FictionMetadataFields.Description))
+        runCurrent()
+
+        assertTrue(fixture.repository.updatedFictions.isEmpty())
+        fixture.close()
+    }
+
+    @Test
+    fun `an older server that drops description and tags is reported rather than called a save`() = runTest {
+        val fixture = fixture()
+        // A server predating hand-edited metadata echoes the title it stored and ignores the rest.
+        fixture.repository.updateFictionResult = Result.success(
+            serial.copy(title = "The Wandering Inn"),
+        )
+        fixture.holder.load(serial)
+
+        fixture.holder.setTitle("The Wandering Inn")
+        fixture.holder.setDescription("A very good inn.")
+        fixture.holder.save()
+        runCurrent()
+
+        val error = fixture.holder.state.value.error.orEmpty()
+        assertTrue(error.contains("Description"), error)
+        assertTrue(error.contains("older than hand-edited metadata"), error)
+        assertNull(fixture.holder.state.value.notice, "a partial write is not a save")
+        fixture.close()
+    }
+
+    @Test
+    fun `a metadata save survives a cover the server refuses`() = runTest {
+        val cover = imageFile("cover.jpg", bytes = 8)
+        val fixture = fixture(picker = { cover })
+        fixture.repository.updateFictionResult = Result.success(serial.copy(title = "The Wandering Inn"))
+        fixture.repository.uploadCoverResult =
+            Result.success(CoverUploadResult.Rejected("That image is too large"))
+        fixture.holder.load(serial)
+
+        fixture.holder.setTitle("The Wandering Inn")
+        fixture.holder.chooseCover()
+        fixture.holder.save()
+        runCurrent()
+
+        assertEquals("The Wandering Inn", fixture.holder.state.value.fiction?.title)
+        assertEquals("That image is too large", fixture.holder.state.value.error)
+        assertEquals(
+            cover,
+            fixture.holder.state.value.chosenCover,
+            "a refusal a person can act on keeps the file for a retry",
+        )
+        fixture.close()
+    }
+
+    @Test
+    fun `a server without the cover route stops offering the control`() = runTest {
+        val cover = imageFile("cover.png", bytes = 8)
+        val fixture = fixture(picker = { cover })
+        fixture.repository.updateFictionResult = Result.success(serial)
+        fixture.repository.uploadCoverResult = Result.success(CoverUploadResult.Unsupported)
+        fixture.holder.load(serial)
+
+        fixture.holder.chooseCover()
+        fixture.holder.save()
+        runCurrent()
+
+        assertFalse(fixture.holder.state.value.coverUploadSupported)
+        assertNull(
+            fixture.holder.state.value.chosenCover,
+            "there is nothing to retry against a server without the route",
+        )
+        fixture.close()
+    }
+
+    @Test
+    fun `the wrong kind of image is refused before it is uploaded`() = runTest {
+        val fixture = fixture(picker = { imageFile("scan.tiff", bytes = 8) })
+        fixture.holder.load(serial)
+
+        fixture.holder.chooseCover()
+
+        assertEquals(
+            "Cover art has to be a JPEG, PNG, WEBP or GIF image",
+            fixture.holder.state.value.error,
+        )
+        assertNull(fixture.holder.state.value.chosenCover)
+        assertTrue(fixture.repository.uploadedCovers.isEmpty())
+        fixture.close()
+    }
+
+    @Test
+    fun `an image over the server's published ceiling is refused with both numbers`() = runTest {
+        val fixture = fixture(picker = { imageFile("huge.jpg", bytes = 3 * 1024 * 1024) })
+        fixture.holder.load(serial, maxCoverBytes = 1024L * 1024)
+
+        fixture.holder.chooseCover()
+
+        val error = fixture.holder.state.value.error.orEmpty()
+        assertTrue(error.contains("3.0 MB"), error)
+        assertTrue(error.contains("1.0 MB"), error)
+        fixture.close()
+    }
+
+    @Test
+    fun `a fresher copy of the same fiction keeps what is being typed`() = runTest {
+        val fixture = fixture()
+        fixture.holder.load(serial)
+        fixture.holder.setTitle("Half-typed tit")
+
+        // The screen re-loads whenever the library cache publishes a fresher row.
+        fixture.holder.load(serial.copy(doneChapters = 12))
+
+        assertEquals("Half-typed tit", fixture.holder.state.value.draft.title)
+        assertEquals(12, fixture.holder.state.value.fiction?.doneChapters)
+
+        // A different fiction is a different form.
+        fixture.holder.load(serial.copy(id = 9, title = "Other"))
+        assertEquals("Other", fixture.holder.state.value.draft.title)
+        fixture.close()
+    }
+
+    @Test
+    fun `revert drops every unsaved edit including a chosen cover`() = runTest {
+        val fixture = fixture(picker = { imageFile("cover.jpg", bytes = 8) })
+        fixture.holder.load(serial)
+
+        fixture.holder.setTitle("Something else")
+        fixture.holder.chooseCover()
+        fixture.holder.revertEdits()
+
+        assertEquals("Wandering Inn", fixture.holder.state.value.draft.title)
+        assertNull(fixture.holder.state.value.chosenCover)
+        assertFalse(fixture.holder.state.value.hasChanges)
+        fixture.close()
+    }
+
+    @Test
+    fun `saving nothing makes no request`() = runTest {
+        val fixture = fixture()
+        fixture.holder.load(serial)
+
+        fixture.holder.save()
+        runCurrent()
+
+        assertEquals("Nothing to save", fixture.holder.state.value.notice)
+        assertTrue(fixture.repository.updatedFictions.isEmpty())
+        fixture.close()
+    }
+
+    @Test
+    fun `a failed save keeps the draft so the edit is not lost`() = runTest {
+        val fixture = fixture()
+        fixture.repository.updateFictionResult = Result.failure(java.io.IOException("offline"))
+        fixture.holder.load(serial)
+
+        fixture.holder.setTitle("The Wandering Inn")
+        fixture.holder.save()
+        runCurrent()
+
+        assertEquals("The Wandering Inn", fixture.holder.state.value.draft.title)
+        assertFalse(fixture.holder.state.value.isBusy)
+        assertTrue(fixture.holder.state.value.error.orEmpty().isNotEmpty())
+        fixture.close()
+    }
+
+    @Test
+    fun `a session ending empties the form`() = runTest {
+        val fixture = fixture()
+        fixture.holder.load(serial)
+        fixture.holder.setTitle("The Wandering Inn")
+
+        fixture.holder.sessionEnded()
+
+        assertNull(fixture.holder.state.value.fiction)
+        assertEquals("", fixture.holder.state.value.draft.title)
+        fixture.close()
+    }
+
+    // --- fixture ----------------------------------------------------------------------------------
+
+    private class Fixture(
+        val repository: FakeRepository,
+        val cache: LibraryCache,
+        val holder: FictionMetadataStateHolder,
+    ) {
+        fun close() {
+            holder.clear()
+            cache.close()
+        }
+    }
+
+    private fun TestScope.fixture(picker: CoverImagePicker = CoverImagePicker { null }): Fixture {
+        val repository = FakeRepository()
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        return Fixture(
+            repository,
+            cache,
+            FictionMetadataStateHolder(
+                repository,
+                cache,
+                picker = picker,
+                dispatcher = UnconfinedTestDispatcher(testScheduler),
+            ),
+        )
+    }
+
+    private fun imageFile(name: String, bytes: Int): File =
+        java.nio.file.Files.createTempDirectory("ttsroad-cover").resolve(name).toFile()
+            .also { it.writeBytes(ByteArray(bytes)) }
+}


### PR DESCRIPTION
Closes #95.

Editing a fiction was a dialog with three fields — title, author, voice — that posted all three
whether or not any of them changed. On a server that tracks hand-edited metadata that is worse than
incomplete: writing a field takes ownership of it, so correcting a typo in a title also froze the
author and the voice against every future refresh of the source.

## What changed

- **Editing is a screen** (`FictionMetadataScreen` + `FictionMetadataStateHolder`), because its
  fields are shared with every account. Adding stays a dialog — it is a question and an answer.
- **Description, tags and cover art** join title, author and voice.
- **Only changed fields are sent.** `patchOf` builds the request from `changedFields`, so an
  untouched field is absent from the body rather than present with its current value.
- **"Use source values"** sends `clear_overrides` and nothing else, and deliberately leaves the form
  alone: clearing removes the protection, it does not restore what the source used to say.
- **The answer is read, not assumed.** `ignoredFields` compares what was sent against what came
  back, so a server predating hand-edited metadata is reported rather than reported as a save.
- **Cover art is an upload.** `POST /fictions/{id}/cover` is additive with no capability flag, so a
  404 retires the control instead of looking like a failure worth retrying. The patch is sent before
  the image, so a metadata save survives an image the server refuses.

## Notes for review

- `voice` is deliberately outside the override machinery — it is a conversion setting, not metadata,
  and changing it claims nothing.
- `maxCoverBytes` is parsed although no server publishes it yet, so the pre-upload check starts
  working the day one does, without a client release.
- `CoverUploadResult` is typed rather than thrown for the same reason `LoginResult` is: "the server
  read this and said no" is not a failed request, and the three answers want three different
  sentences on screen.

## Verification

`./gradlew check` passes under Xvfb. `FictionMetadataStateHolderTest` is new — 16 cases, most of
them asserting an *absence*: which keys are missing from the patch, and that releasing a field
carries no value alongside the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK3sri5jA6ne6tEJnbQaRe