### PR TITLE
Make the now-playing bar skip as far as it says

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreen.kt
@@ -687,10 +687,16 @@ fun NowPlayingBar(
             ) {
                 BarTrackInfo(s, Modifier.weight(1f), onExpand)
                 Spacer(Modifier.width(16.dp))
+                // The same interval, icon and controller path as the full player. Two surfaces that
+                // look identical and jump different distances is worse than either distance.
+                val skipSeconds = (s.skipIntervalMs / 1000).toInt()
                 Row(horizontalArrangement = Arrangement.spacedBy(10.dp), verticalAlignment = Alignment.CenterVertically) {
-                    TransportButton(Icons.Default.Replay30, "Back 30 seconds", enabled = s.hasMedia, size = 36.dp) {
-                        playback.skipBy(-30_000)
-                    }
+                    TransportButton(
+                        rewindIconFor(skipSeconds),
+                        "Back $skipSeconds seconds",
+                        enabled = s.hasMedia,
+                        size = 36.dp,
+                    ) { playback.skipBackward() }
                     TransportButton(
                         if (s.isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
                         if (s.isPlaying) "Pause" else "Play",
@@ -698,9 +704,12 @@ fun NowPlayingBar(
                         size = 44.dp,
                         filled = true,
                     ) { playback.togglePlayPause() }
-                    TransportButton(Icons.Default.Forward30, "Forward 30 seconds", enabled = s.hasMedia, size = 36.dp) {
-                        playback.skipBy(30_000)
-                    }
+                    TransportButton(
+                        forwardIconFor(skipSeconds),
+                        "Forward $skipSeconds seconds",
+                        enabled = s.hasMedia,
+                        size = 36.dp,
+                    ) { playback.skipForward() }
                     TransportButton(Icons.Default.SkipNext, "Next chapter", enabled = s.hasNext, size = 36.dp) {
                         playback.skipToNextChapter()
                     }

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreenUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreenUiTest.kt
@@ -167,6 +167,22 @@ class PlayerScreenUiTest {
     }
 
     @Test
+    fun `the now-playing bar honours the configured skip interval`() {
+        // Regression: the bar hard-coded 30 seconds while the full player and reading mode read the
+        // preference, so the same-looking control jumped twice as far depending on which surface
+        // happened to be on screen.
+        val playback = FakePlaybackController(playingState().copy(skipIntervalMs = 15_000))
+        compose.setContent { TtsRoadTheme { NowPlayingBar(playback) {} } }
+
+        compose.onNodeWithContentDescription("Back 15 seconds").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Forward 15 seconds").assertIsDisplayed().performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithContentDescription("Back 30 seconds").assertDoesNotExist()
+        assertEquals(1, playback.calls.size, "calls were ${playback.calls}")
+    }
+
+    @Test
     fun `the now-playing bar expands to the full player`() {
         val playback = FakePlaybackController(playingState())
         var expanded = false


### PR DESCRIPTION
Closes #77.

The full player and reading mode derive their skip from `s.skipIntervalMs` and call
`skipBackward()`/`skipForward()`, which read the listener's preference through
`QueuePlaybackController`. `NowPlayingBar` hard-coded 30 seconds in three places at once — the
`Replay30`/`Forward30` glyph, the announced label, and `skipBy(±30_000)` — so after choosing 15
seconds in Settings the same-looking control jumped twice as far depending on which surface was
visible.

The bar now uses the same `rewindIconFor`/`forwardIconFor` helpers and the same controller entry
points as the full player, so the preference reaches every surface without each one reading it
separately.

## Verification

New case in `PlayerScreenUiTest`: with a 15-second interval the bar announces "Back 15 seconds" and
"Forward 15 seconds", and no 30-second control exists. It fails against the previous code on the
label alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK3sri5jA6ne6tEJnbQaRe