### PR TITLE
Stop resume affordances failing silently

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -143,7 +143,9 @@ fun App(container: AppContainer = remember { AppContainer() }) {
     // Hoisted for a sharper reason than the other two: bookmarks are *written* from the player and
     // the reader and *read* on a destination the user may never open, so a holder owned by the
     // bookmarks screen would give Ctrl+B nowhere to put anything.
-    val bookmarks = rememberStateHolder(repository) { BookmarksStateHolder(repository) }
+    val bookmarks = rememberStateHolder(repository, cache) {
+        BookmarksStateHolder(repository, cachedChapters = { cache.chapters(it).value.value })
+    }
     // Hoisted for the same reason: "Add to queue" is pressed on a chapter list, so the queue has to
     // exist and report what happened whether or not the queue screen was ever opened.
     val serverQueue = rememberStateHolder(repository, playback) {
@@ -231,14 +233,17 @@ fun App(container: AppContainer = remember { AppContainer() }) {
      * Opens a mark: loads its fiction, queues it, and starts *at the mark* rather than at the
      * chapter's saved resume position — the whole point of having clicked it.
      *
-     * Fetched through the repository rather than the library cache because this screen has no
-     * fiction context at all: a bookmark can point at a serial the session has never opened.
+     * Loaded through the bookmarks holder, which prefers chapters this session already has and
+     * otherwise fetches them: a bookmark can point at a serial the session has never opened, and a
+     * failure has to be visible on the screen the click came from.
      */
     fun openBookmark(bookmark: Bookmark) {
-        val fictionId = bookmark.fictionId ?: return
         val chapterId = bookmark.chapterId ?: return
         scope.launch {
-            val loaded = runCatching { repository.chapters(fictionId) }.getOrNull() ?: return@launch
+            // The holder owns the request *and* the sentence about it failing; this navigator only
+            // acts on a success. Discarding the exception here is what made a Play against an
+            // unreachable server look like a click that never registered.
+            val loaded = bookmarks.loadForPlayback(bookmark) ?: return@launch
             playback.playQueue(loaded.chapters, chapterId, loaded.fiction, bookmark.positionMs)
             nav.open(Destination.Player)
         }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryCache.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryCache.kt
@@ -229,6 +229,31 @@ class LibraryCache(
             .firstOrNull { it.id == fictionId }
             ?.following
 
+    /**
+     * The fiction [fictionId] names, from either shelf, or null when neither holds it.
+     *
+     * Both payloads, not just the followed one: a jump-back moment or a bookmark can point at a
+     * serial this account has since unfollowed, or at one it has only ever browsed.
+     */
+    fun cachedFiction(fictionId: Int): FictionSummary? =
+        (_library.value.value?.fictions.orEmpty() + _browseAll.value.value?.fictions.orEmpty())
+            .firstOrNull { it.id == fictionId }
+
+    /**
+     * The fiction [fictionId] names, fetching it when neither shelf has it.
+     *
+     * The fallback is the chapters endpoint, which carries a `fiction` built by the server's own
+     * `_fiction_payload`. That is deliberately the same request the caller is about to need anyway
+     * — nothing here opens a fiction without also wanting its chapters — so resolving costs no
+     * extra round trip in the case that made it necessary.
+     *
+     * Throws rather than answering null on a failed request, because "the server said there is no
+     * such fiction" and "the request never arrived" want different sentences on screen, and only
+     * the caller knows which surface is asking.
+     */
+    suspend fun resolveFiction(fictionId: Int): FictionSummary =
+        cachedFiction(fictionId) ?: repository.chapters(fictionId).fiction
+
     // --- Chapters --------------------------------------------------------------------------
 
     /** The chapter list for one fiction. Stable across navigation, so scroll and data survive. */

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/BookmarksStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/BookmarksStateHolder.kt
@@ -4,6 +4,7 @@ import dk.perspektiva.ttsroad.desktop.data.Bookmark
 import dk.perspektiva.ttsroad.desktop.data.BookmarkCreateRequest
 import dk.perspektiva.ttsroad.desktop.data.BookmarkLimits
 import dk.perspektiva.ttsroad.desktop.data.BookmarkPatchRequest
+import dk.perspektiva.ttsroad.desktop.data.ChaptersResponse
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
 import dk.perspektiva.ttsroad.desktop.data.visibleBookmarks
@@ -57,11 +58,56 @@ data class BookmarksUiState(
 class BookmarksStateHolder(
     private val repository: TtsRoadRepository,
     dispatcher: CoroutineDispatcher = Dispatchers.Main,
+    /**
+     * Chapters this session already holds for a fiction, when it holds any.
+     *
+     * Consulted before the network so a mark on a serial that is already open plays offline, which
+     * is the case where a failed request would be most obviously unnecessary. Defaults to knowing
+     * nothing, which is correct for a test and for a screen with no library cache behind it.
+     */
+    private val cachedChapters: (Int) -> ChaptersResponse? = { null },
 ) : StateHolder(dispatcher) {
     private val _state = MutableStateFlow(BookmarksUiState())
     val state: StateFlow<BookmarksUiState> = _state.asStateFlow()
 
     private var loadJob: Job? = null
+
+    /**
+     * Loads what a mark needs in order to play, or says why it could not.
+     *
+     * The request lives here rather than in the caller because a failure needs somewhere to be
+     * *seen*: the previous version discarded the exception in the navigator, so a Play against an
+     * unreachable server produced no navigation, no notice and no error — indistinguishable from a
+     * click that never registered. The caller keeps the playback and the navigation, which are the
+     * two things a holder should not know about.
+     *
+     * Answers null having already published the reason.
+     */
+    suspend fun loadForPlayback(bookmark: Bookmark): ChaptersResponse? {
+        val fictionId = bookmark.fictionId
+        val chapterId = bookmark.chapterId
+        if (fictionId == null || chapterId == null) {
+            _state.update { it.copy(error = "That bookmark does not name a chapter to play") }
+            return null
+        }
+        cachedChapters(fictionId)?.let { cached ->
+            if (cached.chapters.any { it.id == chapterId }) return cached
+        }
+        _state.update { it.copy(error = null) }
+        return runCatching { repository.chapters(fictionId) }
+            .onFailure { failure ->
+                _state.update {
+                    it.copy(error = userFacingMessage(failure, "Could not open that bookmark"))
+                }
+            }
+            .getOrNull()
+            ?.also { loaded ->
+                if (loaded.chapters.none { it.id == chapterId }) {
+                    _state.update { it.copy(error = "That chapter is no longer in ${loaded.fiction.title}") }
+                }
+            }
+            ?.takeIf { loaded -> loaded.chapters.any { it.id == chapterId } }
+    }
 
     /** Loads once. What the bookmarks screen calls on entry; a second visit costs nothing. */
     fun ensureLoaded() {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/Components.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/Components.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.paneTitle
@@ -264,6 +265,42 @@ fun StaleContentBanner(message: String, lastSuccessMillis: Long?, nowMillis: Lon
             shape = RectangleShape,
             modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
         ) { Text("RETRY") }
+    }
+}
+
+const val InlineNoticeTestTag: String = "inlineNotice"
+
+/**
+ * One line about something the user just did that did not work, with a way to dismiss it.
+ *
+ * Distinct from [StaleContentBanner], which is about the *content* being older than it looks and
+ * therefore always carries a Retry. This is about an *action* — a jump-back card that could not be
+ * opened, a bookmark whose fiction is gone — where retrying the same click is not obviously the
+ * right advice, and the only thing owed is a sentence saying the click was received.
+ */
+@Composable
+fun InlineNotice(message: String, onDismiss: () -> Unit) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .background(AarisColor.BgRaise)
+            .border(1.dp, AarisColor.Warning)
+            .padding(horizontal = 14.dp, vertical = 10.dp)
+            .testTag(InlineNoticeTestTag),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = AarisColor.Warning,
+            modifier = Modifier.weight(1f),
+        )
+        Spacer(Modifier.width(12.dp))
+        OutlinedButton(
+            onClick = onDismiss,
+            shape = RectangleShape,
+            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+        ) { Text("DISMISS") }
     }
 }
 

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/LibraryScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/LibraryScreen.kt
@@ -80,6 +80,7 @@ import dk.perspektiva.ttsroad.desktop.data.PlaybackSnapshot
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.data.chapterKeys
 import dk.perspektiva.ttsroad.desktop.data.fictionKeys
+import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
 import dk.perspektiva.ttsroad.desktop.player.PlaybackController
 import kotlinx.coroutines.launch
 
@@ -168,6 +169,9 @@ fun LibraryScreen(
     // search text must not be one of the things that disposal takes with it. `rememberSaveable`
     // then hands it to the per-destination state holder, so Back from a fiction restores it.
     var query by rememberSaveable { mutableStateOf("") }
+    // Deliberately not `rememberSaveable`: a failure to open is about a click that just happened,
+    // and restoring last session's would be a message with nothing behind it.
+    var openError by remember { mutableStateOf<String?>(null) }
     val gridState = rememberLazyGridState()
 
     // The rails — hero, jump-back, recent — always come from the shelf, in both modes. The server
@@ -199,6 +203,12 @@ fun LibraryScreen(
                     horizontalArrangement = Arrangement.spacedBy(GridGap),
                     verticalArrangement = Arrangement.spacedBy(GridGap),
                 ) {
+                    openError?.let { message ->
+                        fullWidthItem("open-error") {
+                            InlineNotice(message) { openError = null }
+                        }
+                    }
+
                     // A refresh that failed reports itself here, above content it did not replace.
                     if (state.isStale) {
                         fullWidthItem("stale") {
@@ -244,9 +254,22 @@ fun LibraryScreen(
                                 Spacer(Modifier.height(16.dp))
                                 JumpBackShelf(
                                     snapshots = jumpBack,
+                                    // Resolved outside the followed shelf on purpose: a moment
+                                    // recorded on another client can name a serial this account has
+                                    // since unfollowed, or one it has only browsed, and looking it
+                                    // up in `rails` alone turned the card into a clickable no-op.
                                     onOpen = { snapshot ->
-                                        rails.fictions.firstOrNull { it.id == snapshot.fictionId }
-                                            ?.let(onOpenFiction)
+                                        scope.launch {
+                                            openError = null
+                                            runCatching { cache.resolveFiction(snapshot.fictionId) }
+                                                .onSuccess(onOpenFiction)
+                                                .onFailure { failure ->
+                                                    openError = userFacingMessage(
+                                                        failure,
+                                                        "Could not open ${snapshot.fictionTitle}",
+                                                    )
+                                                }
+                                        }
                                     },
                                     onDismiss = { history.dismiss(it.key) },
                                 )

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryCacheTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/LibraryCacheTest.kt
@@ -860,6 +860,43 @@ class LibraryCacheTest {
     }
 
     @Test
+    fun `a fiction is resolved from either shelf before anything is fetched`() = runTest {
+        val repository = FakeRepository(
+            libraryResult = Result.success(shelf("Followed")),
+            browseAllResult = Result.success(catalogue("Followed" to true, "Only browsed" to false)),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        cache.ensureLibrary()
+        cache.ensureBrowseAll()
+        runCurrent()
+
+        // Id 2 is in the catalogue and not on the shelf, which is exactly the case that used to
+        // turn a jump-back card into a clickable no-op.
+        assertEquals("Only browsed", cache.resolveFiction(2).title)
+        assertEquals(0, repository.chaptersCalls, "neither answer needed a request")
+        cache.close()
+    }
+
+    @Test
+    fun `a fiction in neither shelf is fetched rather than dropped`() = runTest {
+        val repository = FakeRepository(
+            libraryResult = Result.success(shelf("Followed")),
+            chaptersResult = Result.success(
+                ChaptersResponse(fiction = FictionSummary(id = 99, title = "Unfollowed elsewhere")),
+            ),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        cache.ensureLibrary()
+        runCurrent()
+
+        // A moment recorded on another client can name a serial this account has since unfollowed.
+        assertEquals("Unfollowed elsewhere", cache.resolveFiction(99).title)
+        assertEquals(1, repository.chaptersCalls)
+        assertNull(cache.cachedFiction(99), "the fetch is not a silent write into either shelf")
+        cache.close()
+    }
+
+    @Test
     fun `signing out drops the catalogue as well as the shelf`() = runTest {
         val repository = FakeRepository(
             libraryResult = Result.success(shelf("Followed")),

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/BookmarksStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/BookmarksStateHolderTest.kt
@@ -3,6 +3,9 @@ package dk.perspektiva.ttsroad.desktop.ui
 import dk.perspektiva.ttsroad.desktop.FakeRepository
 import dk.perspektiva.ttsroad.desktop.data.Bookmark
 import dk.perspektiva.ttsroad.desktop.data.BookmarkKind
+import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
+import dk.perspektiva.ttsroad.desktop.data.ChaptersResponse
+import dk.perspektiva.ttsroad.desktop.data.FictionSummary
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -27,6 +30,71 @@ class BookmarksStateHolderTest {
 
     private fun bookmark(id: Int, createdAt: String = "2027-01-0${id}T09:00:00Z") =
         Bookmark(id = id, chapterId = 100 + id, fictionId = 7, createdAt = createdAt)
+
+    private fun chaptersFor(vararg chapterIds: Int) = ChaptersResponse(
+        fiction = FictionSummary(id = 7, title = "A Test Serial"),
+        chapters = chapterIds.map { ChapterSummary(id = it, title = "Chapter $it") },
+    )
+
+    @Test
+    fun `a bookmark that cannot be loaded says so instead of doing nothing`() = runTest {
+        // Regression: the navigator did `runCatching { ... }.getOrNull() ?: return@launch`, so a
+        // Play against an unreachable server produced no navigation and no message at all.
+        val repository = FakeRepository().apply {
+            chaptersResult = Result.failure(java.io.IOException("offline"))
+        }
+        val holder = holder(repository)
+
+        val loaded = holder.loadForPlayback(bookmark(1))
+
+        assertNull(loaded)
+        assertNotNull(holder.state.value.error, "a failed open has to be visible")
+    }
+
+    @Test
+    fun `a bookmark whose chapter is gone names the fiction it went missing from`() = runTest {
+        val repository = FakeRepository().apply {
+            // The fiction still exists; chapter 101 has been excluded or deleted since the mark.
+            chaptersResult = Result.success(chaptersFor(102, 103))
+        }
+        val holder = holder(repository)
+
+        val loaded = holder.loadForPlayback(bookmark(1))
+
+        assertNull(loaded)
+        assertEquals("That chapter is no longer in A Test Serial", holder.state.value.error)
+    }
+
+    @Test
+    fun `chapters this session already holds are preferred over a request`() = runTest {
+        val repository = FakeRepository().apply {
+            chaptersResult = Result.failure(java.io.IOException("offline"))
+        }
+        val holder = BookmarksStateHolder(
+            repository,
+            UnconfinedTestDispatcher(),
+            cachedChapters = { chaptersFor(101, 102) },
+        )
+
+        val loaded = holder.loadForPlayback(bookmark(1))
+
+        // Offline, but the serial is open in this session — the mark plays without a request.
+        assertNotNull(loaded)
+        assertEquals(0, repository.chaptersCalls)
+        assertNull(holder.state.value.error)
+    }
+
+    @Test
+    fun `a bookmark with no chapter is refused before any request`() = runTest {
+        val repository = FakeRepository()
+        val holder = holder(repository)
+
+        val loaded = holder.loadForPlayback(Bookmark(id = 1, chapterId = null, fictionId = 7))
+
+        assertNull(loaded)
+        assertEquals(0, repository.chaptersCalls)
+        assertNotNull(holder.state.value.error)
+    }
 
     @Test
     fun `loading asks only for manual marks`() = runTest {


### PR DESCRIPTION
Closes #78. Closes #79.

Filed separately, fixed together: both are the same defect — an id resolved against a list that
need not contain it, with the click dropped when it did not.

## Jump back in (#78)

`onOpen` did `rails.fictions.firstOrNull { it.id == snapshot.fictionId }?.let(onOpenFiction)`, and
`rails` is always the followed shelf. A moment merged from the server's `kind=auto` bookmarks can
name a serial this account has since unfollowed, or one it has only browsed — and while browsing
Everything the handler searched the shelf while the user was looking at the catalogue. The card
still said Open and did nothing.

## Bookmarks (#79)

`openBookmark` discarded both the exception and the null in the navigator, so an unreachable
server, a deleted fiction and a click that never registered were indistinguishable.

## What changed

- **`LibraryCache.cachedFiction` / `resolveFiction`** — reads *both* shelves, then falls back to the
  chapters endpoint, which carries the server's own `_fiction_payload`. That is the request the
  caller needs anyway, so the fallback costs no extra round trip in the case that required it.
- **`BookmarksStateHolder.loadForPlayback`** — the request and the message about it failing now live
  where the screen can see them. It prefers chapters this session already holds, so a mark on an
  open serial plays offline; and it separates "that chapter is no longer in *X*" from "could not
  open that bookmark".
- **`InlineNotice`** — a new component in `Components.kt` for an *action* that failed, as distinct
  from `StaleContentBanner`, which is about *content* being older than it looks and always carries a
  Retry.

## Verification

`./gradlew check` passes. Four new holder cases and two new `LibraryCacheTest` cases, including the
catalogue-not-shelf resolution that reproduces #78 directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK3sri5jA6ne6tEJnbQaRe