### PR TITLE
Say what a row's icon actions do before they are clicked

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/Components.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/Components.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
@@ -95,7 +96,9 @@ fun RowIconAction(
     enabled: Boolean = true,
 ) {
     TooltipBox(
-        positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+        // Above the row rather than below it: a chapter row's actions sit at the right-hand end
+        // of a list, and a label drawn downwards covers the next row's actions.
+        positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
         tooltip = { PlainTooltip { Text(contentDescription) } },
         state = rememberTooltipState(),
         // The anchor keeps its own semantics: `TooltipBox` would otherwise describe the wrapper as

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/Components.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/Components.kt
@@ -23,12 +23,17 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -73,7 +78,14 @@ val PageGutter = 28.dp
  * Shared rather than per-screen so a chapter row and a queue row afford their actions identically —
  * same hit target, same focus border, same "the clickable node carries the description" rule that
  * screen readers and tests both depend on.
+ *
+ * Every one of these is icon-only, and a chapter row can show eight of them at once — download,
+ * cancel, delete, retry, play next, queue, read, mark played — several of which are near-identical
+ * glyphs guarding state changes that are awkward to undo. [contentDescription] was reaching a
+ * screen reader and a test and nobody else, so the mouse user, who is the majority on a desktop,
+ * had to click one to find out what it did. It is now also the visible hover label.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RowIconAction(
     icon: ImageVector,
@@ -81,6 +93,26 @@ fun RowIconAction(
     tint: Color,
     onClick: () -> Unit,
     enabled: Boolean = true,
+) {
+    TooltipBox(
+        positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+        tooltip = { PlainTooltip { Text(contentDescription) } },
+        state = rememberTooltipState(),
+        // The anchor keeps its own semantics: `TooltipBox` would otherwise describe the wrapper as
+        // well, and every test on this screen asks for the action by exactly one description.
+        enableUserInput = enabled,
+    ) {
+        RowIconActionAnchor(icon, contentDescription, tint, onClick, enabled)
+    }
+}
+
+@Composable
+private fun RowIconActionAnchor(
+    icon: ImageVector,
+    contentDescription: String,
+    tint: Color,
+    onClick: () -> Unit,
+    enabled: Boolean,
 ) {
     val interaction = remember { MutableInteractionSource() }
     val pointerOver by interaction.collectIsHoveredAsState()

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/RowIconActionTooltipTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/RowIconActionTooltipTest.kt
@@ -3,7 +3,7 @@ package dk.perspektiva.ttsroad.desktop.ui
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.PlaylistAdd
+import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.moveTo
 import androidx.compose.ui.test.onAllNodesWithText
@@ -28,7 +28,7 @@ class RowIconActionTooltipTest {
         compose.setContent {
             TtsRoadTheme {
                 Row {
-                    RowIconAction(Icons.Default.PlaylistAdd, "Add to shared queue", AarisColor.Muted, {})
+                    RowIconAction(Icons.AutoMirrored.Filled.PlaylistAdd, "Add to shared queue", AarisColor.Muted, {})
                     RowIconAction(Icons.Default.Delete, "Delete download", AarisColor.Danger, {})
                 }
             }

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/RowIconActionTooltipTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/RowIconActionTooltipTest.kt
@@ -1,0 +1,48 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.PlaylistAdd
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.moveTo
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performMouseInput
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * A chapter row can show eight icon-only actions at once, several of them near-identical glyphs in
+ * front of a state change that is awkward to undo. The description was reaching a screen reader and
+ * a test and nobody else; these pin that a mouse user is told as well.
+ */
+class RowIconActionTooltipTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun `hovering an icon action reveals its label`() {
+        compose.setContent {
+            TtsRoadTheme {
+                Row {
+                    RowIconAction(Icons.Default.PlaylistAdd, "Add to shared queue", AarisColor.Muted, {})
+                    RowIconAction(Icons.Default.Delete, "Delete download", AarisColor.Danger, {})
+                }
+            }
+        }
+
+        // Nothing is claimed before the pointer arrives.
+        compose.onNodeWithText("Add to shared queue").assertDoesNotExist()
+
+        compose.onNodeWithContentDescription("Add to shared queue").performMouseInput { moveTo(center) }
+        compose.waitUntil(5_000) {
+            compose.onAllNodesWithText("Add to shared queue").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // The neighbouring action, which shares neither glyph nor consequence, stays silent.
+        compose.onNodeWithText("Delete download").assertDoesNotExist()
+    }
+}


### PR DESCRIPTION
Closes #81.

`RowIconAction` carried a `contentDescription` that reached the semantics tree and nothing else. A
chapter row can show eight of these at once — download, cancel, delete, retry, play next, add to
shared queue, read, mark played — and the server queue shows four more. Several are near-identical
glyphs in front of a state change that is awkward to undo, so the mouse user, who is the majority on
a desktop, had to click one to find out what it did.

The same string is now the visible hover label via Material 3's `TooltipBox` + `PlainTooltip`, so
the screen-reader label and the visible label are one value and cannot drift.

## Notes for review

- The anchor is a separate composable keeping its own `semantics { contentDescription = ... }`.
  `TooltipBox` otherwise adds anchor semantics of its own, and every existing test on these screens
  asks for the action by exactly one description. All of them pass unchanged.
- `enableUserInput` follows `enabled`, so a disabled action does not explain itself on hover.
- Transport glyphs (play/pause/skip) are deliberately left alone — they are self-explanatory, and
  the issue scopes this to glyphs that are not.

## Verification

`./gradlew check` passes. New `RowIconActionTooltipTest` moves a real pointer onto one action and
asserts the label appears, that it did not exist before the hover, and that the neighbouring action
stays silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK3sri5jA6ne6tEJnbQaRe