### PR TITLE
Give every choice a role, a selected state and a focus ring

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/Components.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/Components.kt
@@ -3,6 +3,7 @@ package dk.perspektiva.ttsroad.desktop.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
@@ -20,6 +21,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -154,6 +158,115 @@ private fun RowIconActionAnchor(
             },
             modifier = Modifier.size(18.dp),
         )
+    }
+}
+
+/**
+ * One option in a group of mutually exclusive choices.
+ *
+ * Extracted from Settings, which is where the pattern was already right, because the player's speed
+ * presets and the reader's theme and highlight choices were plain `Text.clickable`: announced as
+ * generic clickable text, with the current choice carried by colour alone and no visible focus at
+ * all. Three things are load-bearing here and none of them survive being reimplemented per screen:
+ *
+ * - **[Role.RadioButton] and `selected`** — so a screen reader says "radio button, selected" rather
+ *   than reading four labels with nothing to say which one is in force.
+ * - **A focus border drawn explicitly** — the AARIS look has no ripple, so a keyboard-only user has
+ *   nothing else to tell them where they are.
+ * - **Selection shown by more than colour** — the background and the border both move, because
+ *   colour alone fails anyone who cannot separate accent from muted.
+ *
+ * The caller is responsible for wrapping the group in [selectableGroup]; see [AarisChoiceRow] for
+ * the ordinary case where the options sit in a row together.
+ */
+@Composable
+fun AarisChoiceChip(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    /** Overrides what a screen reader announces, where the visible label is an abbreviation. */
+    contentDescription: String? = null,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    val focused by interaction.collectIsFocusedAsState()
+    val description = contentDescription
+    Box(
+        modifier
+            .hoverable(interaction, enabled = enabled)
+            .let { if (enabled) it.pointerHoverIcon(PointerIcon.Hand) else it }
+            .background(if (selected) AarisColor.BgHover else Color.Transparent)
+            .border(
+                1.dp,
+                when {
+                    !enabled -> AarisColor.Line
+                    focused -> AarisColor.Accent
+                    selected -> AarisColor.Ink
+                    hovered -> AarisColor.Muted
+                    else -> AarisColor.Line
+                },
+            )
+            .selectable(
+                selected = selected,
+                enabled = enabled,
+                interactionSource = interaction,
+                indication = null,
+                role = Role.RadioButton,
+                onClick = onClick,
+            )
+            .let { base ->
+                if (description == null) base else base.semantics { this.contentDescription = description }
+            }
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+    ) {
+        MetaText(
+            label,
+            color = when {
+                !enabled -> AarisColor.Dim
+                selected -> AarisColor.Accent
+                hovered || focused -> AarisColor.Ink
+                else -> AarisColor.Muted
+            },
+        )
+    }
+}
+
+/**
+ * A labelled row of mutually exclusive choices.
+ *
+ * [selectableGroup] is what makes this announce as one choice with N options rather than as N
+ * unrelated buttons, which is the whole reason these are not plain clickable boxes.
+ */
+@Composable
+fun <T> AarisChoiceRow(
+    label: String?,
+    options: List<T>,
+    selected: T,
+    labelOf: (T) -> String,
+    onSelect: (T) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    isSelected: (T, T) -> Boolean = { option, current -> option == current },
+) {
+    Column(modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        if (label != null) MetaText(label)
+        Row(
+            // Nine speeds do not fit a narrow pane; scrolling beats wrapping into a grid whose rows
+            // change height as the option list changes.
+            Modifier.horizontalScroll(rememberScrollState()).selectableGroup(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            options.forEach { option ->
+                AarisChoiceChip(
+                    label = labelOf(option),
+                    selected = isSelected(option, selected),
+                    onClick = { onSelect(option) },
+                    enabled = enabled,
+                )
+            }
+        }
     }
 }
 

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.FastForward
@@ -360,23 +361,27 @@ private fun SpeedControl(
 ) {
     Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
         MetaText("Speed", color = AarisColor.Dim)
-        SpeedPresets.forEach { preset ->
-            // Compared with a tolerance, not ==: the value shown is the one the engine accepted,
-            // which can be a clamped float rather than the exact preset that was asked for.
-            val isCurrent = kotlin.math.abs(current - preset) < 0.01f
-            Text(
-                text = formatSpeed(preset),
-                color = when {
-                    !enabled -> AarisColor.Dim
-                    isCurrent -> AarisColor.Accent
-                    else -> AarisColor.Muted
-                },
-                modifier = Modifier
-                    .testTag(SpeedChipTestTag)
-                    .clickable(enabled = enabled) { onSelect(preset) }
-                    .pointerHoverIcon(PointerIcon.Hand)
-                    .padding(horizontal = 8.dp, vertical = 4.dp),
-            )
+        // One `selectableGroup`, so this announces as one choice with N options rather than as N
+        // unrelated pieces of clickable text — the same treatment Settings already gave its panes.
+        Row(
+            Modifier.selectableGroup(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            SpeedPresets.forEach { preset ->
+                // Compared with a tolerance, not ==: the value shown is the one the engine accepted,
+                // which can be a clamped float rather than the exact preset that was asked for.
+                val isCurrent = kotlin.math.abs(current - preset) < 0.01f
+                AarisChoiceChip(
+                    label = formatSpeed(preset),
+                    selected = isCurrent,
+                    onClick = { onSelect(preset) },
+                    modifier = Modifier.testTag(SpeedChipTestTag),
+                    enabled = enabled,
+                    // "1.5×" is an abbreviation; a screen reader should not have to guess the unit.
+                    contentDescription = "Speed ${formatSpeed(preset)}",
+                )
+            }
         }
         if (perFiction) {
             Text(
@@ -769,6 +774,9 @@ private fun TransportButton(
     onClick: () -> Unit,
 ) {
     val interaction = remember { MutableInteractionSource() }
+    // Bound before entering the semantics lambda: inside it the bare name resolves to the
+    // write-only semantics property rather than to this parameter.
+    val description = contentDescription
     val hovered by interaction.collectIsHoveredAsState()
     // Transport controls are the most likely thing to be driven from the keyboard, so focus has
     // to be as visible here as hover is with a mouse.
@@ -802,9 +810,21 @@ private fun TransportButton(
             )
             .hoverable(interaction)
             .let { if (enabled) it.pointerHoverIcon(PointerIcon.Hand) else it }
-            .clickable(interactionSource = interaction, indication = null, enabled = enabled, onClick = onClick),
+            .clickable(
+                interactionSource = interaction,
+                indication = null,
+                enabled = enabled,
+                role = Role.Button,
+                onClick = onClick,
+            )
+            // On the clickable node rather than on the child Icon: that is the node a screen reader
+            // lands on and the node that carries the role, and a description on the child leaves
+            // the actionable node announcing nothing. Same rule as RowIconAction.
+            .let { base ->
+                if (description == null) base else base.semantics { this.contentDescription = description }
+            },
         contentAlignment = Alignment.Center,
     ) {
-        Icon(icon, contentDescription, tint = tint, modifier = Modifier.size(size / 2))
+        Icon(icon, contentDescription = null, tint = tint, modifier = Modifier.size(size / 2))
     }
 }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ReaderScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -898,13 +899,15 @@ private fun ReaderSettingsDialog(
                     onIncrease = { onChange { it.copy(lineHeight = it.lineHeight + 0.1) } },
                 )
                 MetaText("// Theme", color = AarisColor.Accent)
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                // `selectableGroup` on the row, not on each option: it is what makes three themes
+                // announce as one choice with three answers rather than as three loose buttons.
+                Row(Modifier.selectableGroup(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     ReaderTheme.entries.forEach { theme ->
                         ReaderChoice(theme.label, theme == prefs.theme) { onChange { it.copy(theme = theme) } }
                     }
                 }
                 MetaText("// Highlight", color = AarisColor.Accent)
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Row(Modifier.selectableGroup(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     ReaderHighlight.entries.forEach { mode ->
                         ReaderChoice(mode.label, mode == prefs.highlight) { onChange { it.copy(highlight = mode) } }
                     }
@@ -935,16 +938,14 @@ private fun ReaderNumberControl(
     }
 }
 
+/**
+ * One reader theme or highlight option.
+ *
+ * Was a plain `Text.clickable` conveying its state through colour alone: announced as generic
+ * clickable text, with no role, no selected state and no focus ring. It is now the same primitive
+ * Settings and the player's speed presets use — the caller wraps the group in `selectableGroup`.
+ */
 @Composable
 private fun ReaderChoice(label: String, selected: Boolean, onClick: () -> Unit) {
-    Text(
-        label.uppercase(),
-        color = if (selected) AarisColor.Accent else AarisColor.Muted,
-        modifier = Modifier
-            .border(1.dp, if (selected) AarisColor.Accent else AarisColor.Line)
-            .clickable(onClick = onClick)
-            .pointerHoverIcon(PointerIcon.Hand)
-            .padding(horizontal = 9.dp, vertical = 7.dp),
-        style = MaterialTheme.typography.labelLarge,
-    )
+    AarisChoiceChip(label = label.uppercase(), selected = selected, onClick = onClick)
 }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
@@ -816,9 +816,9 @@ private fun formatSpeed(speed: Float): String {
 /**
  * A labelled row of mutually exclusive choices.
  *
- * `selectableGroup` plus `Role.RadioButton` on each entry is what makes this announce as one
- * choice with N options rather than as N unrelated buttons, and it is why these are not plain
- * clickable boxes.
+ * Now a thin alias over [AarisChoiceRow]. The pattern started here and was reimplemented — badly —
+ * on the player and in the reader, where the options ended up as plain clickable text with no role
+ * and no selected state; it lives in `Components.kt` so there is one of it. See #82.
  */
 @Composable
 private fun <T> ChoiceRow(
@@ -827,59 +827,7 @@ private fun <T> ChoiceRow(
     selected: T,
     labelOf: (T) -> String,
     onSelect: (T) -> Unit,
-) {
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        MetaText(label)
-        Row(
-            // Nine speeds do not fit a narrow settings pane; scrolling beats wrapping into a grid
-            // whose rows change height as the option list changes.
-            Modifier.horizontalScroll(rememberScrollState()).selectableGroup(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            options.forEach { option ->
-                ChoiceChip(
-                    label = labelOf(option),
-                    selected = option == selected,
-                    onClick = { onSelect(option) },
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun ChoiceChip(label: String, selected: Boolean, onClick: () -> Unit) {
-    val interaction = remember { MutableInteractionSource() }
-    val hovered by interaction.collectIsHoveredAsState()
-    val focused by interaction.collectIsFocusedAsState()
-    Box(
-        Modifier
-            .hoverable(interaction)
-            .pointerHoverIcon(PointerIcon.Hand)
-            .background(if (selected) AarisColor.BgHover else Color.Transparent)
-            // The AARIS look has no ripple, so focus has to be drawn explicitly or a keyboard-only
-            // user cannot see where they are.
-            .border(
-                1.dp,
-                when {
-                    focused -> AarisColor.Accent
-                    selected -> AarisColor.Ink
-                    hovered -> AarisColor.Muted
-                    else -> AarisColor.Line
-                },
-            )
-            .selectable(
-                selected = selected,
-                interactionSource = interaction,
-                indication = null,
-                role = Role.RadioButton,
-                onClick = onClick,
-            )
-            .padding(horizontal = 12.dp, vertical = 8.dp),
-    ) {
-        MetaText(label, color = if (selected || hovered || focused) AarisColor.Ink else AarisColor.Muted)
-    }
-}
+) = AarisChoiceRow(label, options, selected, labelOf, onSelect)
 
 /**
  * Hours, chapters and a streak, computed locally from `listening.json`.

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreenUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreenUiTest.kt
@@ -3,6 +3,8 @@ package dk.perspektiva.ttsroad.desktop.ui
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
@@ -167,7 +169,7 @@ class PlayerScreenUiTest {
     }
 
     @Test
-    fun `the now-playing bar honours the configured skip interval`() {
+fun `the now-playing bar honours the configured skip interval`() {
         // Regression: the bar hard-coded 30 seconds while the full player and reading mode read the
         // preference, so the same-looking control jumped twice as far depending on which surface
         // happened to be on screen.
@@ -180,6 +182,29 @@ class PlayerScreenUiTest {
 
         compose.onNodeWithContentDescription("Back 30 seconds").assertDoesNotExist()
         assertEquals(1, playback.calls.size, "calls were ${playback.calls}")
+    }
+
+    @Test
+    fun `speed presets announce as a radio group with a selected option`() {
+        // Regression: the presets were plain `Text.clickable`, so a screen reader read them as
+        // unrelated pieces of text with nothing to say which was in force, and the only visual cue
+        // for the current one was the accent colour.
+        val playback = FakePlaybackController(playingState().copy(speed = 1.5f, canChangeSpeed = true))
+        compose.setContent { TtsRoadTheme { PlayerScreen(playback, onBack = {}) } }
+
+        compose.onNodeWithContentDescription("Speed 1.5x").assertIsSelected()
+        compose.onNodeWithContentDescription("Speed 1x").assertIsNotSelected()
+    }
+
+    @Test
+    fun `transport labels are on the node that is actually clickable`() {
+        // The description used to sit on the child Icon while the outer Box carried the click, so
+        // the node a screen reader lands on announced nothing and declared no role.
+        val playback = FakePlaybackController(playingState())
+        compose.setContent { TtsRoadTheme { PlayerScreen(playback, onBack = {}) } }
+
+        compose.onNodeWithContentDescription("Pause").assertHasClickAction()
+        compose.onNodeWithContentDescription("Next chapter").assertHasClickAction()
     }
 
     @Test


### PR DESCRIPTION
Closes #82.

Settings already had this right — `selectableGroup`, `Role.RadioButton`, selected state, and a focus
border drawn explicitly because the AARIS look has no ripple to borrow one from. `SpeedControl` and
`ReaderChoice` were plain `Text.clickable`: announced as unrelated pieces of text, current choice
carried by colour alone, no visible keyboard focus.

## What changed

- **`AarisChoiceChip` / `AarisChoiceRow`** in `Components.kt` — the pattern *moved* out of Settings
  rather than being copied a fourth time. Settings keeps `ChoiceRow` as a thin alias over it, which
  is what makes that a move.
- **Selection is no longer colour-only.** Background and border both move with `selected`, so it
  does not depend on separating accent from muted.
- **`SpeedControl`** wraps its presets in one `selectableGroup` and gives each an explicit
  `contentDescription` ("Speed 1.5x"), because "1.5x" alone is an abbreviation a screen reader
  should not have to guess the unit for.
- **`ReaderChoice`** becomes a call to the shared chip; both reader groups get `selectableGroup`.
- **`TransportButton`** put its description on the child `Icon` while the outer `Box` carried the
  click, so the node a screen reader lands on announced nothing and declared no role. Both now sit
  on the clickable node — the rule `RowIconAction` already followed.

## Verification

`./gradlew clean check --warning-mode fail -Pttsroad.warningsAsErrors=true` — the CI gate — passes.
Two new `PlayerScreenUiTest` cases: the presets assert `assertIsSelected`/`assertIsNotSelected`
(impossible against the old plain-text controls), and the transport labels assert
`assertHasClickAction` on the described node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK3sri5jA6ne6tEJnbQaRe