### PR TITLE
Give the shelf an order, a tag filter and the server's own progress

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,39 @@ Chapter MP3s are bearer-protected and pushed *into* GStreamer (`appsrc`) rather 
 via `HttpMediaSource` on the shared client — that is how the auth interceptor and its origin rule
 apply to audio.
 
+### Browsing the shelf
+
+`data/FictionBrowse.kt` is the whole pipeline — scope, tags, text, order — as pure functions, and
+`browseFictions` applies them in that sequence so a screen cannot reorder the stages and change what
+"N of M" counts. **Nulls sort last in every order, without exception**: a missing `updated_at`, an
+absent rating and a row with no `progress` all mean *we were not told*, which is not "a long time
+ago" or "zero", and letting an absent answer read as the smallest one buries the book that just
+arrived. Ties break on title so the order is total; a lazy grid whose items swap places between two
+recompositions of the same data is a scroll position that will not stay still.
+
+Tag filtering is an **intersection** — two ticked tags mean both — matching `ttsroadApplyLibrary` in
+the web client, because a filter that widens the list as you add to it is one nobody uses twice. The
+vocabulary is the union of tags on the loaded shelf, not a fixed list; a ticked tag nothing carries
+any more is dropped rather than left emptying the grid with no box on screen to un-tick.
+
+`FictionSummary.progress` is the server's **per-caller** aggregate, decoded nested exactly as the
+backend nests it and for the backend's stated reason: the flat counters are properties of the
+fiction and the same for everybody, while every key inside `progress` is scoped to the account
+asking. Its labels are preferred over anything formatted locally so the desktop and the web shelf
+cannot disagree about the same book by rounding. It is null on `/chapters`, which builds its
+`fiction` without the key.
+
+`data/BrowsePreferences.kt` keeps order, tags and scope in `browse.json` — OS-profile-local like
+`playback.json`, fully nullable on disk, sort stored as a string so an order a newer build added
+degrades to the default rather than failing the parse. **The search text is deliberately not
+persisted**: a search is a question being asked now, and restoring last week's would open the shelf
+onto a near-empty grid with no visible cause.
+
+`SyncScope` exists because the server's default is the dangerous one: `add_fiction` branches on
+`if body.sync_limit:` and otherwise converts *every chapter*, so a client that omits the field
+queues a whole backlog. The dialog defaults to the web form's newest 25 and the whole-backlog option
+states its cost before it is picked.
+
 ### Listening preferences, the sleep timer and history
 
 - `data/PlaybackPreferences.kt` — speed, skip interval, skip silence, volume boost, in

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -76,7 +76,7 @@ whole response fail. Limits are server policy, not suggestions; honor them when 
 | Data | Location class | Lifetime |
 | --- | --- | --- |
 | bearer token | OS credential store only | removed on sign-out/revocation |
-| server/account hints, window/listening/reader settings, history | platform config | retained across sign-out; no secrets |
+| server/account hints, window/listening/reader/browse settings, history | platform config | retained across sign-out; no secrets |
 | requested chapter downloads | platform data, server/account identity namespace | user-managed, never automatically evicted |
 | streamed audio, library metadata, read-along text | platform cache, identity namespace | rebuildable and bounded |
 | logs | platform state | redacted, owner-only, 1 MiB + three backups |

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -480,6 +480,7 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                     repository = repository,
                                     playback = playback,
                                     history = container.playbackHistory,
+                                    browsePreferences = container.browsePreferences,
                                     historyOwnerKey = container.historyOwnerKey(),
                                     onOpenFiction = { nav.open(Destination.Fiction(it)) },
                                     onOpenPlayer = { nav.open(Destination.Player) },

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/BrowsePreferences.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/BrowsePreferences.kt
@@ -1,0 +1,149 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dk.perspektiva.ttsroad.desktop.security.SecureFiles
+import java.io.File
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * How the shelf is currently arranged: the order, the ticked tags, and which half is being browsed.
+ *
+ * All three were composition state, which covers navigating into a fiction and back and nothing
+ * else — so an order picked on Monday was gone by Tuesday. The web console has kept the same three
+ * in `localStorage` all along.
+ *
+ * **The search text is deliberately not here.** A search is a question being asked now; restoring
+ * last week's would open the shelf onto a near-empty grid with no visible cause. That asymmetry is
+ * the whole design of this type, not an omission.
+ *
+ * OS-profile-local like [PlaybackPreferences], and for the same reason: this is about how somebody
+ * likes to look at a shelf, not about which TTSRoad account they were signed into. Nothing here is
+ * secret, and there is nowhere in the type to put something that is.
+ */
+data class BrowsePreferences(
+    val sort: FictionSort = FictionSort.Default,
+    val tags: Set<String> = emptySet(),
+    /**
+     * Whether the shelf or the whole catalogue was last being browsed.
+     *
+     * Honoured only where the server advertises `follows`; without per-user libraries the two are
+     * the same list and the mode switch is not drawn at all.
+     */
+    val browsingAll: Boolean = false,
+) {
+    companion object {
+        /**
+         * A ceiling on remembered tags.
+         *
+         * Not a UI limit — tick as many as you like in a session. It bounds what a file written
+         * once and never cleaned can grow to, the same reason `fictionSpeeds` is bounded.
+         */
+        const val MaxRememberedTags: Int = 32
+    }
+}
+
+interface BrowsePreferencesStore {
+    val preferences: StateFlow<BrowsePreferences>
+
+    fun update(transform: (BrowsePreferences) -> BrowsePreferences)
+}
+
+/** In-memory store for tests and for the smoke test, which must not write to a real home. */
+class InMemoryBrowsePreferencesStore(
+    initial: BrowsePreferences = BrowsePreferences(),
+) : BrowsePreferencesStore {
+    private val _preferences = MutableStateFlow(initial.sanitised())
+    override val preferences: StateFlow<BrowsePreferences> = _preferences.asStateFlow()
+
+    @Synchronized
+    override fun update(transform: (BrowsePreferences) -> BrowsePreferences) {
+        _preferences.value = transform(_preferences.value).sanitised()
+    }
+}
+
+/**
+ * `browse.json`, beside `playback.json` and `reader.json`, written owner-only through [SecureFiles].
+ *
+ * Read eagerly for the same reason the playback settings are: the library composes on the first
+ * frame after sign-in, and a lazy read would draw the shelf once in the default order and then
+ * reshuffle it under the reader.
+ *
+ * Write failure is logged, never surfaced. Losing a remembered sort order is not worth a dialog.
+ */
+class FileBrowsePreferencesStore(
+    private val file: File = defaultFile(),
+) : BrowsePreferencesStore {
+    private val adapter = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+        .adapter(StoredBrowsePreferences::class.java)
+
+    private val _preferences = MutableStateFlow(read())
+    override val preferences: StateFlow<BrowsePreferences> = _preferences.asStateFlow()
+
+    @Synchronized
+    override fun update(transform: (BrowsePreferences) -> BrowsePreferences) {
+        val next = transform(_preferences.value).sanitised()
+        if (next == _preferences.value) return
+        _preferences.value = next
+        runCatching { SecureFiles.writeAtomically(file, adapter.toJson(StoredBrowsePreferences.from(next))) }
+            .onFailure { AppLog.warn("could not write the browse settings file", it) }
+    }
+
+    private fun read(): BrowsePreferences =
+        runCatching { if (file.isFile) adapter.fromJson(file.readText()) else null }
+            .onFailure { AppLog.warn("could not read the browse settings file", it) }
+            .getOrNull()
+            ?.toPreferences()
+            ?: BrowsePreferences()
+
+    companion object {
+        fun defaultFile(): File = FileSessionStore.configDir().resolve("browse.json")
+    }
+}
+
+/**
+ * The on-disk shape: separate from [BrowsePreferences] and **fully nullable**.
+ *
+ * Same rule as `StoredPlaybackPreferences`. A file written by another build — older, newer, or
+ * half-truncated by a crash — must degrade to defaults field by field rather than failing to parse
+ * and taking the whole shelf's arrangement with it. The sort is a string because an enum that has
+ * gained a case since the file was written is a `null`, not an exception.
+ */
+internal data class StoredBrowsePreferences(
+    val sort: String? = null,
+    val tags: List<String>? = null,
+    val browsingAll: Boolean? = null,
+) {
+    fun toPreferences(): BrowsePreferences = BrowsePreferences(
+        sort = FictionSort.fromStorage(sort),
+        tags = tags?.toSet().orEmpty(),
+        browsingAll = browsingAll ?: false,
+    ).sanitised()
+
+    companion object {
+        fun from(preferences: BrowsePreferences) = StoredBrowsePreferences(
+            sort = preferences.sort.name,
+            // Sorted so the file does not churn on every write purely because a set reordered.
+            tags = preferences.tags.sorted(),
+            browsingAll = preferences.browsingAll,
+        )
+    }
+}
+
+/**
+ * Brings a value back into range on the way *in*, so a bad one never sits in memory either.
+ *
+ * Blank tags are dropped rather than kept as an un-tickable box, and the set is trimmed to
+ * [BrowsePreferences.MaxRememberedTags] to bound a file that is written for the life of the
+ * install.
+ */
+internal fun BrowsePreferences.sanitised(): BrowsePreferences = copy(
+    tags = tags.mapNotNull { it.trim().takeIf(String::isNotEmpty) }
+        .distinctBy(String::lowercase)
+        .take(BrowsePreferences.MaxRememberedTags)
+        .toSet(),
+)

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/FictionBrowse.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/FictionBrowse.kt
@@ -1,0 +1,220 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+/**
+ * How the shelf can be ordered.
+ *
+ * The web console has had most of these since before this client existed; the desktop offered a
+ * text filter and the server's own order, which meant finding the book that gained a chapter
+ * yesterday required remembering its name.
+ *
+ * Every order here is a *view* over a list that was already fetched. None of them changes what is
+ * requested — the library endpoint has no ordering parameter, and inventing one client-side that
+ * only worked on the loaded page would be worse than no ordering at all.
+ */
+enum class FictionSort(
+    val label: String,
+    /**
+     * The line under the option, where the label alone would mislead. Null where it would not.
+     *
+     * [RecentlyUpdated] is the reason this exists: it follows the fiction row, and the poller
+     * touches that row whether or not a check found anything, so it means *recently active* rather
+     * than *new chapters*. Saying so under the option is cheaper than the support question.
+     */
+    val detail: String? = null,
+) {
+    RecentlyUpdated("Recently updated", "Server activity, which is not the same as new chapters"),
+    RecentlyAdded("Recently added"),
+    Title("Title"),
+    Author("Author"),
+    Rating("Rating"),
+    MostLeft("Most left to hear", "Listening time remaining for you"),
+    LeastFinished("Least finished", "Smallest share of the book heard"),
+    MostChapters("Most chapters"),
+    PercentConverted("% converted", "How far the server is through making the audio"),
+    ;
+
+    companion object {
+        val Default: FictionSort = RecentlyUpdated
+
+        /** Parsed leniently, because this arrives from a file an older or newer build wrote. */
+        fun fromStorage(value: String?): FictionSort =
+            entries.firstOrNull { it.name == value } ?: Default
+    }
+}
+
+/**
+ * Applies an order to a shelf.
+ *
+ * **Nulls sort last in every order, without exception.** A server that never sent a date, a fiction
+ * with no rating, a row with no progress aggregate — each is saying *we were not told*, which is
+ * not "a long time ago" or "zero". Letting an absent answer read as the smallest one buries the
+ * book that actually just arrived underneath every book nobody has rated.
+ *
+ * Ties break on title so the order is total: a lazy grid whose items change places between two
+ * recompositions of the same data is a scroll position that will not stay still.
+ */
+fun sortFictions(fictions: List<FictionSummary>, sort: FictionSort): List<FictionSummary> {
+    val byTitle = compareBy<FictionSummary> { it.title.lowercase() }
+    return when (sort) {
+        FictionSort.RecentlyUpdated -> fictions.sortedWith(descendingNullsLast(byTitle) { it.updatedAt })
+        FictionSort.RecentlyAdded -> fictions.sortedWith(descendingNullsLast(byTitle) { it.createdAt })
+        FictionSort.Title -> fictions.sortedWith(byTitle)
+        FictionSort.Author -> fictions.sortedWith(
+            ascendingNullsLast(byTitle) { it.author?.trim()?.lowercase()?.takeIf(String::isNotEmpty) },
+        )
+        FictionSort.Rating -> fictions.sortedWith(descendingNullsLast(byTitle) { it.rating })
+        FictionSort.MostLeft -> fictions.sortedWith(
+            descendingNullsLast(byTitle) { it.progress?.takeIf(FictionProgress::isMeaningful)?.remainingSeconds },
+        )
+        FictionSort.LeastFinished -> fictions.sortedWith(
+            ascendingNullsLast(byTitle) { it.progress?.listenedFraction },
+        )
+        FictionSort.MostChapters -> fictions.sortedWith(
+            descendingNullsLast(byTitle) { it.totalChapters.takeIf { count -> count > 0 } },
+        )
+        FictionSort.PercentConverted -> fictions.sortedWith(
+            descendingNullsLast(byTitle) { it.takeIf { f -> f.totalChapters > 0 }?.readyFraction },
+        )
+    }
+}
+
+private fun <T : Comparable<T>> descendingNullsLast(
+    tieBreak: Comparator<FictionSummary>,
+    key: (FictionSummary) -> T?,
+): Comparator<FictionSummary> =
+    compareBy<FictionSummary> { key(it) == null }.thenByDescending(NullsFirstNaturalOrder(), key).then(tieBreak)
+
+private fun <T : Comparable<T>> ascendingNullsLast(
+    tieBreak: Comparator<FictionSummary>,
+    key: (FictionSummary) -> T?,
+): Comparator<FictionSummary> =
+    compareBy<FictionSummary> { key(it) == null }.thenBy(NullsFirstNaturalOrder(), key).then(tieBreak)
+
+/**
+ * Natural order that tolerates the nulls the "is it null" key has already sorted to the back.
+ *
+ * The leading `compareBy { key(it) == null }` guarantees a null is never compared against a
+ * non-null, so the value this returns for a null pair never affects the result — it only has to
+ * exist so `thenBy` can take a comparator rather than requiring a non-null key.
+ */
+private class NullsFirstNaturalOrder<T : Comparable<T>> : Comparator<T?> {
+    override fun compare(a: T?, b: T?): Int = when {
+        a == null && b == null -> 0
+        a == null -> -1
+        b == null -> 1
+        else -> a.compareTo(b)
+    }
+}
+
+/**
+ * Every tag carried by the loaded shelf, in one alphabetical list.
+ *
+ * Drawn from the fictions rather than from a fixed vocabulary, because the server's tags are
+ * whatever the source happened to publish and there is no endpoint that enumerates them. Compared
+ * case-insensitively, keeping the first spelling seen, for the same reason [cleanFictionTags] does.
+ */
+fun availableTags(fictions: List<FictionSummary>): List<String> {
+    val seen = LinkedHashMap<String, String>()
+    for (fiction in fictions) {
+        for (tag in fiction.tags) {
+            val key = tag.trim().lowercase()
+            if (key.isNotEmpty()) seen.putIfAbsent(key, tag.trim())
+        }
+    }
+    return seen.values.sortedBy(String::lowercase)
+}
+
+/**
+ * Narrows a shelf to the fictions carrying **all** of [tags].
+ *
+ * Intersection rather than union, matching `ttsroadApplyLibrary` in the web client: a filter that
+ * widens the list as you add to it is one nobody uses twice.
+ */
+fun filterByTags(fictions: List<FictionSummary>, tags: Set<String>): List<FictionSummary> {
+    if (tags.isEmpty()) return fictions
+    val wanted = tags.map(String::lowercase).toSet()
+    return fictions.filter { fiction ->
+        val carried = fiction.tags.map { it.trim().lowercase() }.toSet()
+        carried.containsAll(wanted)
+    }
+}
+
+/**
+ * Tags in [selected] that nothing on the shelf carries any more.
+ *
+ * Worth naming rather than silently intersecting: a stored tag whose fiction was deleted would
+ * otherwise empty the grid with no box left on screen to un-tick.
+ */
+fun staleTags(fictions: List<FictionSummary>, selected: Set<String>): Set<String> {
+    if (selected.isEmpty()) return emptySet()
+    val available = availableTags(fictions).map(String::lowercase).toSet()
+    return selected.filterNot { it.lowercase() in available }.toSet()
+}
+
+/**
+ * The whole browse pipeline, in the order the user thinks about it: scope, then tags, then text,
+ * then order.
+ *
+ * One function so the screen cannot apply them in a different order than the tests do — sorting
+ * before filtering gives the same set, but naming an intermediate count ("14 of 200") requires
+ * knowing which stage produced which number.
+ */
+data class BrowseResult(
+    val fictions: List<FictionSummary>,
+    /** How many survived the tag filter, before the text query. What "N of M" is counted against. */
+    val taggedCount: Int,
+    val totalCount: Int,
+) {
+    val isEmpty: Boolean get() = fictions.isEmpty()
+}
+
+fun browseFictions(
+    fictions: List<FictionSummary>,
+    query: String,
+    tags: Set<String>,
+    sort: FictionSort,
+): BrowseResult {
+    val tagged = filterByTags(fictions, tags)
+    val searched = filterFictionsByText(tagged, query)
+    return BrowseResult(
+        fictions = sortFictions(searched, sort),
+        taggedCount = tagged.size,
+        totalCount = fictions.size,
+    )
+}
+
+/** Case-insensitive across title, author and tags — the same three fields as the mobile client. */
+fun filterFictionsByText(fictions: List<FictionSummary>, query: String): List<FictionSummary> {
+    val q = query.trim().lowercase()
+    if (q.isBlank()) return fictions
+    return fictions.filter { fiction ->
+        fiction.title.lowercase().contains(q) ||
+            fiction.author?.lowercase()?.contains(q) == true ||
+            fiction.tags.any { it.lowercase().contains(q) }
+    }
+}
+
+/**
+ * Why the grid is empty, so the screen can say the thing the reader can act on.
+ *
+ * "No fictions found" is a lie with a tag ticked or on an empty shelf: it reads as the server
+ * having lost the library rather than as something one click undoes.
+ */
+enum class EmptyBrowseReason { NothingOnServer, NothingFollowed, TagFilter, TextQuery }
+
+fun emptyBrowseReason(
+    result: BrowseResult,
+    query: String,
+    tags: Set<String>,
+    browsingAll: Boolean,
+): EmptyBrowseReason? = when {
+    !result.isEmpty -> null
+    result.totalCount == 0 && browsingAll -> EmptyBrowseReason.NothingOnServer
+    result.totalCount == 0 -> EmptyBrowseReason.NothingFollowed
+    // Order matters: with both a tag and a query in force, the tag is the one hiding the most, and
+    // it is also the one a reader is most likely to have forgotten is on.
+    tags.isNotEmpty() && result.taggedCount == 0 -> EmptyBrowseReason.TagFilter
+    query.isNotBlank() -> EmptyBrowseReason.TextQuery
+    tags.isNotEmpty() -> EmptyBrowseReason.TagFilter
+    else -> EmptyBrowseReason.NothingOnServer
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
@@ -139,15 +139,111 @@ data class FictionSummary(
      * chapters arrived. Null means *ask someone else*, and false would have meant "not followed".
      */
     val following: Boolean? = null,
+    /**
+     * When the fiction row was created and last touched, as the server serialised them.
+     *
+     * ISO-8601 strings rather than parsed instants: they are only ever compared with each other and
+     * sorted, which the lexicographic order of a UTC ISO stamp already gives, and parsing would
+     * turn a server sending a shape this build has not seen into a failed library load.
+     *
+     * Null on a server that does not send them. Null is **not** "a long time ago" — it means *we
+     * were not told* — so every order built on these sorts nulls last. See [FictionSort].
+     */
+    @param:Json(name = "created_at") val createdAt: String? = null,
+    @param:Json(name = "updated_at") val updatedAt: String? = null,
+    /**
+     * This caller's progress through the fiction, computed by the server in one grouped query.
+     *
+     * Nested rather than flattened alongside [totalChapters] and [doneChapters], exactly as the
+     * backend nests it, and for the backend's own stated reason: those are properties of the
+     * fiction and the same for everybody, while every field in here is scoped to the account
+     * asking. A shared-looking object holding per-user numbers is how a cache serves one listener
+     * another's progress.
+     *
+     * Null on `/api/mobile/fictions/{id}/chapters`, which builds its `fiction` with
+     * `_fiction_payload()` and does not add the key, and on any server predating the aggregate.
+     */
+    val progress: FictionProgress? = null,
 ) {
     val readyFraction: Float
         get() = if (totalChapters > 0) (doneChapters.toFloat() / totalChapters).coerceIn(0f, 1f) else 0f
 }
 
-/** Admin-only `POST /api/mobile/fictions`. A bare Royal Road id is accepted by the server. */
+/**
+ * What one account has left of one fiction, as the server counts it.
+ *
+ * The labels are the server's own rendering and are preferred over anything computed here, so the
+ * desktop and the web shelf cannot disagree about the same book by rounding differently.
+ */
+data class FictionProgress(
+    @param:Json(name = "chapters_total") val chaptersTotal: Int = 0,
+    /** Chapters with audio — the ones that can actually be listened to. */
+    @param:Json(name = "chapters_ready") val chaptersReady: Int = 0,
+    @param:Json(name = "chapters_played") val chaptersPlayed: Int = 0,
+    @param:Json(name = "chapters_unplayed") val chaptersUnplayed: Int = 0,
+    @param:Json(name = "duration_seconds") val durationSeconds: Double = 0.0,
+    @param:Json(name = "duration_label") val durationLabel: String? = null,
+    @param:Json(name = "remaining_seconds") val remainingSeconds: Double = 0.0,
+    @param:Json(name = "remaining_label") val remainingLabel: String? = null,
+) {
+    /**
+     * How much of what can be heard has been heard, or null when nothing can be yet.
+     *
+     * Null rather than zero for an unconverted book: "0% listened" and "there is nothing to listen
+     * to" are different sentences, and only one of them is about the reader.
+     */
+    val listenedFraction: Float?
+        get() = if (chaptersReady > 0) {
+            (chaptersPlayed.toFloat() / chaptersReady).coerceIn(0f, 1f)
+        } else {
+            null
+        }
+
+    /** True where the server actually had something to say, as opposed to filling in the shape. */
+    val isMeaningful: Boolean get() = chaptersTotal > 0 || chaptersReady > 0
+}
+
+/**
+ * How much of a serial's backlog to convert when it is first tracked.
+ *
+ * The whole point of naming this is that **the server's default is everything**: `add_fiction`
+ * branches on `if body.sync_limit:` and otherwise calls `poll_and_process_fiction(id, True)`. A
+ * client that omits the field is not accepting a sensible default, it is queueing four hundred
+ * chapters of TTS. The web form has posted 25 since it existed.
+ */
+enum class SyncScope(val label: String, val detail: String) {
+    NewestTwentyFive("Newest 25", "What the web console does. Older chapters can be filled in later."),
+    OldestTwentyFive("Oldest 25", "Start at the beginning of the serial."),
+    Everything("Everything", "Converts the entire backlog now. On a long serial this is hours of audio."),
+    ;
+
+    /** Null for [Everything], which is the server's own "no limit" sentinel. */
+    val limit: Int? get() = if (this == Everything) null else DefaultBatch
+
+    /** The server's vocabulary: `last` counts back from the newest chapter, `first` forward. */
+    val direction: String get() = if (this == OldestTwentyFive) "first" else "last"
+
+    companion object {
+        /** Matches the web form, which is the behaviour everyone adding a fiction already expects. */
+        val Default: SyncScope = NewestTwentyFive
+        private const val DefaultBatch: Int = 25
+    }
+}
+
+/**
+ * Admin-only `POST /api/mobile/fictions`. A bare Royal Road id is accepted by the server.
+ *
+ * [syncLimit] is deliberately **not** nullable-by-omission in the caller's mind: see [SyncScope].
+ * `enabled` is the auto-poll switch and defaults to the server's own `True`.
+ */
 data class FictionCreateRequest(
     @param:Json(name = "fiction_url") val fictionUrl: String,
     val voice: String? = null,
+    /** Speech rate, in the same vocabulary `FictionUpdate.rate` uses. Null leaves the default. */
+    val rate: String? = null,
+    val enabled: Boolean = true,
+    @param:Json(name = "sync_limit") val syncLimit: Int? = null,
+    @param:Json(name = "sync_direction") val syncDirection: String = "last",
 )
 
 /**

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/di/AppContainer.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/di/AppContainer.kt
@@ -2,6 +2,8 @@ package dk.perspektiva.ttsroad.desktop.di
 
 import dk.perspektiva.ttsroad.desktop.data.AppDirectories
 import dk.perspektiva.ttsroad.desktop.data.FilePlaybackHistoryStore
+import dk.perspektiva.ttsroad.desktop.data.BrowsePreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.FileBrowsePreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.FilePlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.FileSessionStore
 import dk.perspektiva.ttsroad.desktop.data.FileWindowPreferencesStore
@@ -102,6 +104,13 @@ class AppContainer(
      * test never writes into the user's config directory.
      */
     val playbackPreferences: PlaybackPreferencesStore = FilePlaybackPreferencesStore(),
+    /**
+     * How the shelf is arranged — order, ticked tags, browsed scope — kept across restarts.
+     *
+     * Machine-local like [playbackPreferences] and for the same reason: it is about how somebody
+     * likes to look at a shelf, not about which account they signed into.
+     */
+    val browsePreferences: BrowsePreferencesStore = FileBrowsePreferencesStore(),
     // Null selects the production local-plus-server store. Supplying a store keeps UI tests wholly
     // in memory and avoids making a fake repository call just because the library was composed.
     playbackHistory: PlaybackHistoryStore? = null,

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementDialogs.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementDialogs.kt
@@ -4,6 +4,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
@@ -17,7 +21,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.data.SyncScope
 
 const val AddFictionDialogTestTag: String = "addFictionDialog"
 const val ChooseEpubButtonTestTag: String = "chooseEpubButton"
@@ -65,7 +71,7 @@ private fun AddFictionDialog(
     isBusy: Boolean,
     error: String?,
     epubUploadAvailable: Boolean,
-    onUpdateAdd: (String?, String?) -> Unit,
+    onUpdateAdd: (String?, String?, String?, Boolean?, SyncScope?) -> Unit,
     onChooseEpub: () -> Unit,
     onClearEpub: () -> Unit,
     onSubmit: () -> Unit,
@@ -87,7 +93,7 @@ private fun AddFictionDialog(
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 OutlinedTextField(
                     value = editor.fictionUrl,
-                    onValueChange = { onUpdateAdd(it, null) },
+                    onValueChange = { onUpdateAdd(it, null, null, null, null) },
                     label = { Text("ROYAL ROAD URL OR FICTION ID") },
                     supportingText = if (epub != null) {
                         { Text("Not used while an EPUB is chosen") }
@@ -125,13 +131,36 @@ private fun AddFictionDialog(
                 }
                 OutlinedTextField(
                     value = editor.voice,
-                    onValueChange = { onUpdateAdd(null, it) },
+                    onValueChange = { onUpdateAdd(null, it, null, null, null) },
                     label = { Text("VOICE (OPTIONAL)") },
                     supportingText = { Text("Blank uses the server default") },
                     enabled = !isBusy,
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
+                OutlinedTextField(
+                    value = editor.rate,
+                    onValueChange = { onUpdateAdd(null, null, it, null, null) },
+                    label = { Text("SPEECH RATE (OPTIONAL)") },
+                    supportingText = { Text("Blank uses the server default. Nothing already converted is re-narrated.") },
+                    enabled = !isBusy,
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                // Only meaningful on the Royal Road path: an EPUB has no source to poll and no
+                // backlog to bound, so offering either control there would be inventing a choice.
+                if (epub == null) {
+                    SyncScopeChoice(
+                        selected = editor.syncScope,
+                        enabled = !isBusy,
+                        onSelect = { onUpdateAdd(null, null, null, null, it) },
+                    )
+                    AutoPollChoice(
+                        enabled = !isBusy,
+                        checked = editor.autoPoll,
+                        onChange = { onUpdateAdd(null, null, null, it, null) },
+                    )
+                }
                 error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
             }
         },
@@ -157,4 +186,76 @@ private fun AddFictionDialog(
             }
         },
     )
+}
+
+const val SyncScopeTestTag: String = "addFictionSyncScope"
+const val AutoPollTestTag: String = "addFictionAutoPoll"
+
+/**
+ * How much of the backlog to convert.
+ *
+ * Drawn as a choice rather than left to a default because the default the *server* applies when
+ * this is absent is "everything", and the cost of that is hours of TTS on a long serial. The
+ * whole-backlog option says what it costs before it is picked, not after.
+ */
+@Composable
+private fun SyncScopeChoice(selected: SyncScope, enabled: Boolean, onSelect: (SyncScope) -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp), modifier = Modifier.testTag(SyncScopeTestTag)) {
+        MetaText("// Chapters to convert now")
+        Column(Modifier.selectableGroup(), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            SyncScope.entries.forEach { scope ->
+                Column(
+                    Modifier
+                        .fillMaxWidth()
+                        .selectable(
+                            selected = scope == selected,
+                            enabled = enabled,
+                            role = Role.RadioButton,
+                            onClick = { onSelect(scope) },
+                        )
+                        .padding(vertical = 6.dp),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    Text(
+                        if (scope == selected) "· ${scope.label}" else scope.label,
+                        color = when {
+                            !enabled -> AarisColor.Dim
+                            scope == selected -> AarisColor.Accent
+                            else -> AarisColor.Muted
+                        },
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    MetaText(scope.detail, color = AarisColor.Dim)
+                }
+            }
+        }
+    }
+}
+
+/** The server's `enabled` flag, named for what it does rather than for what the field is called. */
+@Composable
+private fun AutoPollChoice(enabled: Boolean, checked: Boolean, onChange: (Boolean) -> Unit) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .toggleable(value = checked, enabled = enabled, role = Role.Checkbox) { onChange(it) }
+            .testTag(AutoPollTestTag)
+            .padding(vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text(
+            if (checked) "[x]" else "[ ]",
+            color = if (checked) AarisColor.Accent else AarisColor.Muted,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                "Keep checking for new chapters",
+                color = if (enabled) AarisColor.Ink else AarisColor.Dim,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            MetaText("Turn off for a finished work.", color = AarisColor.Dim)
+        }
+    }
 }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolder.kt
@@ -5,6 +5,7 @@ import dk.perspektiva.ttsroad.desktop.data.FictionSummary
 import dk.perspektiva.ttsroad.desktop.data.LibraryCache
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
+import dk.perspektiva.ttsroad.desktop.data.SyncScope
 import java.io.File
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -34,6 +35,22 @@ enum class FictionManagementAccess {
 data class FictionAddDraft(
     val fictionUrl: String = "",
     val voice: String = "",
+    /** Speech rate. Blank leaves the server's default rather than sending a guess. */
+    val rate: String = "",
+    /**
+     * Whether the server keeps polling the source for new chapters. The endpoint's own default.
+     *
+     * Offered here because it is a property of *tracking* a serial, and a finished work is exactly
+     * the case where somebody wants the backlog once and no poller afterwards.
+     */
+    val autoPoll: Boolean = true,
+    /**
+     * How much of the backlog to convert.
+     *
+     * Defaults to what the web form does. The desktop previously sent nothing, which the backend
+     * reads as *every chapter* — see [SyncScope].
+     */
+    val syncScope: SyncScope = SyncScope.Default,
     /**
      * A chosen EPUB, which makes this an *upload* rather than a Royal Road add.
      *
@@ -144,13 +161,22 @@ class FictionManagementStateHolder(
         _state.update { it.copy(editor = FictionAddDraft(), error = null, notice = null) }
     }
 
-    fun updateAdd(fictionUrl: String? = null, voice: String? = null) {
+    fun updateAdd(
+        fictionUrl: String? = null,
+        voice: String? = null,
+        rate: String? = null,
+        autoPoll: Boolean? = null,
+        syncScope: SyncScope? = null,
+    ) {
         _state.update { current ->
             val editor = current.editor ?: return@update current
             current.copy(
                 editor = editor.copy(
                     fictionUrl = fictionUrl ?: editor.fictionUrl,
                     voice = voice ?: editor.voice,
+                    rate = rate ?: editor.rate,
+                    autoPoll = autoPoll ?: editor.autoPoll,
+                    syncScope = syncScope ?: editor.syncScope,
                 ),
             )
         }
@@ -209,6 +235,12 @@ class FictionManagementStateHolder(
                     FictionCreateRequest(
                         fictionUrl = editor.fictionUrl.trim(),
                         voice = editor.voice.trim().takeIf(String::isNotEmpty),
+                        rate = editor.rate.trim().takeIf(String::isNotEmpty),
+                        enabled = editor.autoPoll,
+                        // Always sent, including the null that means "everything": the field is
+                        // chosen in the form, so its absence would be this client guessing again.
+                        syncLimit = editor.syncScope.limit,
+                        syncDirection = editor.syncScope.direction,
                     ),
                 )
             }
@@ -221,7 +253,7 @@ class FictionManagementStateHolder(
                             editor = null,
                             isBusy = false,
                             error = null,
-                            notice = "Added ${fiction.title}; chapter discovery is running on the server",
+                            notice = addedNotice(fiction.title, editor.syncScope),
                         )
                     }
                 }
@@ -306,6 +338,16 @@ class FictionManagementStateHolder(
          * dialog. The extension check is not belt-and-braces: AWT's filename filter is a *hint*
          * that several Linux window managers ignore outright.
          */
+        /** Says what was actually queued, because the three scopes cost wildly different amounts. */
+        internal fun addedNotice(title: String, scope: SyncScope): String = when (scope) {
+            SyncScope.Everything ->
+                "Added $title; the whole backlog is converting on the server"
+            SyncScope.OldestTwentyFive ->
+                "Added $title; the oldest 25 chapters are converting on the server"
+            SyncScope.NewestTwentyFive ->
+                "Added $title; the newest 25 chapters are converting on the server"
+        }
+
         internal fun epubProblem(file: File, maxBytes: Long?): String? = when {
             !file.isFile -> "That file could not be read"
             !file.name.endsWith(".epub", ignoreCase = true) -> "Only .epub files can be uploaded"

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/LibraryScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/LibraryScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -24,6 +25,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
@@ -40,11 +43,13 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Button
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -72,6 +77,15 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.staleTags
+import dk.perspektiva.ttsroad.desktop.data.emptyBrowseReason
+import dk.perspektiva.ttsroad.desktop.data.browseFictions
+import dk.perspektiva.ttsroad.desktop.data.availableTags
+import dk.perspektiva.ttsroad.desktop.data.InMemoryBrowsePreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.EmptyBrowseReason
+import dk.perspektiva.ttsroad.desktop.data.FictionSort
+import dk.perspektiva.ttsroad.desktop.data.FictionProgress
+import dk.perspektiva.ttsroad.desktop.data.BrowsePreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackHistoryStore
 import dk.perspektiva.ttsroad.desktop.data.LibraryCache
 import dk.perspektiva.ttsroad.desktop.data.PlaybackHistory
@@ -134,6 +148,13 @@ fun LibraryScreen(
      */
     history: PlaybackHistoryStore = remember { InMemoryPlaybackHistoryStore() },
     /**
+     * Order, ticked tags and browsed scope, kept across restarts.
+     *
+     * Defaulted to an in-memory store so a screen test never reads or writes the real config
+     * directory, exactly like [history].
+     */
+    browsePreferences: BrowsePreferencesStore = remember { InMemoryBrowsePreferencesStore() },
+    /**
      * Which account's snapshots may be shown. Blank means "nobody's", which is what a signed-out
      * screen and a history file from an older build both get — see [PlaybackHistory.jumpBackChoices].
      */
@@ -143,10 +164,10 @@ fun LibraryScreen(
     val scope = rememberCoroutineScope()
     // Retained per destination, so walking into a fiction from browse-all and back lands where the
     // user left rather than snapping to the shelf.
-    var browsing by rememberSaveable { mutableStateOf(false) }
+    val browse by browsePreferences.preferences.collectAsState()
     // Browse-all is unreachable on a server without follows, and staying in it after a downgrade
     // would leave the user in a mode the server no longer honours.
-    val browseAll = browsing && followsAvailable
+    val browseAll = browse.browsingAll && followsAvailable
     val shelf by cache.library.collectAsState()
     val everything by cache.browseAll.collectAsState()
     val state = if (browseAll) everything else shelf
@@ -186,32 +207,48 @@ fun LibraryScreen(
         rails == null && shelf.error != null -> InitialErrorState(shelf.error.orEmpty()) { cache.refreshLibrary() }
         rails == null -> CenterProgress()
         else -> {
-            val filtered = remember(library?.fictions, query) {
-                filterFictions(library?.fictions.orEmpty(), query)
+            val loaded = library?.fictions.orEmpty()
+            // One call rather than four steps inline: the screen must apply scope, tags, text and
+            // order in the same sequence the tests do, or "14 of 200" counts a different stage.
+            val result = remember(loaded, query, browse.tags, browse.sort) {
+                browseFictions(loaded, query, browse.tags, browse.sort)
+            }
+            val filtered = result.fictions
+            val tags = remember(loaded) { availableTags(loaded) }
+            // A ticked tag whose last fiction was deleted would otherwise empty the grid with no
+            // box left on screen to un-tick, so it is dropped rather than left in force.
+            val stale = remember(loaded, browse.tags) { staleTags(loaded, browse.tags) }
+            LaunchedEffect(stale) {
+                if (stale.isNotEmpty()) {
+                    browsePreferences.update { it.copy(tags = it.tags - stale) }
+                }
             }
             val keys = remember(filtered) { fictionKeys(filtered) }
             Box(Modifier.fillMaxSize()) {
-                LazyVerticalGrid(
-                    columns = GridCells.Adaptive(MinCardWidth),
-                    state = gridState,
-                    modifier = Modifier
+                Column(
+                    Modifier
                         .align(Alignment.TopCenter)
                         .widthIn(max = ContentMaxWidth)
-                        .fillMaxSize()
-                        .testTag(LibraryGridTestTag),
-                    contentPadding = PaddingValues(PageGutter),
-                    horizontalArrangement = Arrangement.spacedBy(GridGap),
-                    verticalArrangement = Arrangement.spacedBy(GridGap),
+                        .fillMaxSize(),
                 ) {
-                    openError?.let { message ->
-                        fullWidthItem("open-error") {
+                    // Pinned above the grid rather than scrolling inside it.
+                    //
+                    // Both of these are announcements about the *screen*, and a lazy list anchors
+                    // its scroll position on the key of whatever is at the top: inserting a banner
+                    // above that anchor scrolls by exactly the banner's height, so a notice about a
+                    // failed refresh could appear already out of view. Keeping them outside the
+                    // scroller is the only way "we told you" and "you could see it" stay the same
+                    // statement.
+                    Column(
+                        Modifier.padding(horizontal = PageGutter),
+                        verticalArrangement = Arrangement.spacedBy(GridGap),
+                    ) {
+                        openError?.let { message ->
+                            Spacer(Modifier.height(PageGutter))
                             InlineNotice(message) { openError = null }
                         }
-                    }
-
-                    // A refresh that failed reports itself here, above content it did not replace.
-                    if (state.isStale) {
-                        fullWidthItem("stale") {
+                        if (state.isStale) {
+                            Spacer(Modifier.height(PageGutter))
                             StaleContentBanner(
                                 message = error.orEmpty(),
                                 lastSuccessMillis = state.lastSuccessMillis,
@@ -220,7 +257,17 @@ fun LibraryScreen(
                             )
                         }
                     }
-
+                LazyVerticalGrid(
+                    columns = GridCells.Adaptive(MinCardWidth),
+                    state = gridState,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .testTag(LibraryGridTestTag),
+                    contentPadding = PaddingValues(PageGutter),
+                    horizontalArrangement = Arrangement.spacedBy(GridGap),
+                    verticalArrangement = Arrangement.spacedBy(GridGap),
+                ) {
                     val continueList = rails.continueListening
                     if (continueList.isNotEmpty()) {
                         val hero = continueList.first()
@@ -313,7 +360,9 @@ fun LibraryScreen(
                                 Spacer(Modifier.height(10.dp))
                             }
                             if (followsAvailable) {
-                                LibraryScopeTabs(browseAll) { browsing = it }
+                                LibraryScopeTabs(browseAll) { wanted ->
+                                    browsePreferences.update { it.copy(browsingAll = wanted) }
+                                }
                                 Spacer(Modifier.height(14.dp))
                             }
                             if (library != null && library.fictions.isNotEmpty()) {
@@ -341,6 +390,31 @@ fun LibraryScreen(
                                         onSearch = { onSearchServer(query) },
                                     )
                                 }
+                                Spacer(Modifier.height(14.dp))
+                                BrowseControls(
+                                    sort = browse.sort,
+                                    onSort = { picked ->
+                                        browsePreferences.update { it.copy(sort = picked) }
+                                    },
+                                    tags = tags,
+                                    selectedTags = browse.tags,
+                                    onToggleTag = { tag ->
+                                        browsePreferences.update { current ->
+                                            current.copy(
+                                                tags = if (tag in current.tags) {
+                                                    current.tags - tag
+                                                } else {
+                                                    current.tags + tag
+                                                },
+                                            )
+                                        }
+                                    },
+                                    onClearTags = {
+                                        browsePreferences.update { it.copy(tags = emptySet()) }
+                                    },
+                                    shown = filtered.size,
+                                    total = result.totalCount,
+                                )
                             }
                         }
                     }
@@ -360,9 +434,12 @@ fun LibraryScreen(
                             }
                         }
 
-                        library.fictions.isEmpty() -> fullWidthItem("no-fictions") {
-                            if (browseAll) {
-                                EmptyState(
+                        // Every empty grid names the thing that emptied it. "No fictions found"
+                        // is a lie with a tag ticked or on an empty shelf: it reads as the server
+                        // having lost the library rather than as something one click undoes.
+                        filtered.isEmpty() -> fullWidthItem("no-matches") {
+                            when (emptyBrowseReason(result, query, browse.tags, browseAll)) {
+                                EmptyBrowseReason.NothingOnServer -> EmptyState(
                                     "The server has no fictions",
                                     if (fictionManagement.canManage) {
                                         "Use Add fiction to start tracking one."
@@ -370,16 +447,24 @@ fun LibraryScreen(
                                         "An administrator can add one from a supported client."
                                     },
                                 )
-                            } else {
-                                EmptyState(
+
+                                EmptyBrowseReason.NothingFollowed -> EmptyState(
                                     "Your shelf is empty",
                                     "Switch to Everything to find something to follow.",
                                 )
-                            }
-                        }
 
-                        filtered.isEmpty() -> fullWidthItem("no-matches") {
-                            EmptyState("No matches for \"$query\"", "Try a different title, author or tag.")
+                                EmptyBrowseReason.TagFilter -> EmptyState(
+                                    "No fictions carry all ${browse.tags.size} of those tags",
+                                    "Ticking more tags narrows the list. Clear them to see everything again.",
+                                )
+
+                                EmptyBrowseReason.TextQuery -> EmptyState(
+                                    "No matches for \"$query\"",
+                                    "Try a different title, author or tag.",
+                                )
+
+                                null -> Unit
+                            }
                         }
 
                         else -> itemsIndexed(
@@ -405,6 +490,7 @@ fun LibraryScreen(
                             }
                         }
                     }
+                }
                 }
                 RefreshingStrip(state.isRefreshing && !state.isStale)
             }
@@ -573,22 +659,203 @@ private fun InlineRetry(message: String, onRetry: () -> Unit) {
     }
 }
 
+const val BrowseSortTestTag: String = "browseSort"
+const val BrowseTagTestTag: String = "browseTag"
+const val BrowseFilterSummaryTestTag: String = "browseFilterSummary"
+
+/**
+ * "3 chapters · 4h 12m left", from the server's own aggregate, or null when there is nothing to say.
+ *
+ * The server's [FictionProgress.remainingLabel] is preferred over anything formatted here so the
+ * desktop and the web shelf cannot disagree about the same book purely by rounding. A row with no
+ * aggregate renders **nothing** rather than an invented `0 left`: an older server that omits the
+ * key is saying "we were not told", and a zero would be a claim about the reader.
+ */
+internal fun remainingLabel(progress: FictionProgress?): String? {
+    if (progress == null || !progress.isMeaningful) return null
+    if (progress.chaptersUnplayed <= 0) return "Finished"
+    val chapters = "${progress.chaptersUnplayed} left"
+    val time = progress.remainingLabel?.takeIf { it.isNotBlank() && progress.remainingSeconds > 0 }
+    return listOfNotNull(chapters, time).joinToString("  ·  ")
+}
+
+/**
+ * The order, the tag filter, and what they are currently hiding.
+ *
+ * The order control's label is the order *in force*, not the word "Sort": a grid should never have
+ * to be read to work out how it is arranged. The filter summary appears only while something is
+ * actually filtering, because a filter that hides rows without saying it is on is indistinguishable
+ * from a server that has lost the shelf.
+ */
+@Composable
+private fun BrowseControls(
+    sort: FictionSort,
+    onSort: (FictionSort) -> Unit,
+    tags: List<String>,
+    selectedTags: Set<String>,
+    onToggleTag: (String) -> Unit,
+    onClearTags: () -> Unit,
+    shown: Int,
+    total: Int,
+) {
+    var sortOpen by remember { mutableStateOf(false) }
+    var tagsOpen by remember { mutableStateOf(false) }
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp), verticalAlignment = Alignment.CenterVertically) {
+            OutlinedButton(
+                onClick = { sortOpen = true },
+                shape = RectangleShape,
+                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).testTag(BrowseSortTestTag),
+            ) { Text("ORDER: ${sort.label.uppercase()}") }
+            if (tags.isNotEmpty()) {
+                OutlinedButton(
+                    onClick = { tagsOpen = true },
+                    shape = RectangleShape,
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).testTag(BrowseTagTestTag),
+                ) {
+                    Text(
+                        if (selectedTags.isEmpty()) "TAGS" else "TAGS (${selectedTags.size})",
+                    )
+                }
+            }
+        }
+        if (selectedTags.isNotEmpty()) {
+            Column(
+                Modifier.testTag(BrowseFilterSummaryTestTag),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                MetaText(
+                    "Showing $shown of $total  ·  ${selectedTags.sorted().joinToString(", ")}",
+                    color = AarisColor.Accent,
+                )
+                OutlinedButton(
+                    onClick = onClearTags,
+                    shape = RectangleShape,
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                ) { Text("CLEAR TAGS") }
+            }
+        }
+    }
+
+    if (sortOpen) {
+        ChoiceDialog(
+            title = "Order",
+            onDismiss = { sortOpen = false },
+        ) {
+            FictionSort.entries.forEach { option ->
+                DialogChoiceRow(
+                    label = option.label,
+                    detail = option.detail,
+                    selected = option == sort,
+                ) {
+                    onSort(option)
+                    sortOpen = false
+                }
+            }
+        }
+    }
+
+    if (tagsOpen) {
+        ChoiceDialog(
+            title = "Tags",
+            // Said once, above the list, rather than left to be discovered by ticking a second one
+            // and watching the grid shrink.
+            subtitle = "A fiction has to carry every ticked tag",
+            onDismiss = { tagsOpen = false },
+        ) {
+            tags.forEach { tag ->
+                DialogChoiceRow(
+                    label = tag,
+                    detail = null,
+                    selected = tag in selectedTags,
+                    toggle = true,
+                ) { onToggleTag(tag) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChoiceDialog(
+    title: String,
+    onDismiss: () -> Unit,
+    subtitle: String? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title.uppercase(), style = MaterialTheme.typography.titleMedium) },
+        text = {
+            Column(
+                Modifier.verticalScroll(rememberScrollState()).selectableGroup(),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                if (subtitle != null) {
+                    MetaText(subtitle, color = AarisColor.Dim)
+                    Spacer(Modifier.height(4.dp))
+                }
+                content()
+            }
+        },
+        confirmButton = { TextButton(onClick = onDismiss) { Text("DONE") } },
+        shape = RectangleShape,
+        containerColor = AarisColor.BgRaise,
+    )
+}
+
+/**
+ * One row in [ChoiceDialog].
+ *
+ * [toggle] picks the role: tags are independent checkboxes, orders are one radio group. Announcing
+ * a multi-select list as radio buttons would tell a screen reader that ticking the second untocks
+ * the first, which is exactly the misunderstanding the "both tags" rule already invites.
+ */
+@Composable
+private fun DialogChoiceRow(
+    label: String,
+    detail: String?,
+    selected: Boolean,
+    toggle: Boolean = false,
+    onSelect: () -> Unit,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val focused by interaction.collectIsFocusedAsState()
+    val hovered by interaction.collectIsHoveredAsState()
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .hoverable(interaction)
+            .pointerHoverIcon(PointerIcon.Hand)
+            .background(if (selected) AarisColor.BgHover else Color.Transparent)
+            .border(1.dp, if (focused) AarisColor.Accent else Color.Transparent)
+            .selectable(
+                selected = selected,
+                interactionSource = interaction,
+                indication = null,
+                role = if (toggle) Role.Checkbox else Role.RadioButton,
+                onClick = onSelect,
+            )
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Text(
+            if (selected) "· $label" else label,
+            color = when {
+                selected -> AarisColor.Accent
+                hovered || focused -> AarisColor.Ink
+                else -> AarisColor.Muted
+            },
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        if (detail != null) MetaText(detail, color = AarisColor.Dim)
+    }
+}
+
 /** Full-width row inside the grid, for heroes, shelves and section headers. */
 private fun LazyGridScope.fullWidthItem(
     key: String,
     content: @Composable () -> Unit,
 ) = item(key = key, span = { GridItemSpan(maxLineSpan) }, contentType = "span") { content() }
-
-/** Case-insensitive across title, author and tags — the same three fields as the mobile client. */
-internal fun filterFictions(fictions: List<FictionSummary>, query: String): List<FictionSummary> {
-    val q = query.trim().lowercase()
-    if (q.isBlank()) return fictions
-    return fictions.filter { fiction ->
-        fiction.title.lowercase().contains(q) ||
-            fiction.author?.lowercase()?.contains(q) == true ||
-            fiction.tags.any { it.lowercase().contains(q) }
-    }
-}
 
 /** Fraction of the chapter already listened to, for progress-on-artwork. */
 private fun listenedFraction(chapter: ChapterSummary): Float {
@@ -762,6 +1029,10 @@ private fun FictionCard(
                     ).joinToString("  ·  "),
                     color = AarisColor.Dim,
                 )
+                // The server already worked this out for this account, in one grouped query. The
+                // alternative is opening every book and downloading its whole chapter list, which
+                // is why the shelf never used to say it.
+                remainingLabel(fiction.progress)?.let { MetaText(it, color = AarisColor.Muted) }
             }
         }
     }

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/BrowsePreferencesTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/BrowsePreferencesTest.kt
@@ -1,0 +1,91 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * The browse settings file.
+ *
+ * The interesting cases are all about a file written by a *different* build: the on-disk type is
+ * fully nullable and the sort is a string, so an order this build has never heard of degrades to
+ * the default rather than taking the shelf's whole arrangement down with it.
+ */
+class BrowsePreferencesTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private fun file() = tempDir.resolve("browse.json")
+
+    @Test
+    fun `an order survives a restart`() {
+        val file = file()
+        FileBrowsePreferencesStore(file).update {
+            it.copy(sort = FictionSort.Title, tags = setOf("LitRPG"), browsingAll = true)
+        }
+
+        val reopened = FileBrowsePreferencesStore(file).preferences.value
+
+        assertEquals(FictionSort.Title, reopened.sort)
+        assertEquals(setOf("LitRPG"), reopened.tags)
+        assertTrue(reopened.browsingAll)
+    }
+
+    @Test
+    fun `an order this build has never heard of falls back to the default`() {
+        val file = file()
+        file.writeText("""{"sort":"ByVibes","tags":["LitRPG"],"browsingAll":true}""")
+
+        val loaded = FileBrowsePreferencesStore(file).preferences.value
+
+        // The unknown key costs its own field and nothing else.
+        assertEquals(FictionSort.Default, loaded.sort)
+        assertEquals(setOf("LitRPG"), loaded.tags)
+        assertTrue(loaded.browsingAll)
+    }
+
+    @Test
+    fun `a truncated or unreadable file opens on the defaults`() {
+        val file = file()
+        file.writeText("""{"sort":"Titl""")
+
+        assertEquals(BrowsePreferences(), FileBrowsePreferencesStore(file).preferences.value)
+    }
+
+    @Test
+    fun `a file with no keys at all is every default`() {
+        val file = file()
+        file.writeText("{}")
+
+        val loaded = FileBrowsePreferencesStore(file).preferences.value
+
+        assertEquals(FictionSort.Default, loaded.sort)
+        assertTrue(loaded.tags.isEmpty())
+        assertTrue(!loaded.browsingAll)
+    }
+
+    @Test
+    fun `blank tags are dropped and the remembered set is bounded`() {
+        val store = InMemoryBrowsePreferencesStore()
+
+        store.update { it.copy(tags = setOf("  ", "LitRPG", "\t")) }
+        assertEquals(setOf("LitRPG"), store.preferences.value.tags)
+
+        store.update { current ->
+            current.copy(tags = (1..BrowsePreferences.MaxRememberedTags + 10).map { "tag $it" }.toSet())
+        }
+        assertEquals(BrowsePreferences.MaxRememberedTags, store.preferences.value.tags.size)
+    }
+
+    @Test
+    fun `the same tag in two spellings is remembered once`() {
+        val store = InMemoryBrowsePreferencesStore()
+
+        store.update { it.copy(tags = setOf("LitRPG", "litrpg")) }
+
+        assertEquals(1, store.preferences.value.tags.size)
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/FictionBrowseTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/FictionBrowseTest.kt
@@ -1,0 +1,236 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Ordering and filtering, away from the composable that draws them.
+ *
+ * The recurring rule here is what an *absent* answer means. A server that never sent `updated_at`,
+ * a fiction nobody rated, a row with no progress aggregate — each is saying "we were not told",
+ * which is not "a long time ago" or "zero". Most of these cases exist to pin that nulls sort last.
+ */
+class FictionBrowseTest {
+
+    private fun fiction(
+        id: Int,
+        title: String = "Fiction $id",
+        author: String? = null,
+        tags: List<String> = emptyList(),
+        rating: Double? = null,
+        createdAt: String? = null,
+        updatedAt: String? = null,
+        total: Int = 0,
+        done: Int = 0,
+        progress: FictionProgress? = null,
+    ) = FictionSummary(
+        id = id,
+        title = title,
+        author = author,
+        tags = tags,
+        rating = rating,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+        totalChapters = total,
+        doneChapters = done,
+        progress = progress,
+    )
+
+    @Test
+    fun `recently updated puts the newest first and the undated last`() {
+        val fictions = listOf(
+            fiction(1, updatedAt = "2026-01-05T00:00:00Z"),
+            fiction(2, updatedAt = null),
+            fiction(3, updatedAt = "2026-09-01T00:00:00Z"),
+        )
+
+        // The undated row is an older server saying nothing, not a book from 1970.
+        assertContentEquals(
+            listOf(3, 1, 2),
+            sortFictions(fictions, FictionSort.RecentlyUpdated).map { it.id },
+        )
+    }
+
+    @Test
+    fun `every order sorts nulls last`() {
+        val known = fiction(1, title = "AAA", author = "Writer", rating = 4.5, createdAt = "2026-01-01T00:00:00Z", updatedAt = "2026-01-01T00:00:00Z", total = 10, done = 5, progress = FictionProgress(chaptersTotal = 10, chaptersReady = 10, chaptersPlayed = 2, chaptersUnplayed = 8, remainingSeconds = 900.0))
+        val unknown = fiction(2, title = "AAB")
+
+        for (sort in FictionSort.entries) {
+            val ordered = sortFictions(listOf(unknown, known), sort)
+            if (sort == FictionSort.Title) continue // Title is never null; AAA sorts before AAB anyway.
+            assertEquals(
+                1,
+                ordered.first().id,
+                "$sort put the row with no answer ahead of the row with one",
+            )
+        }
+    }
+
+    @Test
+    fun `ties break on title so the order is total`() {
+        // A grid whose items swap places between two recompositions of the same data is a scroll
+        // position that will not stay still.
+        val fictions = listOf(
+            fiction(1, title = "Zebra", updatedAt = "2026-01-01T00:00:00Z"),
+            fiction(2, title = "Alpha", updatedAt = "2026-01-01T00:00:00Z"),
+        )
+
+        assertContentEquals(
+            listOf(2, 1),
+            sortFictions(fictions, FictionSort.RecentlyUpdated).map { it.id },
+        )
+    }
+
+    @Test
+    fun `least finished ranks by the share heard, not the time left`() {
+        val longBookBarelyStarted = fiction(
+            1,
+            progress = FictionProgress(chaptersReady = 400, chaptersPlayed = 4, chaptersUnplayed = 396, remainingSeconds = 400_000.0),
+        )
+        val shortBookHalfDone = fiction(
+            2,
+            progress = FictionProgress(chaptersReady = 12, chaptersPlayed = 6, chaptersUnplayed = 6, remainingSeconds = 6_000.0),
+        )
+
+        assertContentEquals(
+            listOf(1, 2),
+            sortFictions(listOf(shortBookHalfDone, longBookBarelyStarted), FictionSort.LeastFinished).map { it.id },
+        )
+        // Most left to hear is about absolute time, which is why the two orders are both offered.
+        assertContentEquals(
+            listOf(1, 2),
+            sortFictions(listOf(shortBookHalfDone, longBookBarelyStarted), FictionSort.MostLeft).map { it.id },
+        )
+    }
+
+    @Test
+    fun `percent converted is about the pipeline, not about listening`() {
+        val twoOfFourHundred = fiction(1, total = 400, done = 2)
+        val twelveOfTwelve = fiction(2, total = 12, done = 12)
+
+        assertContentEquals(
+            listOf(2, 1),
+            sortFictions(listOf(twoOfFourHundred, twelveOfTwelve), FictionSort.PercentConverted).map { it.id },
+        )
+        // ...while the same pair is ordered the other way by size.
+        assertContentEquals(
+            listOf(1, 2),
+            sortFictions(listOf(twelveOfTwelve, twoOfFourHundred), FictionSort.MostChapters).map { it.id },
+        )
+    }
+
+    @Test
+    fun `two ticked tags mean both, not either`() {
+        val both = fiction(1, tags = listOf("LitRPG", "Fantasy"))
+        val one = fiction(2, tags = listOf("LitRPG"))
+        val neither = fiction(3, tags = listOf("Romance"))
+        val fictions = listOf(both, one, neither)
+
+        // A filter that widens the list as you add to it is one nobody uses twice.
+        assertContentEquals(
+            listOf(1),
+            filterByTags(fictions, setOf("LitRPG", "Fantasy")).map { it.id },
+        )
+        assertContentEquals(listOf(1, 2), filterByTags(fictions, setOf("LitRPG")).map { it.id })
+        assertEquals(fictions, filterByTags(fictions, emptySet()))
+    }
+
+    @Test
+    fun `tag matching and the tag list ignore case and spacing`() {
+        val fictions = listOf(
+            fiction(1, tags = listOf(" LitRPG ")),
+            fiction(2, tags = listOf("litrpg")),
+        )
+
+        assertContentEquals(listOf(1, 2), filterByTags(fictions, setOf("LITRPG")).map { it.id })
+        // One entry, keeping the first spelling seen, like `cleanFictionTags`.
+        assertContentEquals(listOf("LitRPG"), availableTags(fictions))
+    }
+
+    @Test
+    fun `a ticked tag nothing carries any more is reported as stale`() {
+        val fictions = listOf(fiction(1, tags = listOf("LitRPG")))
+
+        // Otherwise it empties the grid with no box left on screen to un-tick.
+        assertEquals(setOf("Romance"), staleTags(fictions, setOf("LitRPG", "Romance")))
+        assertTrue(staleTags(fictions, emptySet()).isEmpty())
+    }
+
+    @Test
+    fun `the pipeline counts the tag stage separately from the text stage`() {
+        val fictions = listOf(
+            fiction(1, title = "Inn", tags = listOf("LitRPG")),
+            fiction(2, title = "Tower", tags = listOf("LitRPG")),
+            fiction(3, title = "Romance", tags = listOf("Romance")),
+        )
+
+        val result = browseFictions(fictions, query = "inn", tags = setOf("LitRPG"), sort = FictionSort.Title)
+
+        assertContentEquals(listOf(1), result.fictions.map { it.id })
+        assertEquals(2, result.taggedCount, "\"N of M\" counts against the tag stage")
+        assertEquals(3, result.totalCount)
+    }
+
+    @Test
+    fun `an empty grid names the thing that emptied it`() {
+        val tagged = listOf(fiction(1, tags = listOf("LitRPG")))
+
+        assertEquals(
+            EmptyBrowseReason.TagFilter,
+            emptyBrowseReason(
+                browseFictions(tagged, "", setOf("Romance"), FictionSort.Title),
+                query = "",
+                tags = setOf("Romance"),
+                browsingAll = true,
+            ),
+        )
+        assertEquals(
+            EmptyBrowseReason.TextQuery,
+            emptyBrowseReason(
+                browseFictions(tagged, "nothing", emptySet(), FictionSort.Title),
+                query = "nothing",
+                tags = emptySet(),
+                browsingAll = true,
+            ),
+        )
+        // An empty shelf and an empty server read very differently to the person looking at them.
+        assertEquals(
+            EmptyBrowseReason.NothingFollowed,
+            emptyBrowseReason(
+                browseFictions(emptyList(), "", emptySet(), FictionSort.Title),
+                query = "",
+                tags = emptySet(),
+                browsingAll = false,
+            ),
+        )
+        assertEquals(
+            EmptyBrowseReason.NothingOnServer,
+            emptyBrowseReason(
+                browseFictions(emptyList(), "", emptySet(), FictionSort.Title),
+                query = "",
+                tags = emptySet(),
+                browsingAll = true,
+            ),
+        )
+        assertNull(
+            emptyBrowseReason(
+                browseFictions(tagged, "", emptySet(), FictionSort.Title),
+                query = "",
+                tags = emptySet(),
+                browsingAll = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `an unconverted book has no listened fraction rather than zero`() {
+        // "0% listened" and "there is nothing to listen to yet" are different sentences, and only
+        // one of them is about the reader.
+        assertNull(FictionProgress(chaptersTotal = 40, chaptersReady = 0).listenedFraction)
+        assertEquals(0.5f, FictionProgress(chaptersReady = 10, chaptersPlayed = 5).listenedFraction)
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ModelParsingTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ModelParsingTest.kt
@@ -61,6 +61,43 @@ class ModelParsingTest {
         assertEquals(1, fiction.errorChapters)
         assertEquals(1, fiction.processingChapters)
         assertEquals(0.6f, fiction.readyFraction)
+        // The 1.4.0 fixture predates the aggregate, which is exactly the older-server case: null,
+        // never a zeroed shape, because `0 left` would be a claim about the reader.
+        assertNull(fiction.progress)
+        assertEquals("2026-01-02T03:04:05Z", fiction.createdAt)
+        assertEquals("2026-08-01T03:04:05Z", fiction.updatedAt)
+    }
+
+    @Test
+    fun `a newer server's per-caller progress aggregate is decoded`() {
+        val fiction = parse<FictionSummary>(
+            """
+            {
+              "id": 7,
+              "title": "A Test Serial",
+              "total_chapters": 40,
+              "done_chapters": 30,
+              "progress": {
+                "chapters_total": 40,
+                "chapters_ready": 30,
+                "chapters_played": 12,
+                "chapters_unplayed": 18,
+                "duration_seconds": 54000.0,
+                "duration_label": "15h",
+                "remaining_seconds": 32400.0,
+                "remaining_label": "9h",
+                "some_key_this_build_has_never_seen": 1
+              }
+            }
+            """.trimIndent(),
+        )
+
+        val progress = assertNotNull(fiction.progress)
+        assertEquals(30, progress.chaptersReady)
+        assertEquals(18, progress.chaptersUnplayed)
+        assertEquals("9h", progress.remainingLabel)
+        assertEquals(0.4f, progress.listenedFraction)
+        assertTrue(progress.isMeaningful)
     }
 
     @Test

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/AdaptiveLayoutTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/AdaptiveLayoutTest.kt
@@ -3,6 +3,7 @@ package dk.perspektiva.ttsroad.desktop.ui
 import androidx.compose.ui.unit.dp
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
 import dk.perspektiva.ttsroad.desktop.data.ListeningTotals
+import dk.perspektiva.ttsroad.desktop.data.filterFictionsByText
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -43,19 +44,19 @@ class AdaptiveLayoutTest {
 
     @Test
     fun `search matches title, author and tags, case-insensitively`() {
-        assertEquals(listOf(1), filterFictions(fictions, "test serial").map { it.id })
-        assertEquals(listOf(2), filterFictions(fictions, "WRITER").map { it.id })
-        assertEquals(listOf(1), filterFictions(fictions, "litrpg").map { it.id })
+        assertEquals(listOf(1), filterFictionsByText(fictions, "test serial").map { it.id })
+        assertEquals(listOf(2), filterFictionsByText(fictions, "WRITER").map { it.id })
+        assertEquals(listOf(1), filterFictionsByText(fictions, "litrpg").map { it.id })
     }
 
     @Test
     fun `a blank query is not a filter`() {
-        assertEquals(fictions, filterFictions(fictions, "   "))
+        assertEquals(fictions, filterFictionsByText(fictions, "   "))
     }
 
     @Test
     fun `surrounding whitespace is ignored`() {
-        assertEquals(listOf(1), filterFictions(fictions, "  serial  ").map { it.id })
+        assertEquals(listOf(1), filterFictionsByText(fictions, "  serial  ").map { it.id })
     }
 
     // --- "how old is this" ---------------------------------------------------------------------

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolderTest.kt
@@ -4,6 +4,7 @@ import dk.perspektiva.ttsroad.desktop.FakeRepository
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
 import dk.perspektiva.ttsroad.desktop.data.LibraryCache
 import dk.perspektiva.ttsroad.desktop.data.MobileUser
+import dk.perspektiva.ttsroad.desktop.data.SyncScope
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
@@ -82,6 +83,99 @@ class FictionManagementStateHolderTest {
         assertNull(repository.createdFictions.single().voice)
         assertNull(holder.state.value.editor)
         assertTrue(holder.state.value.notice.orEmpty().contains("New serial"))
+        holder.clear()
+        cache.close()
+    }
+
+    @Test
+    fun `adding sends the web form's chapter limit rather than the whole backlog`() = runTest {
+        val repository = adminRepository()
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        val holder = adminHolder(repository, cache)
+
+        holder.openAdd()
+        holder.updateAdd(fictionUrl = "424242")
+        holder.submitAdd()
+        runCurrent()
+
+        // The backend reads an absent sync_limit as *every chapter* — `if body.sync_limit:` then
+        // `poll_and_process_fiction(id, True)` — so omitting it queues a whole serial of TTS.
+        val request = repository.createdFictions.single()
+        assertEquals(25, request.syncLimit)
+        assertEquals("last", request.syncDirection)
+        assertTrue(request.enabled)
+        holder.clear()
+        cache.close()
+    }
+
+    @Test
+    fun `the whole backlog is reachable, and only when it is actually asked for`() = runTest {
+        val repository = adminRepository()
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        val holder = adminHolder(repository, cache)
+
+        holder.openAdd()
+        holder.updateAdd(fictionUrl = "424242", syncScope = SyncScope.Everything)
+        holder.submitAdd()
+        runCurrent()
+
+        assertNull(repository.createdFictions.single().syncLimit, "null is the server's own no-limit")
+        assertTrue(
+            holder.state.value.notice.orEmpty().contains("whole backlog"),
+            "the notice has to say what was actually queued: ${holder.state.value.notice}",
+        )
+        holder.clear()
+        cache.close()
+    }
+
+    @Test
+    fun `oldest first flips the direction rather than the limit`() = runTest {
+        val repository = adminRepository()
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        val holder = adminHolder(repository, cache)
+
+        holder.openAdd()
+        holder.updateAdd(fictionUrl = "424242", syncScope = SyncScope.OldestTwentyFive)
+        holder.submitAdd()
+        runCurrent()
+
+        val request = repository.createdFictions.single()
+        assertEquals(25, request.syncLimit)
+        assertEquals("first", request.syncDirection)
+        holder.clear()
+        cache.close()
+    }
+
+    @Test
+    fun `rate and the auto-poll switch reach the request`() = runTest {
+        val repository = adminRepository()
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        val holder = adminHolder(repository, cache)
+
+        holder.openAdd()
+        holder.updateAdd(fictionUrl = "424242", rate = "  +10%  ", autoPoll = false)
+        holder.submitAdd()
+        runCurrent()
+
+        val request = repository.createdFictions.single()
+        assertEquals("+10%", request.rate)
+        assertFalse(request.enabled, "a finished work does not need a poller")
+        holder.clear()
+        cache.close()
+    }
+
+    @Test
+    fun `a blank rate is omitted rather than sent as an empty string`() = runTest {
+        val repository = adminRepository()
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        val holder = adminHolder(repository, cache)
+
+        holder.openAdd()
+        holder.updateAdd(fictionUrl = "424242", rate = "   ")
+        holder.submitAdd()
+        runCurrent()
+
+        assertNull(repository.createdFictions.single().rate, "blank means leave the server's default")
         holder.clear()
         cache.close()
     }

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/NavigationUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/NavigationUiTest.kt
@@ -35,6 +35,7 @@ import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
 import dk.perspektiva.ttsroad.desktop.data.ChaptersResponse
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
 import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackHistoryStore
+import dk.perspektiva.ttsroad.desktop.data.InMemoryBrowsePreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.InMemoryReaderPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.InMemorySessionStore
@@ -74,6 +75,14 @@ class NavigationUiTest {
         },
     )
 
+    /** Two tags, deliberately carried by different fictions, so "both" and "either" differ. */
+    private fun taggedLibrary() = LibraryResponse(
+        fictions = listOf(
+            FictionSummary(id = 1, title = "Serial 01", tags = listOf("LitRPG"), totalChapters = 3),
+            FictionSummary(id = 2, title = "Serial 02", tags = listOf("Romance"), totalChapters = 3),
+        ),
+    )
+
     private val chapters = ChaptersResponse(
         fiction = FictionSummary(id = 50, title = "Serial 50"),
         total = 1,
@@ -100,6 +109,7 @@ class NavigationUiTest {
         // In-memory, so rendering a screen in a test never touches the real
         // ~/.config/TTSRoad files the production stores default to.
         playbackPreferences = InMemoryPlaybackPreferencesStore(),
+        browsePreferences = InMemoryBrowsePreferencesStore(),
         playbackHistory = InMemoryPlaybackHistoryStore(),
         readerPreferencesFactory = { _, _ -> InMemoryReaderPreferencesStore() },
         // See `testLibraryCache`: immediate main dispatch is what makes `waitForIdle` sufficient.
@@ -200,6 +210,83 @@ class NavigationUiTest {
         // One announcement for a screen reader: the failure *and* how old what is on screen is.
         compose.onNode(hasContentDescription("connection reset", substring = true)).assertIsDisplayed()
         compose.onNode(hasContentDescription("Showing content from", substring = true)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a failed refresh stays visible even when the grid is scrollable`() {
+        // Regression: both notices used to be items *inside* the lazy grid. A lazy list anchors its
+        // scroll position on the key of whatever is at the top, so inserting a banner above that
+        // anchor scrolled by exactly the banner's height and the notice arrived already out of
+        // view — on precisely the screens with enough content to scroll, which is most of them.
+        val repository = FakeRepository(libraryResult = Result.success(bigLibrary(40)))
+        compose.setContent { TtsRoadTheme { App(container(repository)) } }
+        compose.waitForIdle()
+        compose.onNodeWithTag(LibraryGridTestTag).performScrollToIndex(20)
+        compose.waitForIdle()
+
+        repository.libraryResult = Result.failure(IllegalStateException("connection reset"))
+        compose.onNodeWithContentDescription("Refresh").performClick()
+        compose.waitForIdle()
+
+        compose.onNode(hasContentDescription("connection reset", substring = true)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the shelf can be reordered and the control says which order is in force`() {
+        val repository = FakeRepository(libraryResult = Result.success(bigLibrary(3)))
+        compose.setContent { TtsRoadTheme { App(container(repository)) } }
+        compose.waitForIdle()
+
+        // The label is the order itself: a grid should never have to be read to work out how it is
+        // arranged.
+        compose.onNodeWithTag(BrowseSortTestTag).assertIsDisplayed().performClick()
+        compose.waitForIdle()
+        // Picking an order closes the sheet: there is exactly one answer, so there is nothing
+        // left to confirm.
+        compose.onNodeWithText("Title").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("ORDER: TITLE").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a tag filter states itself and can be cleared`() {
+        val repository = FakeRepository(libraryResult = Result.success(taggedLibrary()))
+        compose.setContent { TtsRoadTheme { App(container(repository)) } }
+        compose.waitForIdle()
+
+        compose.onNodeWithTag(BrowseTagTestTag).performClick()
+        compose.waitForIdle()
+        compose.onNodeWithText("Romance").performClick()
+        compose.onNodeWithText("DONE").performClick()
+        compose.waitForIdle()
+
+        // A filter that hides rows without saying it is on is indistinguishable from a server that
+        // has lost the shelf.
+        compose.onNodeWithTag(BrowseFilterSummaryTestTag).assertIsDisplayed()
+        compose.onNodeWithText("Serial 01").assertDoesNotExist()
+
+        compose.onNodeWithText("CLEAR TAGS").performClick()
+        compose.waitForIdle()
+        compose.onNodeWithText("Serial 01").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a tag that excludes everything says so rather than blaming the server`() {
+        val repository = FakeRepository(libraryResult = Result.success(taggedLibrary()))
+        compose.setContent { TtsRoadTheme { App(container(repository)) } }
+        compose.waitForIdle()
+
+        compose.onNodeWithTag(BrowseTagTestTag).performClick()
+        compose.waitForIdle()
+        compose.onNodeWithText("Romance").performClick()
+        compose.onNodeWithText("LitRPG").performClick()
+        compose.onNodeWithText("DONE").performClick()
+        compose.waitForIdle()
+
+        // Two ticked tags mean both, and no fiction here carries both.
+        compose.onNode(hasText("NO FICTIONS CARRY ALL 2 OF THOSE TAGS", substring = true))
+            .assertIsDisplayed()
     }
 
     @Test

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ScreensUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ScreensUiTest.kt
@@ -19,6 +19,7 @@ import dk.perspektiva.ttsroad.desktop.FakeRepository
 import dk.perspektiva.ttsroad.desktop.ParsedFixtures
 import dk.perspektiva.ttsroad.desktop.testLibraryCache
 import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackHistoryStore
+import dk.perspektiva.ttsroad.desktop.data.InMemoryBrowsePreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.InMemoryPlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.InMemoryReaderPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.InMemorySessionStore
@@ -74,6 +75,7 @@ class ScreensUiTest {
         // In-memory, so rendering a screen in a test never touches the real
         // ~/.config/TTSRoad files the production stores default to.
         playbackPreferences = InMemoryPlaybackPreferencesStore(),
+        browsePreferences = InMemoryBrowsePreferencesStore(),
         playbackHistory = InMemoryPlaybackHistoryStore(),
         readerPreferencesFactory = { _, _ -> InMemoryReaderPreferencesStore() },
         downloadCoordinatorFactory = ::testDownloads,


### PR DESCRIPTION
Closes #86, #87, #88, #89, #90, #91, #92 — the browse half of the parity pass the Android client
shipped in 0.14.0.

Filed as seven issues, fixed as one PR because they are one surface: the sort orders need the
progress aggregate (#88) and the dates (#89), the empty states need to know about the tag filter
(#90, #92), and persistence covers all three controls at once (#91).

## Most of this was already on the wire

- `_fiction_payload` has serialised `created_at`/`updated_at` on every fiction since before this
  client existed. `FictionSummary` decoded neither, which is why no order but the server's own was
  ever possible.
- Every `/api/mobile/library` row carries a per-caller `progress` aggregate the backend computes in
  one grouped query (`mobile.py:734`). Moshi was dropping it silently.

## The rules worth reviewing

- **Nulls sort last, in every order.** A missing date, an absent rating and a row with no aggregate
  all mean *we were not told* — not "a long time ago" or "zero". `FictionBrowseTest` asserts this
  for every enum case in a loop, so a new order cannot be added without inheriting the rule.
- **Ties break on title**, so the order is total. A lazy grid whose items swap places between two
  recompositions of the same data is a scroll position that will not stay still.
- **Two ticked tags mean both**, matching `ttsroadApplyLibrary`.
- **The search text is deliberately not persisted** while order/tags/scope are.
- **`remainingLabel` renders nothing** for a row with no aggregate — never an invented `0 left`.

## The add-fiction bug (#86)

`POST /api/mobile/fictions` accepts `sync_limit`; the desktop sent none, and `fictions.py:946` reads
its absence as *every chapter*. Tracking a 400-chapter serial from here queued four hundred chapters
of TTS while the web form, posting the same body, has always defaulted to 25. `SyncScope` carries
the whole contract and the whole-backlog option states its cost before it is picked. `rate` and
`enabled` (#87) come along.

## One fix you did not ask for

The stale-content banner and #98's open-failure notice **move out of the lazy grid**. A lazy list
anchors its scroll on the key of whatever is at the top, so inserting a banner above that anchor
scrolls by exactly the banner's height — a notice about a failed refresh could arrive already out of
view. `NavigationUiTest` caught this the moment the header grew; there is now a case that scrolls to
index 20 first and asserts the banner is still displayed.

## Verification

`./gradlew clean check --warning-mode fail -Pttsroad.warningsAsErrors=true` passes. New:
`FictionBrowseTest` (11 cases), `BrowsePreferencesTest` (6), five add-fiction holder cases, an
aggregate parse test, and four `NavigationUiTest` cases. The 1.4.0 fixture keeps no `progress` key
on purpose — it is the older-server case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK3sri5jA6ne6tEJnbQaRe