### PR TITLE
Give controls a rank, and let the fiction screen fit its minimum window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,27 @@ one desktop never shows two different answers. `WindowPlacement` carries the fla
 behaviour are written by different hands at different times, so the close handler merges through
 `withBehaviourOf` rather than saving the startup snapshot wholesale.
 
+### Control rank
+
+`ui/Components.kt` carries three ranks — `AarisPrimaryAction`, `AarisSecondaryAction`,
+`AarisActionRow` — and the rule for picking one is *how often the control is reached for*, not how
+important it feels. **At most one primary per screen.** Secondaries go in a row, not a column;
+`fillMaxWidth()` is the exception there rather than the default. The AARIS look (no radius, thin
+border, mono uppercase) is handsome once and a wall of identical rectangles four times over, and
+colour here carries **severity**, not rank, so tinting a destructive action does not promote it.
+
+The test for rank three: **if a control needs a sentence under it to be safe to press, it is not a
+button, it is a row** — and it belongs behind a disclosure. Deleting a fiction destroys the shared
+chapters and every account's progress, and editing metadata claims the field against every future
+refresh of the source; neither fits on a button label, and neither belongs in the header beside
+Resume.
+
+Fiction detail derives its own `WindowSizeClass`, like Settings does. The app promises 720 dp, where
+the gutters leave 664: the header's cover shrinks, and both control groups are `FlowRow`s. The
+symptom of getting this wrong is not a clipped button but a **squeezed** one — a Row measures
+children against the space left, so the last control keeps its bounds and wraps its own label. That
+is what `ChapterBrowsingUiTest` asserts against: equal heights across the group.
+
 ### Keyboard shortcuts
 
 `nav/Shortcuts.kt` is a pure matcher plus an `AppShortcut.firesWhileTyping` classification. `App`

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/Components.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/Components.kt
@@ -270,6 +270,123 @@ fun <T> AarisChoiceRow(
     }
 }
 
+/**
+ * # Control rank
+ *
+ * AARIS says *no radius, thin border, mono uppercase label*. Applied to one control that is
+ * handsome; applied to every control on a screen it produces a stack of identical rectangles with
+ * nothing for the eye to land on. The fiction header reached four equal-weight buttons and the
+ * chapter list another four beside them, and colour was doing the only differentiating — colour
+ * here carries *severity*, not rank, so a rare destructive action and an everyday one looked
+ * equally loud and merely differently tinted.
+ *
+ * Three ranks. Pick by how often the control is reached for, not by how important it feels:
+ *
+ * 1. **Primary** — at most **one per screen**. Filled, accent. The thing the screen exists for:
+ *    Resume on a fiction, play/pause on the player.
+ * 2. **Secondary** — outlined, laid out in a row rather than a column. Two or three per screen.
+ *    `fillMaxWidth()` is the exception here, not the default.
+ * 3. **Tertiary / housekeeping** — [AarisActionRow], inside a sheet or a collapsed block. Anything
+ *    rare, destructive, or needing its consequence spelled out. Never in the primary scroll.
+ *
+ * The test for rank three is simple: **if the control needs a sentence under it to be safe to
+ * press, it is not a button, it is a row** — and it belongs behind something. "Deleting destroys
+ * every account's progress" cannot ride on a button's label, and trailing it underneath as loose
+ * caption text leaves the reader to guess which control the sentence belongs to.
+ */
+@Composable
+fun AarisPrimaryAction(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    icon: ImageVector? = null,
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        shape = RectangleShape,
+        modifier = modifier.pointerHoverIcon(PointerIcon.Hand),
+    ) {
+        if (icon != null) {
+            Icon(icon, contentDescription = null, Modifier.size(18.dp))
+            Spacer(Modifier.width(8.dp))
+        }
+        Text(label.uppercase())
+    }
+}
+
+/** Rank two. See [AarisPrimaryAction] for what separates the three. */
+@Composable
+fun AarisSecondaryAction(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    icon: ImageVector? = null,
+) {
+    OutlinedButton(
+        onClick = onClick,
+        enabled = enabled,
+        shape = RectangleShape,
+        modifier = modifier.pointerHoverIcon(PointerIcon.Hand),
+    ) {
+        if (icon != null) {
+            Icon(icon, contentDescription = null, Modifier.size(16.dp))
+            Spacer(Modifier.width(8.dp))
+        }
+        Text(label.uppercase())
+    }
+}
+
+/**
+ * Rank three: a titled row carrying its own consequence.
+ *
+ * The [subtitle] is the whole argument for this over a button. "Deleting destroys the shared
+ * chapters and every account's progress" and "No chapters have audio yet" cannot ride on a button
+ * label, and when [enabled] is false this is where **the reason why not** goes — a greyed button
+ * that does not say why is a dead end.
+ */
+@Composable
+fun AarisActionRow(
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    /** For a destructive row: pass [AarisColor.Danger]. Severity, deliberately not rank. */
+    titleColor: Color = AarisColor.Ink,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    val focused by interaction.collectIsFocusedAsState()
+    val active = (hovered || focused) && enabled
+    Column(
+        modifier
+            .fillMaxWidth()
+            .hoverable(interaction, enabled = enabled)
+            .let { if (enabled) it.pointerHoverIcon(PointerIcon.Hand) else it }
+            .background(if (active) AarisColor.BgHover else Color.Transparent)
+            .border(1.dp, if (focused && enabled) AarisColor.Accent else AarisColor.Line)
+            .clickable(
+                interactionSource = interaction,
+                indication = null,
+                enabled = enabled,
+                role = Role.Button,
+                onClick = onClick,
+            )
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            title.uppercase(),
+            style = MaterialTheme.typography.labelLarge,
+            color = if (enabled) titleColor else AarisColor.Dim,
+        )
+        MetaText(subtitle, color = AarisColor.Dim)
+    }
+}
+
 @Composable
 fun SectionTitle(kicker: String, title: String, modifier: Modifier = Modifier) {
     Column(modifier.fillMaxWidth()) {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionDetailScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionDetailScreen.kt
@@ -10,12 +10,14 @@ import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -291,7 +293,11 @@ fun FictionDetailScreen(
         }
     }
 
-    Box(Modifier.fillMaxSize()) {
+    BoxWithConstraints(Modifier.fillMaxSize()) {
+        // The app promises 720 dp. At that width the 28 dp gutters leave 664, and the header's
+        // fixed 190 dp cover plus its 28 dp gap left barely 440 for a title, the counters and four
+        // buttons — which is why this screen needed a size class of its own like Settings has.
+        val compact = windowSizeClassFor(maxWidth).isCompact
         LazyColumn(
             state = listState,
             modifier = Modifier
@@ -338,7 +344,19 @@ fun FictionDetailScreen(
                         } else {
                             null
                         },
+                        compact = compact,
                     )
+
+                    if (fictionManagement.canManage) {
+                        Spacer(Modifier.height(16.dp))
+                        ManageFictionBlock(
+                            FictionManagementActions(
+                                busy = fictionManagement.isBusy,
+                                onEdit = { onEditFiction(header) },
+                                onDelete = { onDeleteFiction(header) },
+                            ),
+                        )
+                    }
 
                     actionError?.let { message ->
                         Spacer(Modifier.height(12.dp))
@@ -481,22 +499,35 @@ private fun ChapterListControls(
     queue: ChapterQueueUi,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        // FlowRow, not Row: three filter tabs, an Order label and two sort tabs already fill the
+        // 664 dp a 720 dp window leaves after its gutters, and any UI scaling above 100% pushed them
+        // straight off the edge with nowhere to go.
+        FlowRow(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            itemVerticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Kept together in their own Row so a wrap never splits one group across two lines,
+            // which would read as five unrelated tabs rather than two choices.
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 ChapterFilter.entries.forEach { entry ->
                     SegmentTab(entry.label, entry == options.filter) { onOptions(options.copy(filter = entry)) }
                 }
             }
-            Spacer(Modifier.width(24.dp))
-            MetaText("Order", color = AarisColor.Dim)
-            Spacer(Modifier.width(8.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                MetaText("Order", color = AarisColor.Dim)
                 ChapterSort.entries.forEach { entry ->
                     SegmentTab(entry.label, entry == options.sort) { onOptions(options.copy(sort = entry)) }
                 }
             }
         }
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
             BulkAction("Mark all played", enabled = canMarkPlayed, onClick = onMarkAllPlayed)
             BulkAction("Mark all unplayed", enabled = canMarkUnplayed, onClick = onMarkAllUnplayed)
             // Absent rather than disabled when there is nowhere to download to: a control that can
@@ -618,14 +649,16 @@ private fun FictionHeader(
     onResume: (ChapterSummary) -> Unit,
     follow: FollowUi? = null,
     management: FictionManagementActions? = null,
+    /** Below this the cover shrinks; the app promises 720 dp and the cover was a fixed 190. */
+    compact: Boolean = false,
 ) {
     Row(Modifier.fillMaxWidth()) {
         CoverImage(
             fiction.title,
             fiction.coverImageUrl?.let(repository::resolveUrl),
-            Modifier.width(190.dp).aspectRatio(2f / 3f),
+            Modifier.width(if (compact) 120.dp else 190.dp).aspectRatio(2f / 3f),
         )
-        Spacer(Modifier.width(28.dp))
+        Spacer(Modifier.width(if (compact) 16.dp else 28.dp))
         Column(Modifier.weight(1f)) {
             MetaText(text = "// Fiction", color = AarisColor.Accent)
             Spacer(Modifier.height(8.dp))
@@ -689,42 +722,64 @@ private fun FictionHeader(
             val target = remember(chapters) { resumeTarget(chapters) }
             if (target != null || follow != null || management != null) {
                 Spacer(Modifier.height(16.dp))
-                Row(horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
+                // One primary control, then a wrapping row of secondaries. The admin pair moves out
+                // entirely — see `ManageFictionBlock`: an edit that permanently takes a field away
+                // from the source, and a delete that destroys every account's progress, are not
+                // things a header button should be able to do in passing.
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
                     if (target != null) {
-                        Button(
+                        AarisPrimaryAction(
+                            label = if (target.resolvedPositionSeconds > 0.0) "Resume" else "Start listening",
                             onClick = { onResume(target) },
-                            shape = RectangleShape,
-                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                        ) {
-                            Icon(Icons.Default.PlayArrow, contentDescription = null, Modifier.size(18.dp))
-                            Spacer(Modifier.width(8.dp))
-                            Text(if (target.resolvedPositionSeconds > 0.0) "RESUME" else "START LISTENING")
-                        }
+                            icon = Icons.Default.PlayArrow,
+                        )
                     }
                     follow?.let { FollowButton(it) }
-                    management?.let { actions ->
-                        OutlinedButton(
-                            onClick = actions.onEdit,
-                            enabled = !actions.busy,
-                            shape = RectangleShape,
-                            modifier = Modifier
-                                .pointerHoverIcon(PointerIcon.Hand)
-                                .testTag(EditFictionButtonTestTag),
-                        ) { Text("EDIT METADATA") }
-                        OutlinedButton(
-                            onClick = actions.onDelete,
-                            enabled = !actions.busy,
-                            shape = RectangleShape,
-                            colors = ButtonDefaults.outlinedButtonColors(
-                                contentColor = MaterialTheme.colorScheme.error,
-                            ),
-                            modifier = Modifier
-                                .pointerHoverIcon(PointerIcon.Hand)
-                                .testTag(DeleteFictionButtonTestTag),
-                        ) { Text("DELETE") }
-                    }
                 }
             }
+        }
+    }
+}
+
+const val ManageFictionTestTag: String = "manageFiction"
+
+/**
+ * The admin housekeeping, behind a disclosure rather than in the header.
+ *
+ * Both of these need a sentence to be safe to press — editing metadata claims the field against
+ * every future refresh of the source, and deleting destroys the shared chapters and every account's
+ * progress — which is the test for rank three. A header row of four equal buttons could say neither.
+ */
+@Composable
+private fun ManageFictionBlock(actions: FictionManagementActions) {
+    var open by rememberSaveable { mutableStateOf(false) }
+    Column(
+        Modifier.fillMaxWidth().testTag(ManageFictionTestTag),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        AarisSecondaryAction(
+            label = if (open) "Hide management" else "Manage this fiction",
+            onClick = { open = !open },
+        )
+        if (open) {
+            AarisActionRow(
+                title = "Edit metadata",
+                subtitle = "Correcting a field stops the server refreshing it from the source.",
+                onClick = actions.onEdit,
+                enabled = !actions.busy,
+                modifier = Modifier.testTag(EditFictionButtonTestTag),
+            )
+            AarisActionRow(
+                title = "Delete fiction",
+                subtitle = "Destroys the shared chapters and every account's progress. Not undoable.",
+                onClick = actions.onDelete,
+                enabled = !actions.busy,
+                titleColor = AarisColor.Danger,
+                modifier = Modifier.testTag(DeleteFictionButtonTestTag),
+            )
         }
     }
 }

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterBrowsingUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterBrowsingUiTest.kt
@@ -39,6 +39,11 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import dk.perspektiva.ttsroad.desktop.data.ChapterFilter
+import dk.perspektiva.ttsroad.desktop.data.ChapterSort
 
 /**
  * The acceptance criteria of the chapter-browsing phase, driven through the real
@@ -96,6 +101,88 @@ class ChapterBrowsingUiTest {
             }
         }
         compose.waitForIdle()
+    }
+
+    /** The screen at the smallest window the app promises to support. */
+    private fun compactScreen(
+        repository: FakeRepository,
+        cache: LibraryCache = testLibraryCache(repository),
+        downloads: ChapterDownloadsUi = ChapterDownloadsUi(),
+        queue: ChapterQueueUi = ChapterQueueUi(),
+    ) {
+        compose.setContent {
+            TtsRoadTheme {
+                Box(Modifier.size(MinWindowWidth, MinWindowHeight)) {
+                    FictionDetailScreen(
+                        fiction = fiction,
+                        cache = cache,
+                        repository = repository,
+                        playback = FakePlaybackController(),
+                        onBack = {},
+                        downloads = downloads,
+                        queue = queue,
+                    )
+                }
+            }
+        }
+        compose.waitForIdle()
+    }
+
+    /**
+     * Asserts the node is inside the window, not merely present in the tree.
+     *
+     * `assertIsDisplayed` is not enough for this: a `Row` measures its children against whatever
+     * space is left, so an overflowing control is still "displayed" while sitting partly or wholly
+     * past the right edge with its label squeezed to nothing. Only the geometry catches it.
+     */
+    private fun assertWithinWindow(label: String) {
+        val node = compose.onNodeWithText(label).fetchSemanticsNode()
+        val right = node.boundsInRoot.right
+        val width = MinWindowWidth.value
+        assertTrue(
+            right <= width + 0.5f,
+            "\"$label\" ends at $right in a ${width}dp window — it has run off the edge",
+        )
+        assertTrue(node.size.width > 0, "\"$label\" was squeezed to zero width")
+    }
+
+    @Test
+    fun `every bulk control fits inside the supported minimum width`() {
+        // 720 dp minus the 28 dp gutters leaves 664, and the four Material bulk buttons already
+        // fill that at default text size. In a fixed Row the last simply ran off the edge.
+        val repository = FakeRepository(chaptersResult = Result.success(response((1..6).map { chapter(it) })))
+
+        compactScreen(
+            repository,
+            downloads = ChapterDownloadsUi(available = true),
+            queue = ChapterQueueUi(available = true),
+        )
+        scrollToControls()
+
+        val labels = listOf("MARK ALL PLAYED", "MARK ALL UNPLAYED", "DOWNLOAD NEXT 10", "QUEUE UNPLAYED")
+        val heights = labels.associateWith { compose.onNodeWithText(it).fetchSemanticsNode().size.height }
+
+        // A control forced taller than its neighbours is one whose label had to wrap, which is what
+        // "runs out of horizontal space" looks like in a Row: the last button was squeezed to 99 dp
+        // wide and 55 tall while the other three sat at 40. Wrapping the *group* is the fix; a
+        // wrapped label inside a squeezed button is the bug.
+        labels.forEach { assertWithinWindow(it) }
+        assertEquals(
+            1,
+            heights.values.distinct().size,
+            "a control had to wrap its own label to fit: $heights",
+        )
+    }
+
+    @Test
+    fun `the filter and order tabs fit inside the supported minimum width`() {
+        val repository = FakeRepository(chaptersResult = Result.success(response((1..6).map { chapter(it) })))
+
+        compactScreen(repository)
+        scrollToControls()
+
+        ChapterFilter.entries.forEach { assertWithinWindow(it.label.uppercase()) }
+        ChapterSort.entries.forEach { assertWithinWindow(it.label.uppercase()) }
     }
 
     /** The controls live in the header item, which auto-scroll may have pushed off screen. */

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ScreensUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ScreensUiTest.kt
@@ -313,7 +313,19 @@ class ScreensUiTest {
 
         compose.onAllNodesWithTag(FictionCardTestTag).onFirst().performClick()
         compose.waitForIdle()
+
+        // Both admin actions live behind a disclosure rather than in the header: each needs a
+        // sentence to be safe to press, which is the test for a housekeeping row over a button.
+        compose.onNodeWithTag(EditFictionButtonTestTag).assertDoesNotExist()
+        compose.onNodeWithTag(ManageFictionTestTag).performScrollTo().assertIsDisplayed()
+        compose.onNodeWithText("MANAGE THIS FICTION").performClick()
+        compose.waitForIdle()
+
         compose.onNodeWithTag(EditFictionButtonTestTag).assertIsDisplayed()
+        compose.onNodeWithText(
+            "DESTROYS THE SHARED CHAPTERS AND EVERY ACCOUNT'S PROGRESS",
+            substring = true,
+        ).assertIsDisplayed()
         compose.onNodeWithTag(DeleteFictionButtonTestTag).performClick()
         compose.onNodeWithText(
             "This permanently deletes the fiction, every chapter and every user's listening progress",


### PR DESCRIPTION
Closes #93. Closes #80.

Fixed together because they meet in the same place: the fiction header was four equal-weight buttons
*and* the widest thing on the narrowest supported window.

## Rank (#93)

`Components.kt` gains `AarisPrimaryAction` / `AarisSecondaryAction` / `AarisActionRow`, with the rule
documented on the first: pick by **how often a control is reached for**, not by how important it
feels. At most one primary per screen.

The fiction header now draws one primary (Resume) and one secondary (Follow). Edit and Delete leave
it entirely for a `Manage this fiction` disclosure, because both need a sentence to be safe to
press — deleting destroys the shared chapters and every account's progress; editing metadata claims
the field against every future refresh of the source. That is the test for rank three: **if it needs
a sentence under it, it is a row, not a button.**

## Compact width (#80)

The screen never derived a `WindowSizeClass`, unlike Settings and the player, while the app promises
720 dp. The cover shrinks to 120 dp at compact width, and both control groups became `FlowRow`s.

## What the bug actually looked like

Not a clipped button — a **squeezed** one. A `Row` measures children against whatever space is left,
so the fourth bulk action kept its bounds and wrapped its own label instead:

```
MARK ALL PLAYED    168 x 40
MARK ALL UNPLAYED  187 x 40
DOWNLOAD NEXT 10   186 x 40
QUEUE UNPLAYED      99 x 55   <- wrapped
```

`assertIsDisplayed` passes on all four, which is why the new test asserts **equal heights across the
group** instead. It fails against the old layout; I checked by reverting the `FlowRow` and watching
it go red.

## Behaviour change to note

`ScreensUiTest` is updated: the admin edit/delete controls are no longer in the header, so the test
opens the disclosure first and now also asserts the destructive consequence is stated before the
control is reachable.

## Verification

`./gradlew clean check --warning-mode fail -Pttsroad.warningsAsErrors=true` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK3sri5jA6ne6tEJnbQaRe