### PR TITLE
Say when a followed serial gains a chapter, until it can be played

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,6 +264,26 @@ all a caller has to be told, and it retires the control rather than offering a r
 patch is sent *before* the image so a save that worked is kept and published even when the image is
 refused afterwards.
 
+### New-chapter notices
+
+`data/ChapterNotifications.kt` + `ui/ChapterNotificationsStateHolder.kt` model the server's
+`notifications` capability. A notice is raised when a chapter is **pulled** and stays open until
+that chapter is **listenable** — the promise and the keeping of it are one row, not two.
+
+Two rules are load-bearing. **`dismissible` and `playable` come off the wire**, never derived from
+the state name: the server answers 409 to a dismissal of a converting chapter, and a client that
+worked the rule out for itself would be a fourth opinion about something the server enforces. And
+the system notification fires **only on the pulled → ready transition** — `newlyReady` returns
+nothing on the first look of a session, because a chapter that was already ready when the app
+started is not news and announcing it would re-announce the backlog on every launch.
+
+An unknown state parses as `Pulled`, never `Ready`: guessing the latter would offer Play for audio
+that may not exist. The holder is hoisted above navigation like the bookmarks one, and for a
+sharper reason — the badge and the notification are driven by a poll that must run whether or not
+the destination was ever opened. `notify` is a `(String, String) -> Unit` supplied by `Main`, so
+nothing in the tree depends on a tray existing; the desktop needs **no push credential**, because
+its OS notification is a rendering of state it already polls.
+
 ### The server queue, which is not the player's queue
 
 `data/ServerQueue.kt` + `ui/ServerQueueStateHolder.kt` model the account's cross-library queue

--- a/docs/MAINTAINER-GUIDE.md
+++ b/docs/MAINTAINER-GUIDE.md
@@ -66,6 +66,7 @@ endpoint 404 becomes a concise unsupported state. Never infer a feature from `ap
 | `epub_upload` | multipart EPUB import, **never** inferred from `fiction_management` | the upload control is hidden; add-by-URL still works |
 | *(no flag)* `POST /fictions/{id}/cover` | cover-art replacement from the metadata editor | additive route — a **404 is the only signal**, and it stops the control being offered |
 | `audiobook_export` | read-only M4B export shelf and resumable save | Audiobooks pane hidden |
+| `notifications` | new-chapter notices held open until the chapter plays; header badge + tray notification | the New destination is hidden entirely |
 | `audio_content_hash` | reserved/parsed contract flag | no UI is promised merely by parsing |
 
 Capability payloads are loose maps by design: unknown keys and non-boolean values cannot make the

--- a/docs/QUALITY-GATE.md
+++ b/docs/QUALITY-GATE.md
@@ -58,6 +58,7 @@ hours. GStreamer linkage, duration, seek, rate and failure paths run separately 
 | fresh install, in-place upgrade, uninstall on supported ABI | Pass — `verify-install-lifecycle.sh` installs two Debian revisions in Ubuntu 24.04, launches both against a mock server, preserves settings/downloads, removes app files and leaves user data |
 | 2FA login | Pass — `LoginTest`, `StateHolderTest` cover missing, wrong and accepted code states and exact wire bodies |
 | older server without capabilities | Pass — `CapabilityDiscoveryTest` maps 404 to baseline; screen/repository tests hide or explain each additive endpoint without breaking library/playback |
+| server refuses an action the client offered | Pass — `ChapterNotificationsStateHolderTest` and `NotificationsScreenUiTest` prove a still-converting chapter offers no dismiss and that the repository treats the server's 409 as a stale list rather than an error |
 | server 1.4.0 | Pass — complete `ServerFixtures` payloads cover login, capabilities, library, chapters and sessions while unknown additive fields are ignored |
 | session expiry/revocation | Pass — `RepositoryTest`, `DevicesRepositoryTest`, `AudioSessionExpiryTest`, `ScreensUiTest` end the session, stop audio, clear protected state and explain the server reason |
 | offline start | Pass — `LibraryCacheTest` restores library/chapters from identity-scoped disk while refresh fails; `DownloadCoordinatorTest` reopens the advertised namespace |

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.isTraySupported
 import dk.perspektiva.ttsroad.desktop.data.Bookmark
+import dk.perspektiva.ttsroad.desktop.data.ChapterNotification
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.di.AppContainer
 import dk.perspektiva.ttsroad.desktop.nav.AppShortcut
@@ -74,6 +75,8 @@ import dk.perspektiva.ttsroad.desktop.nav.shortcutFor
 import dk.perspektiva.ttsroad.desktop.ui.AarisColor
 import dk.perspektiva.ttsroad.desktop.ui.BookmarksScreen
 import dk.perspektiva.ttsroad.desktop.ui.BookmarksStateHolder
+import dk.perspektiva.ttsroad.desktop.ui.ChapterNotificationsStateHolder
+import dk.perspektiva.ttsroad.desktop.ui.NotificationsScreen
 import dk.perspektiva.ttsroad.desktop.ui.ContentMaxWidth
 import dk.perspektiva.ttsroad.desktop.ui.FictionDetailScreen
 import dk.perspektiva.ttsroad.desktop.ui.FictionManagementDialogs
@@ -111,7 +114,17 @@ import kotlinx.coroutines.launch
  * real container so it can be closed when the window closes.
  */
 @Composable
-fun App(container: AppContainer = remember { AppContainer() }) {
+fun App(
+    container: AppContainer = remember { AppContainer() },
+    /**
+     * Raises a system notification. Supplied by `Main`, which owns the tray.
+     *
+     * A `(title, body) -> Unit` rather than the tray state, so nothing in this tree depends on a
+     * tray existing — a desktop session without one still gets the badge and the list, and a
+     * Compose test raises nothing at all.
+     */
+    notify: (String, String) -> Unit = { _, _ -> },
+) {
     val sessionStore = container.sessionStore
     val repository = container.repository
     val playback = container.playback
@@ -153,6 +166,19 @@ fun App(container: AppContainer = remember { AppContainer() }) {
     val serverQueue = rememberStateHolder(repository, playback) {
         ServerQueueStateHolder(repository, playback)
     }
+    // Hoisted, and for the sharpest reason of the four: the header badge and the system
+    // notification are driven by a poll that has to keep running whether or not this destination
+    // has ever been opened. A holder owned by the screen would mean the app only found out about a
+    // new chapter while you were already looking at the list of them.
+    val chapterNotifications = rememberStateHolder(repository) {
+        ChapterNotificationsStateHolder(repository, notify = notify)
+    }
+    val notificationState by chapterNotifications.state.collectAsState()
+    // Started here rather than in the screen, for the same reason it is hoisted here.
+    LaunchedEffect(chapterNotifications, capabilities.notifications) {
+        if (capabilities.notifications) chapterNotifications.start()
+    }
+
     val fictionManagement = rememberStateHolder(repository, cache) {
         FictionManagementStateHolder(repository, cache)
     }
@@ -220,6 +246,7 @@ fun App(container: AppContainer = remember { AppContainer() }) {
             Destination.Settings, Destination.Devices -> settings.refreshCurrentSection()
             Destination.Search -> search.refresh()
             Destination.Bookmarks -> bookmarks.refresh()
+            Destination.Notifications -> chapterNotifications.refresh()
             Destination.Queue -> serverQueue.refresh()
             // A form and a player have nothing a refresh could improve; see `isRefreshable`.
             Destination.Player, is Destination.Reader, is Destination.FictionMetadata -> Unit
@@ -246,6 +273,33 @@ fun App(container: AppContainer = remember { AppContainer() }) {
      * otherwise fetches them: a bookmark can point at a serial the session has never opened, and a
      * failure has to be visible on the screen the click came from.
      */
+    /**
+     * Opens the fiction a notice points at.
+     *
+     * Resolved through the library cache rather than the notice's own payload: the notice carries
+     * enough to *draw* a row, deliberately not enough to be a fiction — one is a message, the other
+     * is the object every screen downstream expects.
+     */
+    fun openNotificationFiction(notification: ChapterNotification) {
+        scope.launch {
+            runCatching { cache.resolveFiction(notification.fiction.id) }
+                .onSuccess { nav.open(Destination.Fiction(it)) }
+        }
+    }
+
+    /** Plays the chapter a ready notice announced, straight from the list. */
+    fun playNotification(notification: ChapterNotification) {
+        scope.launch {
+            val loaded = runCatching { repository.chapters(notification.fiction.id) }.getOrNull()
+                ?: return@launch
+            // Guarded rather than assumed: the list can be a minute old, and a chapter that has
+            // since been excluded would otherwise start the queue at whatever sorted first.
+            if (loaded.chapters.none { it.id == notification.chapter.id }) return@launch
+            playback.playQueue(loaded.chapters, notification.chapter.id, loaded.fiction)
+            nav.open(Destination.Player)
+        }
+    }
+
     fun openBookmark(bookmark: Bookmark) {
         val chapterId = bookmark.chapterId ?: return
         scope.launch {
@@ -385,6 +439,7 @@ fun App(container: AppContainer = remember { AppContainer() }) {
             serverQueue.sessionEnded()
             fictionManagement.sessionEnded()
             fictionMetadata.sessionEnded()
+            chapterNotifications.sessionEnded()
         } else {
             // Cheap, and it is what makes optional UI correct after a restart, where login did
             // not run but a keyring-backed session was restored.
@@ -462,6 +517,8 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                             showBookmarks = capabilities.bookmarks,
                             compact = sizeClass == WindowSizeClass.Compact,
                             queueAvailable = capabilities.queue,
+                            showNotifications = capabilities.notifications && !notificationState.unsupported,
+                            unreadNotifications = notificationState.unread,
                             onBack = { nav.back() },
                             onRefresh = ::refreshCurrentScreen,
                             onSelect = { nav.open(it) },
@@ -579,6 +636,13 @@ fun App(container: AppContainer = remember { AppContainer() }) {
                                     onBack = { nav.back() },
                                 )
 
+                                Destination.Notifications -> NotificationsScreen(
+                                    holder = chapterNotifications,
+                                    repository = repository,
+                                    onPlay = ::playNotification,
+                                    onOpenFiction = ::openNotificationFiction,
+                                )
+
                                 Destination.Bookmarks -> BookmarksScreen(
                                     holder = bookmarks,
                                     onOpen = ::openBookmark,
@@ -680,7 +744,7 @@ fun App(container: AppContainer = remember { AppContainer() }) {
 private val Destination.isRefreshable: Boolean
     get() = when (this) {
         Destination.Library, is Destination.Fiction, Destination.Settings, Destination.Devices,
-        Destination.Bookmarks, Destination.Queue,
+        Destination.Bookmarks, Destination.Queue, Destination.Notifications,
         -> true
         // A form has nothing to refresh into: the fields hold what somebody is halfway through
         // typing, and replacing them with the server's copy is the opposite of what F5 promises.
@@ -701,6 +765,9 @@ private fun HeaderBar(
     compact: Boolean,
     /** Capability-gated: no entry at all on a server with no shared queue. */
     queueAvailable: Boolean,
+    showNotifications: Boolean,
+    /** Everything not dismissed, including chapters still converting. */
+    unreadNotifications: Int,
     onBack: () -> Unit,
     onRefresh: () -> Unit,
     onSelect: (Destination) -> Unit,
@@ -760,6 +827,15 @@ private fun HeaderBar(
                 NavItem("Bookmarks", active = current == Destination.Bookmarks) {
                     onSelect(Destination.Bookmarks)
                 }
+            }
+            if (showNotifications) {
+                NavItem(
+                    // The count is everything unresolved, converting chapters included: the point
+                    // of the feature is that a chapter you were told about stays counted until it
+                    // can actually be played.
+                    if (unreadNotifications > 0) "New ($unreadNotifications)" else "New",
+                    active = current == Destination.Notifications,
+                ) { onSelect(Destination.Notifications) }
             }
             if (queueAvailable) {
                 NavItem("Queue", active = current == Destination.Queue) { onSelect(Destination.Queue) }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -174,9 +174,12 @@ fun App(
         ChapterNotificationsStateHolder(repository, notify = notify)
     }
     val notificationState by chapterNotifications.state.collectAsState()
-    // Started here rather than in the screen, for the same reason it is hoisted here.
-    LaunchedEffect(chapterNotifications, capabilities.notifications) {
-        if (capabilities.notifications) chapterNotifications.start()
+    // Started here rather than in the screen, for the same reason it is hoisted here — and gated on
+    // the *session*, not only on the capability. Discovery is unauthenticated, so a capable server
+    // reports `notifications: true` while the login form is still on screen; without this the poll
+    // would start there and fail every minute against a request that has no credential to send.
+    LaunchedEffect(chapterNotifications, capabilities.notifications, session.isLoggedIn) {
+        if (capabilities.notifications && session.isLoggedIn) chapterNotifications.start()
     }
 
     val fictionManagement = rememberStateHolder(repository, cache) {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/Main.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/Main.kt
@@ -310,7 +310,19 @@ private fun runDesktop(smokeTest: Boolean) {
             }
 
             TtsRoadTheme {
-                App(container)
+                App(
+                    container,
+                    // The desktop needs no push credential: this is a rendering of state the app
+                    // already polls, not a second delivery path. A session with no tray simply
+                    // raises nothing and keeps the badge and the list.
+                    notify = { title, body ->
+                        if (traySupported) {
+                            trayState.sendNotification(
+                                Notification(title, body, Notification.Type.Info),
+                            )
+                        }
+                    },
+                )
             }
             if (smokeTest) {
                 LaunchedEffect(Unit) {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ChapterNotifications.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ChapterNotifications.kt
@@ -1,0 +1,136 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import com.squareup.moshi.Json
+
+/**
+ * Where one reader is in the life of one new chapter.
+ *
+ * The states are the server's own words, and the *first* one is the point of the
+ * feature: a notice is raised the moment a chapter is pulled and stays open while it converts. A
+ * new chapter that cannot be played is a promise, and clearing the notice before the audio lands
+ * loses the only record that the promise was made.
+ *
+ * [Stalled] is not stored anywhere — the server derives it from the chapter's own status, so there
+ * is one answer to "is this converting" rather than two to keep in sync.
+ */
+enum class ChapterNotificationState(val wire: String) {
+    Pulled("pulled"),
+    Stalled("stalled"),
+    Ready("ready"),
+    Dismissed("dismissed"),
+    ;
+
+    companion object {
+        /**
+         * Unknown states resolve to [Pulled], not to null.
+         *
+         * A server newer than this build may name a state it has never heard of, and the safe
+         * reading of "something is happening to this chapter" is the one that keeps the notice on
+         * screen and refuses to dismiss it. Guessing [Ready] would offer a Play button for audio
+         * that may not exist.
+         */
+        fun fromWire(value: String?): ChapterNotificationState =
+            entries.firstOrNull { it.wire == value } ?: Pulled
+    }
+}
+
+data class ChapterNotificationsResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    val notifications: List<ChapterNotification> = emptyList(),
+    /** Everything not dismissed, converting chapters included. What a badge counts. */
+    val unread: Int = 0,
+    val ready: Int = 0,
+)
+
+data class ChapterNotification(
+    val id: Int = 0,
+    private val state: String = "pulled",
+    /**
+     * Whether the server will accept a dismissal, which it answers 409 to while a chapter is still
+     * converting.
+     *
+     * Read from the payload rather than inferred from [state], because it is the one question every
+     * client asks and all three must answer it identically — a client that worked it out for itself
+     * would be a fourth opinion about a rule the server enforces.
+     */
+    val dismissible: Boolean = false,
+    /** Whether the chapter has audio. Never inferred from the notice's own state. */
+    val playable: Boolean = false,
+    @param:Json(name = "created_at") val createdAt: String? = null,
+    @param:Json(name = "ready_at") val readyAt: String? = null,
+    val fiction: NotificationFiction = NotificationFiction(),
+    val chapter: NotificationChapter = NotificationChapter(),
+) {
+    val presentation: ChapterNotificationState get() = ChapterNotificationState.fromWire(state)
+}
+
+data class NotificationFiction(
+    val id: Int = 0,
+    val title: String = "Untitled",
+    val slug: String? = null,
+    @param:Json(name = "cover_image_url") val coverImageUrl: String? = null,
+)
+
+data class NotificationChapter(
+    val id: Int = 0,
+    val title: String = "Untitled",
+    @param:Json(name = "chapter_number") val chapterNumber: Int? = null,
+    val status: String? = null,
+    /**
+     * Conversion percentage while a chapter is still being narrated, null once it is done.
+     *
+     * Null rather than 100 at the end, so a row that stopped updating cannot read as one still
+     * running.
+     */
+    @param:Json(name = "tts_progress") val ttsProgress: Int? = null,
+)
+
+/** One line for a row: "Chapter 412 · converting 62%", or what went wrong instead. */
+fun ChapterNotification.detailLabel(): String {
+    val chapterLabel = chapter.chapterNumber?.let { "Chapter $it" } ?: chapter.title
+    val state = when (presentation) {
+        ChapterNotificationState.Ready -> "ready to listen"
+        ChapterNotificationState.Stalled -> "conversion failed"
+        ChapterNotificationState.Dismissed -> "dismissed"
+        ChapterNotificationState.Pulled ->
+            chapter.ttsProgress?.let { "converting $it%" } ?: "converting"
+    }
+    return "$chapterLabel  ·  $state"
+}
+
+/**
+ * Which notices have *become* ready since [alreadySeen], and the set to remember next time.
+ *
+ * Pure, because the interesting rule has nothing to do with the network: the first look of a
+ * session announces **nothing**. A chapter that was already ready when the app started is not news
+ * — the app was closed when it happened — and without this every launch would re-announce the whole
+ * backlog. `alreadySeen` is null on that first look and a set on every one after.
+ */
+fun newlyReady(
+    notifications: List<ChapterNotification>,
+    alreadySeen: Set<Int>?,
+): Pair<List<ChapterNotification>, Set<Int>> {
+    val readyNow = notifications.filter { it.presentation == ChapterNotificationState.Ready }
+    val ids = readyNow.map { it.id }.toSet()
+    if (alreadySeen == null) return emptyList<ChapterNotification>() to ids
+    return readyNow.filter { it.id !in alreadySeen } to ids
+}
+
+/**
+ * What the desktop should raise for a batch that just became ready, or null for nothing.
+ *
+ * Collapsed into one line above a single chapter, because a serial converting a backlog would
+ * otherwise stack a dozen system notifications at once — the noise that gets a feature muted.
+ */
+fun readyNotificationText(fresh: List<ChapterNotification>): Pair<String, String>? = when {
+    fresh.isEmpty() -> null
+    fresh.size == 1 -> {
+        val item = fresh.single()
+        item.fiction.title to "${item.chapter.title} is ready to listen"
+    }
+    else -> {
+        val serials = fresh.map { it.fiction.title }.distinct()
+        val where = if (serials.size == 1) serials.single() else "${serials.size} serials"
+        "${fresh.size} chapters ready" to "New audio in $where"
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -282,6 +282,27 @@ interface TtsRoadRepository {
     suspend fun updateServerQueue(request: ServerQueueRequest): ServerQueueResponse?
 
     /**
+     * New-chapter notices, or **null on a server that has none of this**.
+     *
+     * Same rule as [serverQueue]: "nothing new" is an answer worth drawing, "this server cannot
+     * tell you about new chapters" is a surface to hide.
+     */
+    suspend fun chapterNotifications(): ChapterNotificationsResponse? = null
+
+    /**
+     * Clears one notice. Answers false when the server refused because the chapter cannot be
+     * played yet.
+     *
+     * The 409 is caught here rather than thrown, because it is not a failure — it is the server
+     * enforcing the rule this whole feature is built on, and it reaches a caller that already knows
+     * not to have offered the control. Everything else still propagates.
+     */
+    suspend fun dismissChapterNotification(notificationId: Int): Boolean = false
+
+    /** Clears every notice whose chapter plays, leaving the converting ones. */
+    suspend fun dismissReadChapterNotifications(): Boolean = false
+
+    /**
      * Record a listening position and try to get it to the server.
      *
      * Queued to disk with a timestamp *before* being sent. That ordering is the fix for #36: if the
@@ -625,6 +646,26 @@ class RetrofitTtsRoadRepository(
         ifEndpointExists { it.deleteBookmark(bookmarkId) } != null
 
     override suspend fun serverQueue(): ServerQueueResponse? = ifEndpointExists { it.queue() }
+
+    override suspend fun chapterNotifications(): ChapterNotificationsResponse? =
+        ifEndpointExists { it.chapterNotifications() }
+
+    override suspend fun dismissChapterNotification(notificationId: Int): Boolean = try {
+        withAuthorizedApi { it.dismissChapterNotification(notificationId) }
+        true
+    } catch (e: HttpException) {
+        // 409: still converting, which the caller should not have offered but the server refuses
+        // regardless. 404: somebody else's, or already gone. Neither is worth an error dialog —
+        // both mean "the list you are looking at is out of date", and a refresh says so.
+        if (e.code() == 409 || e.code() == 404) false else throw e
+    }
+
+    override suspend fun dismissReadChapterNotifications(): Boolean = try {
+        withAuthorizedApi { it.dismissReadChapterNotifications() }
+        true
+    } catch (e: HttpException) {
+        if (e.code() == 404) false else throw e
+    }
 
     override suspend fun updateServerQueue(request: ServerQueueRequest): ServerQueueResponse? =
         ifEndpointExists { it.updateQueue(request) }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
@@ -71,6 +71,14 @@ data class ServerCapabilities(
     val queue: Boolean = false,
     /** Read-only list/download surface for finished whole-fiction M4B exports. */
     val audiobookExport: Boolean = false,
+    /**
+     * New-chapter notices for followed serials, held open until the chapter is listenable.
+     *
+     * Says nothing about push: the backend advertises this on a deployment with no FCM or VAPID
+     * credential at all, because the list is polled. The desktop needs no push credential either —
+     * its system notification is a rendering of state it already has.
+     */
+    val notifications: Boolean = false,
     val maxChaptersPerPage: Int? = null,
     /**
      * How many items `/playback/sync` accepts in one batch.
@@ -116,6 +124,7 @@ data class ServerCapabilities(
             deviceManagement = response.capabilities.flag("device_management"),
             queue = response.capabilities.flag("queue"),
             audiobookExport = response.capabilities.flag("audiobook_export"),
+            notifications = response.capabilities.flag("notifications"),
             maxChaptersPerPage = response.limits.intLimit("max_chapters_per_page"),
             maxPlaybackSyncItems = response.limits.intLimit("max_playback_sync_items"),
             maxEpubBytes = response.limits.longLimit("max_epub_bytes"),

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -212,6 +212,29 @@ interface TtsRoadApi {
      * The account's cross-library queue. Advertised as the `queue` capability; 404 on an older
      * server, which is the only signal available because the endpoint is additive.
      */
+    /**
+     * New-chapter notices for the serials this account follows.
+     *
+     * Dismissed rows are deliberately not requested: the surface is "what is still coming", and a
+     * list that included everything ever cleared would need paging to say the same thing.
+     */
+    @GET("api/mobile/notifications")
+    suspend fun chapterNotifications(): ChapterNotificationsResponse
+
+    /**
+     * Clears one notice.
+     *
+     * Answers **409** while the chapter is still converting. That is the contract, not an edge
+     * case: the notice is the only record that the chapter is coming, so the server refuses to let
+     * a client throw it away early regardless of what that client drew.
+     */
+    @POST("api/mobile/notifications/{notification_id}/dismiss")
+    suspend fun dismissChapterNotification(@Path("notification_id") notificationId: Int)
+
+    /** Clears everything that plays, and deliberately nothing that does not. */
+    @POST("api/mobile/notifications/dismiss-read")
+    suspend fun dismissReadChapterNotifications()
+
     @GET("api/mobile/queue")
     suspend fun queue(): ServerQueueResponse
 

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/nav/AppNavigation.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/nav/AppNavigation.kt
@@ -71,6 +71,15 @@ sealed interface Destination {
      */
     data object Queue : Destination
 
+    /**
+     * New chapters on the serials this account follows.
+     *
+     * Carries nothing, and its holder is hoisted for a sharper reason than the queue's: the badge
+     * on the header and the system notification are both driven by state that has to keep polling
+     * whether or not this destination has ever been opened.
+     */
+    data object Notifications : Destination
+
     data object Settings : Destination
 
     data object Devices : Destination
@@ -94,6 +103,7 @@ val Destination.key: String
         Destination.Search -> "Search"
         Destination.Bookmarks -> "Bookmarks"
         Destination.Queue -> "Queue"
+        Destination.Notifications -> "Notifications"
         Destination.Settings -> "Settings"
         Destination.Devices -> "Devices"
     }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterNotificationsStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterNotificationsStateHolder.kt
@@ -1,0 +1,204 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.data.ChapterNotification
+import dk.perspektiva.ttsroad.desktop.data.ChapterNotificationState
+import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
+import dk.perspektiva.ttsroad.desktop.data.newlyReady
+import dk.perspektiva.ttsroad.desktop.data.readyNotificationText
+import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+data class ChapterNotificationsUiState(
+    val notifications: List<ChapterNotification> = emptyList(),
+    /** Everything not dismissed, converting chapters included. What the badge counts. */
+    val unread: Int = 0,
+    val ready: Int = 0,
+    val loading: Boolean = false,
+    val error: String? = null,
+    /**
+     * The server answered 404 for a route its capability advertised.
+     *
+     * Kept apart from [error] for the reason the bookmarks holder keeps them apart: one is worth a
+     * Retry and the other never will be.
+     */
+    val unsupported: Boolean = false,
+    val loaded: Boolean = false,
+) {
+    val isEmpty: Boolean get() = notifications.isEmpty()
+
+    /** Whether "clear the ready ones" would do anything. */
+    val hasClearable: Boolean get() = ready > 0
+}
+
+/**
+ * New-chapter notices, and the one transition worth interrupting somebody for.
+ *
+ * A notice is raised when a chapter is pulled and stays open until it can be played. That means
+ * this holder draws two very different things from one list, and the rule it must not get wrong is
+ * **which of them may be dismissed**: [ChapterNotification.dismissible] comes from the server,
+ * which answers 409 to the rest. Nothing here re-derives it — a client that worked the rule out for
+ * itself would be a fourth opinion about something the server enforces.
+ *
+ * The system notification fires **only on the pulled → ready transition**, never on arrival. Being
+ * told twice about one chapter — once when it appears and once when it plays — is the noise that
+ * makes people mute a feature like this, and the pulled state is already in the badge and the list,
+ * which are surfaces somebody looks at rather than surfaces that interrupt.
+ *
+ * Polled rather than pushed. The desktop therefore needs no push credential at all: its OS
+ * notification is a rendering of state it already has, unlike the phone's.
+ */
+class ChapterNotificationsStateHolder(
+    private val repository: TtsRoadRepository,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+    /**
+     * Raises a system notification. Substituted in a test, which has no tray and no desktop.
+     *
+     * A `(title, body) -> Unit` rather than the tray state itself, so nothing about this holder
+     * depends on a Compose window existing.
+     */
+    private val notify: (String, String) -> Unit = { _, _ -> },
+    private val pollIntervalMs: Long = DefaultPollIntervalMs,
+) : StateHolder(dispatcher) {
+    private val _state = MutableStateFlow(ChapterNotificationsUiState())
+    val state: StateFlow<ChapterNotificationsUiState> = _state.asStateFlow()
+
+    private var pollJob: Job? = null
+    private var actionJob: Job? = null
+
+    /**
+     * Which notices were already `ready` last time we looked.
+     *
+     * Null until the first successful load, and that is load-bearing: a chapter that was already
+     * ready when the app started is not news — the app was closed when it happened — so the first
+     * pass seeds this and announces nothing. Without it every launch would re-announce the backlog.
+     */
+    private var readySeen: Set<Int>? = null
+
+    /** Starts the poll loop. Idempotent, so a screen entering twice does not double the requests. */
+    fun start() {
+        if (pollJob?.isActive == true) return
+        pollJob = scope.launch {
+            while (isActive) {
+                load()
+                delay(pollIntervalMs)
+            }
+        }
+    }
+
+    fun refresh() {
+        actionJob?.cancel()
+        actionJob = scope.launch { load() }
+    }
+
+    private suspend fun load() {
+        _state.update { it.copy(loading = !it.loaded, error = null) }
+        runCatching { repository.chapterNotifications() }
+            .onSuccess { response ->
+                if (response == null) {
+                    // The capability said yes and the route said 404. Hide the surface rather than
+                    // show an empty list nothing can ever fill.
+                    _state.update {
+                        it.copy(loading = false, unsupported = true, loaded = true, notifications = emptyList())
+                    }
+                    return@onSuccess
+                }
+                val (fresh, seen) = newlyReady(response.notifications, readySeen)
+                readySeen = seen
+                _state.update {
+                    it.copy(
+                        notifications = response.notifications,
+                        unread = response.unread,
+                        ready = response.ready,
+                        loading = false,
+                        error = null,
+                        unsupported = false,
+                        loaded = true,
+                    )
+                }
+                readyNotificationText(fresh)?.let { (title, body) -> notify(title, body) }
+            }
+            .onFailure { failure ->
+                _state.update {
+                    // Content is kept: a poll that failed says nothing about the notices already
+                    // on screen, and blanking them would lose the very thing being waited for.
+                    it.copy(loading = false, error = userFacingMessage(failure, "Could not check for new chapters"))
+                }
+            }
+    }
+
+    /**
+     * Clears one notice.
+     *
+     * Refuses locally for a chapter that cannot be played, which the server would refuse anyway —
+     * the check is here so a stale list cannot turn into a request that looks like it worked.
+     */
+    fun dismiss(notification: ChapterNotification) {
+        if (!notification.dismissible) return
+        actionJob?.cancel()
+        actionJob = scope.launch {
+            runCatching { repository.dismissChapterNotification(notification.id) }
+                .onSuccess { load() }
+                .onFailure { failure ->
+                    _state.update {
+                        it.copy(error = userFacingMessage(failure, "Could not clear that notice"))
+                    }
+                }
+        }
+    }
+
+    fun dismissRead() {
+        if (!_state.value.hasClearable) return
+        actionJob?.cancel()
+        actionJob = scope.launch {
+            runCatching { repository.dismissReadChapterNotifications() }
+                .onSuccess { load() }
+                .onFailure { failure ->
+                    _state.update {
+                        it.copy(error = userFacingMessage(failure, "Could not clear those notices"))
+                    }
+                }
+        }
+    }
+
+    /**
+     * Empties everything on sign-out, including what has been seen.
+     *
+     * The seen set has to go with it: notices belong to an account, and keeping it would let the
+     * next account's already-ready chapters arrive silently — or, worse, announce the previous
+     * account's.
+     */
+    fun sessionEnded() {
+        pollJob?.cancel()
+        actionJob?.cancel()
+        readySeen = null
+        _state.value = ChapterNotificationsUiState()
+    }
+
+    override fun onCleared() {
+        pollJob = null
+        actionJob = null
+    }
+
+    companion object {
+        /**
+         * A minute.
+         *
+         * Well inside how long a chapter takes to convert, so nothing is lost by asking rather than
+         * being pushed — and the request is one small JSON list, not a library refresh.
+         */
+        const val DefaultPollIntervalMs: Long = 60_000L
+
+        /** Rows worth drawing: dismissed ones are not requested, but a stale list can hold one. */
+        fun visible(notifications: List<ChapterNotification>): List<ChapterNotification> =
+            notifications.filter { it.presentation != ChapterNotificationState.Dismissed }
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/NotificationsScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/NotificationsScreen.kt
@@ -1,0 +1,181 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.data.ChapterNotification
+import dk.perspektiva.ttsroad.desktop.data.ChapterNotificationState
+import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
+import dk.perspektiva.ttsroad.desktop.data.detailLabel
+
+const val NotificationsListTestTag: String = "notificationsList"
+const val NotificationRowTestTag: String = "notificationRow"
+const val NotificationDismissTestTag: String = "notificationDismiss"
+const val NotificationPlayTestTag: String = "notificationPlay"
+const val ClearReadNotificationsTestTag: String = "clearReadNotifications"
+
+/**
+ * New chapters on the serials this account follows, from pulled to playable.
+ *
+ * The screen draws two things that look similar and mean opposite things — a chapter that is coming
+ * and a chapter that has arrived — so the state is spelled out on every row rather than left to a
+ * colour. A converting row deliberately offers **no** dismiss: the server refuses it with a 409,
+ * and drawing a control that cannot succeed is worse than drawing none.
+ */
+@Composable
+fun NotificationsScreen(
+    holder: ChapterNotificationsStateHolder,
+    repository: TtsRoadRepository,
+    onPlay: (ChapterNotification) -> Unit,
+    onOpenFiction: (ChapterNotification) -> Unit,
+) {
+    val state by holder.state.collectAsState()
+    LaunchedEffect(holder) { holder.start() }
+
+    Box(Modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .widthIn(max = ContentMaxWidth)
+                .fillMaxSize()
+                .testTag(NotificationsListTestTag),
+            contentPadding = PaddingValues(PageGutter),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            item(key = "header") {
+                Column {
+                    SectionTitle("08", "New chapters")
+                    Spacer(Modifier.height(10.dp))
+                    MetaText(
+                        "A chapter stays here from the moment it is pulled until it can be played.",
+                        color = AarisColor.Dim,
+                    )
+                    if (state.hasClearable) {
+                        Spacer(Modifier.height(14.dp))
+                        // Says "ready", not "all". The converting rows are the ones being waited
+                        // for, and a bulk action that swallowed them would make this untrustworthy
+                        // exactly once.
+                        AarisSecondaryAction(
+                            label = "Clear the ${state.ready} ready",
+                            onClick = holder::dismissRead,
+                            modifier = Modifier.testTag(ClearReadNotificationsTestTag),
+                        )
+                    }
+                    state.error?.let {
+                        Spacer(Modifier.height(12.dp))
+                        Text(it, color = MaterialTheme.colorScheme.error)
+                    }
+                    Spacer(Modifier.height(10.dp))
+                }
+            }
+
+            val rows = ChapterNotificationsStateHolder.visible(state.notifications)
+            when {
+                state.unsupported -> item(key = "unsupported") {
+                    EmptyState(
+                        "This server cannot report new chapters",
+                        "Following still works; there is just nothing to be told with.",
+                    )
+                }
+
+                !state.loaded && state.loading -> item(key = "loading") { CenterProgress() }
+
+                rows.isEmpty() -> item(key = "empty") {
+                    EmptyState(
+                        "Nothing new",
+                        "Follow a serial and its next chapter will appear here while it converts.",
+                    )
+                }
+
+                else -> items(rows, key = { it.id }) { notification ->
+                    NotificationRow(
+                        notification = notification,
+                        repository = repository,
+                        onPlay = { onPlay(notification) },
+                        onOpen = { onOpenFiction(notification) },
+                        onDismiss = { holder.dismiss(notification) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun NotificationRow(
+    notification: ChapterNotification,
+    repository: TtsRoadRepository,
+    onPlay: () -> Unit,
+    onOpen: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AarisCard(modifier = Modifier.fillMaxWidth().testTag(NotificationRowTestTag), onClick = onOpen) {
+        Row(
+            Modifier.fillMaxWidth().padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            CoverImage(
+                notification.fiction.title,
+                notification.fiction.coverImageUrl?.let(repository::resolveUrl),
+                Modifier.width(44.dp).aspectRatio(2f / 3f),
+            )
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    notification.fiction.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = AarisColor.Ink,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                MetaText(
+                    notification.detailLabel(),
+                    color = when (notification.presentation) {
+                        ChapterNotificationState.Ready -> AarisColor.Accent
+                        ChapterNotificationState.Stalled -> AarisColor.Warning
+                        else -> AarisColor.Muted
+                    },
+                )
+            }
+            // Only a chapter that actually has audio offers Play, and only the server's own
+            // `dismissible` offers Dismiss. Neither is inferred from the state name.
+            if (notification.playable) {
+                AarisSecondaryAction(
+                    label = "Play",
+                    onClick = onPlay,
+                    modifier = Modifier.testTag(NotificationPlayTestTag),
+                )
+            }
+            if (notification.dismissible) {
+                AarisSecondaryAction(
+                    label = "Dismiss",
+                    onClick = onDismiss,
+                    modifier = Modifier.testTag(NotificationDismissTestTag),
+                )
+            }
+        }
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -4,6 +4,7 @@ import dk.perspektiva.ttsroad.desktop.data.Bookmark
 import dk.perspektiva.ttsroad.desktop.data.BookmarkCreateRequest
 import dk.perspektiva.ttsroad.desktop.data.BookmarkPatchRequest
 import dk.perspektiva.ttsroad.desktop.data.AudiobookExportsResponse
+import dk.perspektiva.ttsroad.desktop.data.ChapterNotificationsResponse
 import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
 import dk.perspektiva.ttsroad.desktop.data.CoverUploadResult
 import dk.perspektiva.ttsroad.desktop.data.ChaptersResponse
@@ -76,6 +77,8 @@ open class FakeRepository(
     var uploadCoverResult: Result<CoverUploadResult> =
         Result.success(CoverUploadResult.Saved(FictionSummary(id = 1, title = "Updated"))),
     var audiobookExportsResult: Result<AudiobookExportsResponse?> = Result.success(null),
+    /** Null models a server whose notifications route answers 404. */
+    var chapterNotificationsResult: Result<ChapterNotificationsResponse?> = Result.success(null),
 ) : TtsRoadRepository {
     var loginCalls: Int = 0
         private set
@@ -134,6 +137,10 @@ open class FakeRepository(
     val updatedFictions: MutableList<Pair<Int, FictionUpdateRequest>> = mutableListOf()
     val deletedFictions: MutableList<Int> = mutableListOf()
     val uploadedEpubs: MutableList<Pair<java.io.File, String?>> = mutableListOf()
+
+    /** Notification ids passed to [dismissChapterNotification], in order. */
+    val dismissedNotifications: MutableList<Int> = mutableListOf()
+    var dismissReadCalls: Int = 0
 
     /** `(fictionId, file)` pairs passed to [uploadFictionCover], in order. */
     val uploadedCovers: MutableList<Pair<Int, java.io.File>> = mutableListOf()
@@ -221,6 +228,19 @@ open class FakeRepository(
     override suspend fun uploadEpub(file: java.io.File, voice: String?): FictionSummary {
         uploadedEpubs += file to voice
         return uploadEpubResult.getOrThrow()
+    }
+
+    override suspend fun chapterNotifications(): ChapterNotificationsResponse? =
+        chapterNotificationsResult.getOrThrow()
+
+    override suspend fun dismissChapterNotification(notificationId: Int): Boolean {
+        dismissedNotifications += notificationId
+        return true
+    }
+
+    override suspend fun dismissReadChapterNotifications(): Boolean {
+        dismissReadCalls++
+        return true
     }
 
     override suspend fun uploadFictionCover(fictionId: Int, file: java.io.File): CoverUploadResult {

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -141,6 +141,7 @@ open class FakeRepository(
     /** Notification ids passed to [dismissChapterNotification], in order. */
     val dismissedNotifications: MutableList<Int> = mutableListOf()
     var dismissReadCalls: Int = 0
+    var chapterNotificationCalls: Int = 0
 
     /** `(fictionId, file)` pairs passed to [uploadFictionCover], in order. */
     val uploadedCovers: MutableList<Pair<Int, java.io.File>> = mutableListOf()
@@ -230,8 +231,10 @@ open class FakeRepository(
         return uploadEpubResult.getOrThrow()
     }
 
-    override suspend fun chapterNotifications(): ChapterNotificationsResponse? =
-        chapterNotificationsResult.getOrThrow()
+    override suspend fun chapterNotifications(): ChapterNotificationsResponse? {
+        chapterNotificationCalls++
+        return chapterNotificationsResult.getOrThrow()
+    }
 
     override suspend fun dismissChapterNotification(notificationId: Int): Boolean {
         dismissedNotifications += notificationId

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterNotificationsStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterNotificationsStateHolderTest.kt
@@ -209,6 +209,50 @@ class ChapterNotificationsStateHolderTest {
         holder.clear()
     }
 
+    @Test
+    fun `starting twice does not double the polling`() = runTest {
+        // The screen starts it on entry and App starts it on capability discovery; both are correct
+        // and neither should mean two requests a minute.
+        val repository = FakeRepository().apply {
+            chapterNotificationsResult = Result.success(response(notice(1, "pulled")))
+        }
+        val holder = ChapterNotificationsStateHolder(
+            repository,
+            UnconfinedTestDispatcher(testScheduler),
+            pollIntervalMs = 10_000,
+        )
+
+        holder.start()
+        holder.start()
+        runCurrent()
+
+        assertEquals(1, repository.chapterNotificationCalls)
+        holder.clear()
+    }
+
+    @Test
+    fun `signing out stops the poll rather than leaving it running`() = runTest {
+        val repository = FakeRepository().apply {
+            chapterNotificationsResult = Result.success(response(notice(1, "pulled")))
+        }
+        val holder = ChapterNotificationsStateHolder(
+            repository,
+            UnconfinedTestDispatcher(testScheduler),
+            pollIntervalMs = 10_000,
+        )
+        holder.start()
+        runCurrent()
+        val whileSignedIn = repository.chapterNotificationCalls
+
+        holder.sessionEnded()
+        testScheduler.advanceTimeBy(60_000)
+        runCurrent()
+
+        // A request with no credential would fail every interval behind the login screen.
+        assertEquals(whileSignedIn, repository.chapterNotificationCalls)
+        holder.clear()
+    }
+
     // --- the pure rules -------------------------------------------------------------------------
 
     @Test

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterNotificationsStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterNotificationsStateHolderTest.kt
@@ -1,0 +1,254 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.data.ChapterNotification
+import dk.perspektiva.ttsroad.desktop.data.ChapterNotificationState
+import dk.perspektiva.ttsroad.desktop.data.ChapterNotificationsResponse
+import dk.perspektiva.ttsroad.desktop.data.NotificationChapter
+import dk.perspektiva.ttsroad.desktop.data.NotificationFiction
+import dk.perspektiva.ttsroad.desktop.data.detailLabel
+import dk.perspektiva.ttsroad.desktop.data.newlyReady
+import dk.perspektiva.ttsroad.desktop.data.readyNotificationText
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * A notice is raised when a chapter is pulled and stays open until it plays.
+ *
+ * Two rules carry the feature and both are asserted as refusals: a converting chapter must not be
+ * dismissible, and the system notification must fire **only** on the pulled → ready transition —
+ * never on arrival, and never for a chapter that was already ready when the app started.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChapterNotificationsStateHolderTest {
+
+    private fun notice(
+        id: Int,
+        state: String,
+        dismissible: Boolean = state == "ready",
+        playable: Boolean = state == "ready",
+        fictionTitle: String = "A Test Serial",
+        chapterTitle: String = "Chapter $id",
+        progress: Int? = null,
+    ) = ChapterNotification(
+        id = id,
+        state = state,
+        dismissible = dismissible,
+        playable = playable,
+        fiction = NotificationFiction(id = 7, title = fictionTitle),
+        chapter = NotificationChapter(id = 100 + id, title = chapterTitle, chapterNumber = id, ttsProgress = progress),
+    )
+
+    private fun response(vararg notifications: ChapterNotification) = ChapterNotificationsResponse(
+        notifications = notifications.toList(),
+        unread = notifications.count { it.presentation != ChapterNotificationState.Dismissed },
+        ready = notifications.count { it.presentation == ChapterNotificationState.Ready },
+    )
+
+    private class Announcements {
+        val raised: MutableList<Pair<String, String>> = mutableListOf()
+        operator fun invoke(title: String, body: String) {
+            raised += title to body
+        }
+    }
+
+    @Test
+    fun `a chapter already ready at startup is not announced`() = runTest {
+        // The app was closed when it happened. Announcing on the first look would re-announce the
+        // whole backlog on every launch, which is how a feature like this gets muted.
+        val announcements = Announcements()
+        val repository = FakeRepository().apply {
+            chapterNotificationsResult = Result.success(response(notice(1, "ready")))
+        }
+        val holder = ChapterNotificationsStateHolder(
+            repository,
+            UnconfinedTestDispatcher(testScheduler),
+            notify = announcements::invoke,
+        )
+
+        holder.refresh()
+        runCurrent()
+
+        assertEquals(1, holder.state.value.unread)
+        assertTrue(announcements.raised.isEmpty(), "raised ${announcements.raised}")
+        holder.clear()
+    }
+
+    @Test
+    fun `becoming ready announces exactly once`() = runTest {
+        val announcements = Announcements()
+        val repository = FakeRepository().apply {
+            chapterNotificationsResult = Result.success(response(notice(1, "pulled", progress = 40)))
+        }
+        val holder = ChapterNotificationsStateHolder(
+            repository,
+            UnconfinedTestDispatcher(testScheduler),
+            notify = announcements::invoke,
+        )
+
+        holder.refresh()
+        runCurrent()
+        // Arrival is deliberately silent: the badge and the list already carry it.
+        assertTrue(announcements.raised.isEmpty())
+
+        repository.chapterNotificationsResult = Result.success(response(notice(1, "ready")))
+        holder.refresh()
+        runCurrent()
+        assertEquals(1, announcements.raised.size)
+
+        // Polling again must not re-announce what is already known to be ready.
+        holder.refresh()
+        runCurrent()
+        assertEquals(1, announcements.raised.size, "raised ${announcements.raised}")
+        holder.clear()
+    }
+
+    @Test
+    fun `a converting chapter cannot be dismissed`() = runTest {
+        val repository = FakeRepository().apply {
+            chapterNotificationsResult = Result.success(response(notice(1, "pulled")))
+        }
+        val holder = ChapterNotificationsStateHolder(repository, UnconfinedTestDispatcher(testScheduler))
+        holder.refresh()
+        runCurrent()
+
+        holder.dismiss(holder.state.value.notifications.single())
+        runCurrent()
+
+        // Refused before it is sent. The server answers 409 anyway, but a request that looks like
+        // it worked against a stale list is worse than no request.
+        assertTrue(repository.dismissedNotifications.isEmpty())
+        assertEquals(1, holder.state.value.unread)
+        holder.clear()
+    }
+
+    @Test
+    fun `clearing the read ones leaves what is still converting`() = runTest {
+        val repository = FakeRepository().apply {
+            chapterNotificationsResult = Result.success(
+                response(notice(1, "ready"), notice(2, "pulled")),
+            )
+        }
+        val holder = ChapterNotificationsStateHolder(repository, UnconfinedTestDispatcher(testScheduler))
+        holder.refresh()
+        runCurrent()
+
+        assertTrue(holder.state.value.hasClearable)
+        repository.chapterNotificationsResult = Result.success(response(notice(2, "pulled")))
+        holder.dismissRead()
+        runCurrent()
+
+        assertEquals(1, repository.dismissReadCalls)
+        assertContentEquals(listOf(2), holder.state.value.notifications.map { it.id })
+        holder.clear()
+    }
+
+    @Test
+    fun `a server that answers 404 hides the surface rather than showing an empty list`() = runTest {
+        val repository = FakeRepository().apply { chapterNotificationsResult = Result.success(null) }
+        val holder = ChapterNotificationsStateHolder(repository, UnconfinedTestDispatcher(testScheduler))
+
+        holder.refresh()
+        runCurrent()
+
+        assertTrue(holder.state.value.unsupported)
+        assertTrue(holder.state.value.isEmpty)
+        assertNull(holder.state.value.error, "an absent feature is not an error worth retrying")
+        holder.clear()
+    }
+
+    @Test
+    fun `a failed poll keeps what is on screen`() = runTest {
+        val repository = FakeRepository().apply {
+            chapterNotificationsResult = Result.success(response(notice(1, "pulled")))
+        }
+        val holder = ChapterNotificationsStateHolder(repository, UnconfinedTestDispatcher(testScheduler))
+        holder.refresh()
+        runCurrent()
+
+        repository.chapterNotificationsResult = Result.failure(java.io.IOException("offline"))
+        holder.refresh()
+        runCurrent()
+
+        // Blanking the list would lose the very thing being waited for.
+        assertEquals(1, holder.state.value.notifications.size)
+        assertNotNull(holder.state.value.error)
+        holder.clear()
+    }
+
+    @Test
+    fun `signing out forgets what was seen as well as what was shown`() = runTest {
+        val announcements = Announcements()
+        val repository = FakeRepository().apply {
+            chapterNotificationsResult = Result.success(response(notice(1, "ready")))
+        }
+        val holder = ChapterNotificationsStateHolder(
+            repository,
+            UnconfinedTestDispatcher(testScheduler),
+            notify = announcements::invoke,
+        )
+        holder.refresh()
+        runCurrent()
+
+        holder.sessionEnded()
+        assertTrue(holder.state.value.isEmpty)
+
+        // The next account starts from a clean seed: their already-ready chapters are not news
+        // either, and the previous account's certainly are not.
+        holder.refresh()
+        runCurrent()
+        assertTrue(announcements.raised.isEmpty(), "raised ${announcements.raised}")
+        holder.clear()
+    }
+
+    // --- the pure rules -------------------------------------------------------------------------
+
+    @Test
+    fun `an unknown state reads as still converting, never as ready`() {
+        // Guessing Ready would offer a Play button for audio that may not exist.
+        assertEquals(ChapterNotificationState.Pulled, ChapterNotificationState.fromWire("something-new"))
+        assertEquals(ChapterNotificationState.Pulled, ChapterNotificationState.fromWire(null))
+        assertEquals(ChapterNotificationState.Stalled, ChapterNotificationState.fromWire("stalled"))
+    }
+
+    @Test
+    fun `the first look seeds and announces nothing`() {
+        val ready = listOf(notice(1, "ready"), notice(2, "ready"))
+
+        val (fresh, seen) = newlyReady(ready, alreadySeen = null)
+
+        assertTrue(fresh.isEmpty())
+        assertEquals(setOf(1, 2), seen)
+    }
+
+    @Test
+    fun `several chapters at once collapse into one line`() {
+        // A serial converting a backlog would otherwise stack a dozen system notifications.
+        val single = readyNotificationText(listOf(notice(1, "ready")))
+        assertEquals("A Test Serial", single?.first)
+
+        val many = readyNotificationText(
+            listOf(notice(1, "ready"), notice(2, "ready", fictionTitle = "Another Serial")),
+        )
+        assertEquals("2 chapters ready", many?.first)
+        assertEquals("New audio in 2 serials", many?.second)
+
+        assertNull(readyNotificationText(emptyList()))
+    }
+
+    @Test
+    fun `a converting row says how far it has got`() {
+        assertEquals("Chapter 1  ·  converting 62%", notice(1, "pulled", progress = 62).detailLabel())
+        assertEquals("Chapter 1  ·  converting", notice(1, "pulled").detailLabel())
+        assertEquals("Chapter 1  ·  ready to listen", notice(1, "ready").detailLabel())
+        assertEquals("Chapter 1  ·  conversion failed", notice(1, "stalled").detailLabel())
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/NotificationsScreenUiTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/NotificationsScreenUiTest.kt
@@ -1,0 +1,99 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.data.ChapterNotification
+import dk.perspektiva.ttsroad.desktop.data.ChapterNotificationsResponse
+import dk.perspektiva.ttsroad.desktop.data.NotificationChapter
+import dk.perspektiva.ttsroad.desktop.data.NotificationFiction
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * The screen draws two things that look alike and mean opposite things.
+ *
+ * A chapter that is coming and a chapter that has arrived sit in the same list, so what is asserted
+ * here is mostly which controls each one is allowed to offer.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NotificationsScreenUiTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private fun notice(id: Int, state: String) = ChapterNotification(
+        id = id,
+        state = state,
+        dismissible = state == "ready",
+        playable = state == "ready",
+        fiction = NotificationFiction(id = 7, title = "A Test Serial"),
+        chapter = NotificationChapter(id = 100 + id, title = "Chapter $id", chapterNumber = id, ttsProgress = 62),
+    )
+
+    private fun screen(vararg notifications: ChapterNotification): FakeRepository {
+        val repository = FakeRepository().apply {
+            chapterNotificationsResult = Result.success(
+                ChapterNotificationsResponse(
+                    notifications = notifications.toList(),
+                    unread = notifications.size,
+                    ready = notifications.count { it.playable },
+                ),
+            )
+        }
+        val holder = ChapterNotificationsStateHolder(repository, Dispatchers.Main.immediate)
+        compose.setContent {
+            TtsRoadTheme {
+                NotificationsScreen(holder, repository, onPlay = {}, onOpenFiction = {})
+            }
+        }
+        compose.waitForIdle()
+        return repository
+    }
+
+    @Test
+    fun `a converting chapter offers neither Play nor Dismiss`() {
+        screen(notice(1, "pulled"))
+
+        compose.onNodeWithTag(NotificationRowTestTag).assertIsDisplayed()
+        // The row says what is happening; it does not offer to throw away the only record of it.
+        compose.onNodeWithText("CHAPTER 1  ·  CONVERTING 62%").assertIsDisplayed()
+        assertEquals(0, compose.onAllNodesWithTag(NotificationDismissTestTag).fetchSemanticsNodes().size)
+        assertEquals(0, compose.onAllNodesWithTag(NotificationPlayTestTag).fetchSemanticsNodes().size)
+    }
+
+    @Test
+    fun `a ready chapter offers both, and clearing says how many are ready`() {
+        val repository = screen(notice(1, "ready"), notice(2, "pulled"))
+
+        compose.onNodeWithTag(NotificationPlayTestTag).assertIsDisplayed()
+        // "the 1 ready", never "all": the converting one is what is being waited for.
+        compose.onNodeWithText("CLEAR THE 1 READY").assertIsDisplayed().performClick()
+        compose.waitForIdle()
+
+        assertEquals(1, repository.dismissReadCalls)
+    }
+
+    @Test
+    fun `a server without the route says so instead of showing an empty list`() {
+        val repository = FakeRepository().apply { chapterNotificationsResult = Result.success(null) }
+        val holder = ChapterNotificationsStateHolder(repository, Dispatchers.Main.immediate)
+        compose.setContent {
+            TtsRoadTheme {
+                NotificationsScreen(holder, repository, onPlay = {}, onOpenFiction = {})
+            }
+        }
+        compose.waitForIdle()
+
+        compose.onNodeWithText("THIS SERVER CANNOT REPORT NEW CHAPTERS").assertIsDisplayed()
+        assertTrue(compose.onAllNodesWithTag(NotificationRowTestTag).fetchSemanticsNodes().isEmpty())
+    }
+}


### PR DESCRIPTION
Implements #105. **Depends on the server contract in jonarihen/TTSRoad#203** — this is gated on the
`notifications` capability, so it is inert against a server that does not have it yet.

Following a fiction decided only whose shelf it appeared on. This is the half that tells you it
gained something, and the whole design is about *when the notice goes away*.

## The two rules

- **`dismissible` and `playable` come off the wire**, never derived from the state name. The server
  answers **409** to a dismissal of a chapter that is still converting — the notice is the only
  record that the chapter is coming — and a client that worked that rule out for itself would be a
  fourth opinion about something the server enforces.
- **The system notification fires only on pulled → ready.** `newlyReady` returns nothing on the
  first look of a session: a chapter that was already ready when the app started is not news, and
  announcing it would re-announce the backlog on every launch. Arrival is deliberately silent — the
  badge and the list already carry it.

An unknown state parses as `Pulled`, never `Ready`. Guessing the latter would offer Play for audio
that may not exist.

## Structure

- `data/ChapterNotifications.kt` — models plus the two pure rules (`newlyReady`,
  `readyNotificationText`), testable with no network and no display.
- `ui/ChapterNotificationsStateHolder.kt` — hoisted above navigation like the bookmarks holder, and
  for a sharper reason: the badge and the notification are driven by a poll that must run whether or
  not the destination was ever opened.
- `notify` is a `(String, String) -> Unit` supplied by `Main`, so nothing in the tree depends on a
  tray existing. A session without one keeps the badge and the list.

**No push credential is needed on the desktop** — its OS notification renders state it already
polls, unlike the phone's.

## Verification

`./gradlew clean check --warning-mode fail -Pttsroad.warningsAsErrors=true` passes. 11 holder cases
(including "already ready at startup is not announced" and "a converting chapter cannot be
dismissed") plus 3 screen tests asserting which controls each state is allowed to draw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK3sri5jA6ne6tEJnbQaRe