### PR TITLE
Cut 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ All notable changes to TTSRoad Desktop are recorded here. The format follows
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-09-04
+
+One feature, shipped to all three clients at once, and nearly all of its design is about when the
+notice goes *away*. Telling somebody a chapter exists is the easy half; the half that decides
+whether a feature like this stays switched on is not saying it twice.
+
 ### Added
 
 - **New chapters announce themselves, and stay announced until they play.** Following a serial
@@ -214,7 +220,8 @@ server.
 - A Debian package with a bundled JDK 25 runtime, desktop entry, upgrade-safe revisioning and XDG
   rotating logs, plus credential-safe `--version` and `--diagnostics` commands.
 
-[Unreleased]: https://github.com/jonarihen/TTSRoad-Desktop/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/jonarihen/TTSRoad-Desktop/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/jonarihen/TTSRoad-Desktop/releases/tag/v1.3.0
 [1.2.0]: https://github.com/jonarihen/TTSRoad-Desktop/releases/tag/v1.2.0
 [1.1.0]: https://github.com/jonarihen/TTSRoad-Desktop/releases/tag/v1.1.0
 [1.0.2]: https://github.com/jonarihen/TTSRoad-Desktop/releases/tag/v1.0.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.configuration-cache=true
 #   - BuildInfo.VERSION, which the runtime About text renders
 #   - release automation / CI artifact names
 # jpackage rejects MAJOR 0, so this must stay >= 1.0.0.
-ttsroad.version=1.2.0
+ttsroad.version=1.3.0
 
 # Debian revision, deliberately separate from the application version. A packaging-only fix can
 # move 1.0.1-1 to 1.0.1-2 without making the About screen claim the application itself changed.


### PR DESCRIPTION
Cuts 1.3.0 so the new-chapter notices from #106 reach somebody. v1.2.0 was
tagged before that feature merged, so it is currently on `master` and in no
installed copy of the app.

MINOR rather than PATCH: it adds a capability-gated screen and a header entry and
removes nothing. `ttsroad.debRevision` stays `1` — the application version moved,
so the packaging revision starts over rather than continuing.

`[Unreleased]` keeps its heading and the content moves down under a dated
`[1.3.0]`, matching what #104 did. The lead paragraph is new rather than lifted
from the bullet, which would otherwise have said the same sentence twice on
screen.

## Verification

- `xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail
  -Pttsroad.warningsAsErrors=true` — BUILD SUCCESSFUL in 7m22s. That is the CI
  gate rather than plain `check`; a bare `check` passes on deprecations that fail
  the real build.
- `packaging/release/changelog-section.sh 1.3.0` exits 0 and returns 21 lines
  that stop before the 1.2.0 section. The same script with a version that has no
  section still exits 1, so the gate it exists to be has not been loosened.

The tag is not pushed by this PR. Once it is, the release workflow builds the
three installers and creates a **draft** — publishing stays a human step, which
is the repo's own policy rather than an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK3sri5jA6ne6tEJnbQaRe
