### PR TITLE
Pick a voice from the server's list, and refuse a rate it will not narrate

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -208,12 +208,18 @@ fun App(
 
     val scope = rememberCoroutineScope()
 
-    LaunchedEffect(session.isLoggedIn, capabilities.fictionManagement, capabilities.epubUpload) {
+    LaunchedEffect(
+        session.isLoggedIn,
+        capabilities.fictionManagement,
+        capabilities.epubUpload,
+        capabilities.voiceCatalogue,
+    ) {
         if (session.isLoggedIn) {
             fictionManagement.ensureAccess(
                 capabilities.fictionManagement,
                 epubUpload = capabilities.epubUpload,
                 maxEpubBytes = capabilities.maxEpubBytes,
+                voiceCatalogue = capabilities.voiceCatalogue,
             )
         }
     }
@@ -234,6 +240,7 @@ fun App(
                     capabilities.fictionManagement,
                     epubUpload = capabilities.epubUpload,
                     maxEpubBytes = capabilities.maxEpubBytes,
+                    voiceCatalogue = capabilities.voiceCatalogue,
                     forceRefresh = true,
                 )
             }
@@ -243,6 +250,7 @@ fun App(
                     capabilities.fictionManagement,
                     epubUpload = capabilities.epubUpload,
                     maxEpubBytes = capabilities.maxEpubBytes,
+                    voiceCatalogue = capabilities.voiceCatalogue,
                     forceRefresh = true,
                 )
             }
@@ -617,6 +625,7 @@ fun App(
                                         fictionMetadata.load(
                                             cached.value?.fiction ?: destination.fiction,
                                             maxCoverBytes = capabilities.maxCoverBytes,
+                                            voiceCatalogue = capabilities.voiceCatalogue,
                                         )
                                     }
                                     FictionMetadataScreen(

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
@@ -109,6 +109,14 @@ data class FictionSummary(
     val author: String? = null,
     /** Narration voice; present on management/detail payloads and optional on older library rows. */
     val voice: String? = null,
+    /**
+     * Speech rate for the next conversion, as `+0%` / `-10%`.
+     *
+     * `FictionResponse` has always carried it beside `voice`; this client simply never decoded it,
+     * which is why the rate of an existing fiction could not be shown or changed. Nullable for the
+     * same reason [voice] is: `/chapters` builds its `fiction` without either.
+     */
+    val rate: String? = null,
     val slug: String? = null,
     @param:Json(name = "cover_image_url") val coverImageUrl: String? = null,
     val description: String? = null,
@@ -264,6 +272,11 @@ data class FictionUpdateRequest(
     /** Empty list clears the tags. The server trims, de-duplicates and caps whatever it is sent. */
     val tags: List<String>? = null,
     val voice: String? = null,
+    /**
+     * Speech rate. Like [voice] and unlike the metadata fields, writing it claims nothing: no poll
+     * has ever set it, so there is no source ownership to take away.
+     */
+    val rate: String? = null,
     /**
      * Metadata field names to hand back to the source, so the next poll may overwrite them again.
      *
@@ -492,4 +505,33 @@ data class PlaybackMarkResponse(
     val played: Boolean = false,
     @param:Json(name = "chapter_ids") val chapterIds: List<Int> = emptyList(),
     val count: Int = 0,
+)
+
+/**
+ * `GET /api/mobile/voices` — the edge-tts catalogue, in an envelope (#109).
+ *
+ * Several hundred entries across a hundred-odd locales, which is why nothing is drawn as a flat
+ * list; see `voiceGroups`.
+ */
+data class VoicesResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    val voices: List<MobileVoice> = emptyList(),
+)
+
+/**
+ * One narrator.
+ *
+ * [name] is the short form — `en-US-BrianNeural` — which is both what a fiction stores and what
+ * `FictionUpdateRequest.voice` expects; nothing here ever sends a display name. It is the one field
+ * with no meaningful default, so a row arriving without one is dropped rather than offered as a
+ * choice that cannot be applied.
+ *
+ * [locale] and [gender] are nullable on purpose. The server sends both today, and they drive
+ * grouping and one line of description — neither is worth failing a parse over, and a catalogue
+ * that would not load at all is worse than a voice filed under "Other".
+ */
+data class MobileVoice(
+    val name: String = "",
+    val locale: String? = null,
+    val gender: String? = null,
 )

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -205,6 +205,15 @@ interface TtsRoadRepository {
     suspend fun audiobookExports(): AudiobookExportsResponse? = null
 
     /**
+     * The narrator catalogue, or null when this server has no `/voices` route.
+     *
+     * Null and empty differ here the way they do for [devices]: an empty catalogue would mean the
+     * server has no voices installed, which is a different thing to say than "this server cannot be
+     * asked", and only the second one should retire the picker.
+     */
+    suspend fun voices(): List<MobileVoice>? = null
+
+    /**
      * Revokes one session.
      *
      * False means the server answered 404, which is ambiguous by design: the endpoint may be
@@ -566,6 +575,8 @@ class RetrofitTtsRoadRepository(
 
     override suspend fun audiobookExports(): AudiobookExportsResponse? =
         ifEndpointExists { it.audiobookExports() }
+
+    override suspend fun voices(): List<MobileVoice>? = ifEndpointExists { it.voices() }?.voices
 
     override suspend fun revokeDevice(tokenId: Int): Boolean =
         ifEndpointExists { it.revokeDevice(tokenId) } != null

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
@@ -79,6 +79,15 @@ data class ServerCapabilities(
      * its system notification is a rendering of state it already has.
      */
     val notifications: Boolean = false,
+    /**
+     * `GET /api/mobile/voices` — the narrator catalogue.
+     *
+     * Listing is open to any signed-in account; *applying* a choice is admin-gated by the fiction
+     * `PATCH`. So this flag alone is never the gate for the picker — see `canPickVoice`, which takes
+     * both halves. Previewing a voice is a separate capability and deliberately not mirrored here:
+     * a cache miss spends an outbound synthesis request to Microsoft.
+     */
+    val voiceCatalogue: Boolean = false,
     val maxChaptersPerPage: Int? = null,
     /**
      * How many items `/playback/sync` accepts in one batch.
@@ -125,6 +134,7 @@ data class ServerCapabilities(
             queue = response.capabilities.flag("queue"),
             audiobookExport = response.capabilities.flag("audiobook_export"),
             notifications = response.capabilities.flag("notifications"),
+            voiceCatalogue = response.capabilities.flag("voice_catalogue"),
             maxChaptersPerPage = response.limits.intLimit("max_chapters_per_page"),
             maxPlaybackSyncItems = response.limits.intLimit("max_playback_sync_items"),
             maxEpubBytes = response.limits.longLimit("max_epub_bytes"),

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -54,6 +54,16 @@ interface TtsRoadApi {
     @GET("api/mobile/exports")
     suspend fun audiobookExports(): AudiobookExportsResponse
 
+    /**
+     * The narrator catalogue. Open to any signed-in account, like the web route it mirrors.
+     *
+     * There is deliberately no preview route beside it: `POST /api/voices/{voice}/preview` is
+     * admin-only and spends an outbound synthesis request to Microsoft on a cache miss, which is why
+     * the server advertises it as a separate capability.
+     */
+    @GET("api/mobile/voices")
+    suspend fun voices(): VoicesResponse
+
     // Both revoke calls answer with a small status object (`{"status": "ok", ...}`) whose shape is
     // not worth modelling: the client re-reads the list afterwards rather than trusting an echo,
     // because a 404 on the DELETE is ambiguous between "already gone" and "no such endpoint".

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/VoiceCatalogue.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/VoiceCatalogue.kt
@@ -1,0 +1,234 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import java.util.Locale
+
+/**
+ * Turning `GET /api/mobile/voices` into something pickable (#109).
+ *
+ * The server publishes the edge-tts catalogue: several hundred narrators across a hundred-odd
+ * locales, spelled `en-US-BrianNeural`. Until this existed the desktop rendered a text field, so
+ * choosing a voice meant knowing Microsoft's exact spelling and a typo was stored without complaint.
+ *
+ * Three things here are decisions rather than mechanics.
+ *
+ * [canPickVoice] takes **both** halves of the gate. Listing voices is open to any signed-in account
+ * and *applying* one is admin-gated by the `PATCH`, so the capability alone would draw a picker for
+ * a regular account whose save is a 403.
+ *
+ * [normaliseVoiceRate] exists because nothing else checks. `FictionUpdate.rate` on the server is a
+ * bare `Optional[str]` with no validator, so `10` or `10%` saves cleanly, looks right on screen, and
+ * then fails at the *next conversion* as a chapter that will not narrate — hours later, with nothing
+ * on screen connecting the two. This is the only place between the keyboard and the database that
+ * can catch it.
+ *
+ * [voiceChangeConsequence] says what a voice change does *not* do. Existing chapters keep the audio
+ * they were made with; the choice applies to what the server converts next. Making it retroactive is
+ * re-converting every chapter, which is hours of TTS and a separate decision under
+ * `fiction_maintenance`.
+ */
+
+/** Both halves of the gate: the server has the catalogue, and this account may store a choice. */
+fun canPickVoice(capabilities: ServerCapabilities, isAdmin: Boolean): Boolean =
+    capabilities.voiceCatalogue && isAdmin
+
+/**
+ * One narrator, as the picker draws it.
+ *
+ * [name] is what gets stored and is never derived from anything else. [shortName] is only ever a
+ * label — `en-US-BrianNeural` shown as "Brian" — and both are on screen, because two locales'
+ * "Brian" are different narrators and the full name is the only thing that tells them apart.
+ */
+data class VoiceChoice(
+    val name: String,
+    val shortName: String,
+    val locale: String,
+    val gender: String?,
+) {
+    /** The line under the name: "Female · en-GB-SoniaNeural", or just the name when no gender came. */
+    val detail: String
+        get() = gender?.takeIf { it.isNotBlank() }?.let { "$it  ·  $name" } ?: name
+}
+
+/** The voices of one locale, under the name that locale has in the reader's own language. */
+data class VoiceGroup(
+    /** The server's own tag — `en-US` — which is what the grouping is keyed on. */
+    val locale: String,
+    /** "English (United States)", or the raw tag when the platform cannot name it. */
+    val label: String,
+    val voices: List<VoiceChoice>,
+)
+
+/** Voices whose row carried no locale at all. Kept rather than dropped: the name still works. */
+const val UnknownVoiceLocale: String = "other"
+
+/**
+ * The catalogue as groups, ordered so the useful one is first.
+ *
+ * The ordering is the point, and it is not alphabetical:
+ *
+ * 1. The locale of [current] — the voice this fiction already uses. Someone opening the picker is
+ *    usually moving to a neighbouring voice, and starting anywhere else means scrolling back to
+ *    where they already were.
+ * 2. The locales matching the machine's own language, so a Danish desktop reading English serials
+ *    still finds `da-DK` without a hundred locales of alphabet first.
+ * 3. Everything else by label, so the tail is at least predictable.
+ *
+ * [query] filters on name, gender, locale tag and locale label, so both "sonia" and "british" find
+ * `en-GB-SoniaNeural`. An empty result is an empty list — the caller says what that means.
+ *
+ * A row with a blank name is dropped: it cannot be stored, so offering it would be offering a
+ * choice whose save fails. A name that arrives twice is kept once.
+ */
+fun voiceGroups(
+    voices: List<MobileVoice>?,
+    current: String? = null,
+    query: String = "",
+    locale: Locale = Locale.getDefault(),
+): List<VoiceGroup> {
+    if (voices.isNullOrEmpty()) return emptyList()
+    val currentLocale = voices.firstOrNull { it.name == current?.trim() }?.localeTag
+    val machineLanguage = locale.language.lowercase(Locale.ROOT)
+    val wanted = query.trim().lowercase(Locale.ROOT)
+
+    val groups = voices
+        .filter { it.name.isNotBlank() }
+        // One row per name. A name is the identity here, not a label, and the picker keys its list
+        // on it — a server that published the same narrator twice would otherwise be a duplicate key
+        // rather than merely a repeated row.
+        .distinctBy { it.name.trim() }
+        .groupBy { it.localeTag }
+        .map { (tag, rows) ->
+            VoiceGroup(
+                locale = tag,
+                label = voiceLocaleLabel(tag, locale),
+                // By the name a human reads, not by the wire name: `en-US-AvaNeural` and
+                // `en-US-AvaMultilingualNeural` belong next to each other.
+                voices = rows.map { it.asChoice(tag) }.sortedBy { it.shortName.lowercase(Locale.ROOT) },
+            )
+        }
+        .filter { it.voices.isNotEmpty() }
+
+    val matched = if (wanted.isEmpty()) groups else groups.mapNotNull { group ->
+        val hits = group.voices.filter { choice ->
+            choice.name.lowercase(Locale.ROOT).contains(wanted) ||
+                group.locale.lowercase(Locale.ROOT).contains(wanted) ||
+                group.label.lowercase(Locale.ROOT).contains(wanted) ||
+                choice.gender?.lowercase(Locale.ROOT)?.contains(wanted) == true
+        }
+        group.copy(voices = hits).takeIf { hits.isNotEmpty() }
+    }
+
+    return matched.sortedWith(
+        compareBy(
+            { if (it.locale == currentLocale) 0 else 1 },
+            { if (it.locale.substringBefore('-').lowercase(Locale.ROOT) == machineLanguage) 0 else 1 },
+            { it.label.lowercase(Locale.ROOT) },
+        ),
+    )
+}
+
+/**
+ * Which group should already be open, or null when none should be.
+ *
+ * The one holding [current], so the voice in force is on screen without hunting — "which is it now"
+ * and "what else is near it" are the same question. With no current voice there is nothing to be
+ * near, and the first group opens instead.
+ */
+fun initiallyExpandedVoiceLocale(groups: List<VoiceGroup>, current: String?): String? {
+    val name = current?.trim().orEmpty()
+    if (name.isNotEmpty()) {
+        groups.firstOrNull { group -> group.voices.any { it.name == name } }?.let { return it.locale }
+    }
+    return groups.firstOrNull()?.locale
+}
+
+/** `en-US` as "English (United States)", or the tag itself when the platform has no name for it. */
+fun voiceLocaleLabel(tag: String, locale: Locale = Locale.getDefault()): String {
+    if (tag == UnknownVoiceLocale) return "Other"
+    val named = runCatching { Locale.forLanguageTag(tag).getDisplayName(locale) }.getOrNull()
+    return named?.takeIf { it.isNotBlank() && it != tag } ?: tag
+}
+
+/** The locale this voice is filed under — the server's tag, or [UnknownVoiceLocale]. */
+private val MobileVoice.localeTag: String
+    get() = locale?.trim()?.takeIf { it.isNotEmpty() } ?: UnknownVoiceLocale
+
+private fun MobileVoice.asChoice(tag: String) = VoiceChoice(
+    name = name.trim(),
+    shortName = shortVoiceName(name.trim(), tag),
+    locale = tag,
+    gender = gender?.trim()?.takeIf { it.isNotEmpty() },
+)
+
+/**
+ * `en-US-BrianNeural` as "Brian".
+ *
+ * The locale prefix is stripped by the voice's own tag rather than by a pattern, which is what makes
+ * `zh-CN-liaoning-XiaobeiNeural` come out as "Xiaobei": its locale really is `zh-CN-liaoning`, and a
+ * two-letter-plus-region pattern would leave "liaoning" in the label. Anything that shortens to
+ * nothing keeps its full name — a label is not worth losing the identity over.
+ */
+fun shortVoiceName(name: String, locale: String?): String {
+    val prefix = locale?.takeIf { it.isNotBlank() && it != UnknownVoiceLocale }?.let { "$it-" }
+    val stripped = when {
+        prefix != null && name.startsWith(prefix, ignoreCase = true) -> name.substring(prefix.length)
+        else -> name.substringAfterLast('-')
+    }
+    return stripped.removeSuffix("Neural").trim().ifEmpty { name }
+}
+
+/**
+ * The rate as the server should store it, or null when this is not a rate.
+ *
+ * `[+-]NNN%` is the form edge-tts takes and the same expression the web console validates with
+ * (`VP_RATE_RE` in `app.js`). A bare number is accepted and signed — "10" is unambiguously "+10%",
+ * and nobody should have to remember that the plus is load-bearing.
+ *
+ * Zero is the one case where the sign is not a choice: `-0%` and `+0%` are the same rate, so both
+ * normalise to `+0%` rather than leaving two spellings of "unchanged" in the database.
+ */
+fun normaliseVoiceRate(input: String?): String? {
+    val text = input?.trim().orEmpty()
+    if (text.isEmpty()) return null
+    val body = text.removeSuffix("%").trim()
+    val negative = body.startsWith("-")
+    val digits = body.removePrefix("+").removePrefix("-")
+    if (digits.isEmpty() || digits.length > 3 || !digits.all { it.isDigit() }) return null
+    val magnitude = digits.toInt()
+    return if (negative && magnitude > 0) "-$magnitude%" else "+$magnitude%"
+}
+
+/** Why that rate cannot be sent, or null when it can. Empty is not a problem — it means "leave it". */
+fun voiceRateProblem(input: String?): String? = when {
+    input.isNullOrBlank() -> null
+    normaliseVoiceRate(input) != null -> null
+    else -> "A rate reads like +0%, +25% or -10%."
+}
+
+/**
+ * What this change will and will not do, in words, at the point of making it.
+ *
+ * Null when nothing about the narration is changing. Otherwise it names the half that a picker
+ * silently implies is included: the chapters that exist keep the audio they were made with, and the
+ * choice applies to whatever is converted next.
+ */
+fun voiceChangeConsequence(
+    doneChapters: Int,
+    voiceChanged: Boolean,
+    rateChanged: Boolean,
+): String? {
+    if (!voiceChanged && !rateChanged) return null
+    val what = when {
+        voiceChanged && rateChanged -> "This voice and rate are"
+        voiceChanged -> "This voice is"
+        else -> "This rate is"
+    }
+    val existing = when (doneChapters) {
+        0 -> "Nothing has been converted yet, so nothing is affected."
+        1 -> "The one chapter already converted keeps the audio it was made with."
+        else ->
+            "The $doneChapters chapters already converted keep the audio they were made with — " +
+                "nothing is re-narrated."
+    }
+    return "$existing $what used for whatever the server converts next."
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementDialogs.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementDialogs.kt
@@ -23,11 +23,13 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.data.MobileVoice
 import dk.perspektiva.ttsroad.desktop.data.SyncScope
 
 const val AddFictionDialogTestTag: String = "addFictionDialog"
 const val ChooseEpubButtonTestTag: String = "chooseEpubButton"
 const val ChosenEpubNameTestTag: String = "chosenEpubName"
+const val AddRateFieldTestTag: String = "addRateField"
 
 /**
  * The holder owns the answers; this composable only renders its one active question.
@@ -46,6 +48,8 @@ fun FictionManagementDialogs(holder: FictionManagementStateHolder) {
             isBusy = state.isBusy,
             error = state.error,
             epubUploadAvailable = state.epubUploadAvailable,
+            voices = state.voices.takeIf { state.canPickVoice },
+            rateProblem = state.rateProblem,
             onUpdateAdd = holder::updateAdd,
             onChooseEpub = holder::chooseEpub,
             onClearEpub = holder::clearEpub,
@@ -71,6 +75,9 @@ private fun AddFictionDialog(
     isBusy: Boolean,
     error: String?,
     epubUploadAvailable: Boolean,
+    /** The narrator catalogue, or null on a server without it — then the voice stays typed. */
+    voices: List<MobileVoice>?,
+    rateProblem: String?,
     onUpdateAdd: (String?, String?, String?, Boolean?, SyncScope?) -> Unit,
     onChooseEpub: () -> Unit,
     onClearEpub: () -> Unit,
@@ -129,23 +136,44 @@ private fun AddFictionDialog(
                         }
                     }
                 }
-                OutlinedTextField(
-                    value = editor.voice,
-                    onValueChange = { onUpdateAdd(null, it, null, null, null) },
-                    label = { Text("VOICE (OPTIONAL)") },
-                    supportingText = { Text("Blank uses the server default") },
-                    enabled = !isBusy,
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                if (voices != null) {
+                    VoiceField(
+                        voices = voices,
+                        selected = editor.voice,
+                        enabled = !isBusy,
+                        onSelect = { onUpdateAdd(null, it, null, null, null) },
+                        label = "VOICE (OPTIONAL)",
+                    )
+                } else {
+                    // No catalogue on this server, so the exact name still has to be typed. Worth
+                    // keeping rather than hiding: it is the only way to set a voice at all there.
+                    OutlinedTextField(
+                        value = editor.voice,
+                        onValueChange = { onUpdateAdd(null, it, null, null, null) },
+                        label = { Text("VOICE (OPTIONAL)") },
+                        supportingText = { Text("Blank uses the server default") },
+                        enabled = !isBusy,
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
                 OutlinedTextField(
                     value = editor.rate,
                     onValueChange = { onUpdateAdd(null, null, it, null, null) },
                     label = { Text("SPEECH RATE (OPTIONAL)") },
-                    supportingText = { Text("Blank uses the server default. Nothing already converted is re-narrated.") },
+                    // The server stores this string without checking it, so a typo does not fail
+                    // here — it fails hours later as a chapter that will not narrate. This is the
+                    // only place it can be caught.
+                    isError = rateProblem != null,
+                    supportingText = {
+                        Text(
+                            rateProblem
+                                ?: "Blank uses the server default. Nothing already converted is re-narrated.",
+                        )
+                    },
                     enabled = !isBusy,
                     singleLine = true,
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth().testTag(AddRateFieldTestTag),
                 )
                 // Only meaningful on the Royal Road path: an EPUB has no source to poll and no
                 // backlog to bound, so offering either control there would be inventing a choice.
@@ -167,7 +195,8 @@ private fun AddFictionDialog(
         confirmButton = {
             Button(
                 onClick = onSubmit,
-                enabled = !isBusy,
+                // A malformed rate is refused here rather than sent. The server would accept it.
+                enabled = !isBusy && rateProblem == null,
                 shape = RectangleShape,
             ) {
                 Text(

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolder.kt
@@ -3,8 +3,11 @@ package dk.perspektiva.ttsroad.desktop.ui
 import dk.perspektiva.ttsroad.desktop.data.FictionCreateRequest
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
 import dk.perspektiva.ttsroad.desktop.data.LibraryCache
+import dk.perspektiva.ttsroad.desktop.data.MobileVoice
+import dk.perspektiva.ttsroad.desktop.data.normaliseVoiceRate
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
+import dk.perspektiva.ttsroad.desktop.data.voiceRateProblem
 import dk.perspektiva.ttsroad.desktop.data.SyncScope
 import java.io.File
 import kotlinx.coroutines.CoroutineDispatcher
@@ -76,8 +79,22 @@ data class FictionManagementUiState(
     val notice: String? = null,
     /** Consumed by the root navigator after a successful delete. */
     val deletedFictionId: Int? = null,
+    /**
+     * The narrator catalogue, or null when it has not been asked for or the server has no route.
+     *
+     * Null rather than empty because the two say different things: "not available here" retires the
+     * picker and leaves the typed field, while an empty catalogue would be a server with no voices
+     * installed — which has never been seen and is not worth pretending to handle differently.
+     */
+    val voices: List<MobileVoice>? = null,
 ) {
     val canManage: Boolean get() = access == FictionManagementAccess.Admin
+
+    /** Whether a picker can be drawn: the server has the list and this account may apply a choice. */
+    val canPickVoice: Boolean get() = voices != null && canManage
+
+    /** Why the typed rate cannot be sent, or null. Nothing else between here and the database checks. */
+    val rateProblem: String? get() = voiceRateProblem(editor?.rate)
     val hasOpenOverlay: Boolean get() = editor != null || deleteConfirmation != null
 }
 
@@ -104,6 +121,8 @@ class FictionManagementStateHolder(
     val state: StateFlow<FictionManagementUiState> = _state.asStateFlow()
 
     private var accessJob: Job? = null
+    private var voicesJob: Job? = null
+    private var voiceCatalogueAdvertised: Boolean = false
     private var mutationJob: Job? = null
     private var lastSupported: Boolean? = null
 
@@ -111,6 +130,7 @@ class FictionManagementStateHolder(
         supported: Boolean,
         epubUpload: Boolean = false,
         maxEpubBytes: Long? = null,
+        voiceCatalogue: Boolean = false,
         forceRefresh: Boolean = false,
     ) {
         if (!supported) {
@@ -125,6 +145,8 @@ class FictionManagementStateHolder(
         // after the first access check, and a server upgraded under a running desktop is noticed
         // the same day.
         _state.update { it.copy(epubUploadAvailable = epubUpload, maxEpubBytes = maxEpubBytes) }
+        voiceCatalogueAdvertised = voiceCatalogue
+        if (!voiceCatalogue) _state.update { it.copy(voices = null) }
         val newlySupported = lastSupported != true
         lastSupported = true
         if (accessJob?.isActive == true || (!forceRefresh && !newlySupported && _state.value.access in VerifiedAccess)) {
@@ -144,6 +166,7 @@ class FictionManagementStateHolder(
                             error = null,
                         )
                     }
+                    if (user?.isAdmin == true) loadVoices()
                 }
                 .onFailure { failure ->
                     _state.update {
@@ -153,6 +176,21 @@ class FictionManagementStateHolder(
                         )
                     }
                 }
+        }
+    }
+
+    /**
+     * Fetch the narrator catalogue, once, in the background.
+     *
+     * Deliberately silent on failure. The picker is an improvement on a text field that still works;
+     * an error banner over the add form for a list nobody asked for would report a problem the user
+     * did not have. A null catalogue simply leaves the field typed.
+     */
+    private fun loadVoices() {
+        if (!voiceCatalogueAdvertised || _state.value.voices != null || voicesJob?.isActive == true) return
+        voicesJob = scope.launch {
+            runCatching { repository.voices() }
+                .onSuccess { voices -> _state.update { it.copy(voices = voices) } }
         }
     }
 
@@ -219,7 +257,9 @@ class FictionManagementStateHolder(
         val validation = when {
             editor.epubFile != null -> epubProblem(editor.epubFile, _state.value.maxEpubBytes)
             editor.fictionUrl.isBlank() -> "A Royal Road URL, a fiction id, or an EPUB is required"
-            else -> null
+            // Checked here and not only on the button: a disabled control is a courtesy, not a
+            // guarantee, and nothing downstream — including the server — checks this string.
+            else -> voiceRateProblem(editor.rate)
         }
         if (validation != null) {
             _state.update { it.copy(error = validation) }
@@ -235,7 +275,9 @@ class FictionManagementStateHolder(
                     FictionCreateRequest(
                         fictionUrl = editor.fictionUrl.trim(),
                         voice = editor.voice.trim().takeIf(String::isNotEmpty),
-                        rate = editor.rate.trim().takeIf(String::isNotEmpty),
+                        // Normalised, not sent as typed: "10" means +10% and the server would
+                        // store the bare string and fail on it at conversion time.
+                        rate = normaliseVoiceRate(editor.rate),
                         enabled = editor.autoPoll,
                         // Always sent, including the null that means "everything": the field is
                         // chosen in the form, so its absence would be this client guessing again.

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionMetadataScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionMetadataScreen.kt
@@ -53,6 +53,8 @@ const val ChosenCoverNameTestTag: String = "chosenCoverName"
 const val SaveMetadataButtonTestTag: String = "saveMetadataButton"
 const val UseSourceValuesButtonTestTag: String = "useSourceValuesButton"
 const val TagDraftFieldTestTag: String = "tagDraftField"
+const val MetadataRateFieldTestTag: String = "metadataRateField"
+const val NarrationConsequenceTestTag: String = "narrationConsequence"
 
 /** How many characters of tag text fit on one row before the next chip wraps. */
 private const val TagRowBudget = 46
@@ -244,15 +246,51 @@ private fun MetadataForm(
         MetaText("Narration")
         // Deliberately outside the metadata block above: the voice is a conversion setting, not a
         // description of the book, so changing it claims nothing and no refresh would overwrite it.
+        val voices = state.voices
+        if (voices != null) {
+            VoiceField(
+                voices = voices,
+                selected = draft.voice,
+                enabled = !state.isBusy,
+                onSelect = holder::setVoice,
+                emptyLabel = "Not set — the server default is used",
+            )
+        } else {
+            // No catalogue route on this server, so the exact edge-tts name still has to be typed.
+            OutlinedTextField(
+                value = draft.voice,
+                onValueChange = holder::setVoice,
+                label = { Text("VOICE") },
+                supportingText = { Text("The edge-tts voice new chapters are narrated with") },
+                enabled = !state.isBusy,
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
         OutlinedTextField(
-            value = draft.voice,
-            onValueChange = holder::setVoice,
-            label = { Text("VOICE") },
-            supportingText = { Text("The edge-tts voice new chapters are narrated with") },
+            value = draft.rate,
+            onValueChange = holder::setRate,
+            label = { Text("SPEECH RATE") },
+            // Nothing downstream checks this. `FictionUpdate.rate` is a bare string on the server,
+            // so a malformed value saves cleanly and then fails at the next conversion, hours later.
+            isError = state.rateProblem != null,
+            supportingText = {
+                Text(state.rateProblem ?: "How much faster or slower than the voice's own pace, like +10%.")
+            },
             enabled = !state.isBusy,
             singleLine = true,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().testTag(MetadataRateFieldTestTag),
         )
+        // The half a picker silently implies is included. Shown only while something is actually
+        // changing, so it reads as a consequence rather than as standing documentation.
+        state.narrationConsequence?.let { consequence ->
+            Text(
+                consequence,
+                color = AarisColor.Dim,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.testTag(NarrationConsequenceTestTag),
+            )
+        }
     }
 }
 

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionMetadataStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionMetadataStateHolder.kt
@@ -7,9 +7,13 @@ import dk.perspektiva.ttsroad.desktop.data.FictionSummary
 import dk.perspektiva.ttsroad.desktop.data.FictionTagLimits
 import dk.perspektiva.ttsroad.desktop.data.FictionUpdateRequest
 import dk.perspektiva.ttsroad.desktop.data.LibraryCache
+import dk.perspektiva.ttsroad.desktop.data.MobileVoice
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.data.cleanFictionTags
+import dk.perspektiva.ttsroad.desktop.data.normaliseVoiceRate
 import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
+import dk.perspektiva.ttsroad.desktop.data.voiceChangeConsequence
+import dk.perspektiva.ttsroad.desktop.data.voiceRateProblem
 import java.io.File
 import java.util.Locale
 import kotlinx.coroutines.CoroutineDispatcher
@@ -30,6 +34,8 @@ data class FictionMetadataDraft(
     /** The half-typed tag in the "add a tag" field, which is not a tag until it is committed. */
     val tagDraft: String = "",
     val voice: String = "",
+    /** Speech rate for the next conversion. Blank means the fiction had none to show. */
+    val rate: String = "",
 )
 
 data class FictionMetadataUiState(
@@ -45,6 +51,8 @@ data class FictionMetadataUiState(
     val notice: String? = null,
     /** Cleared once this server has answered 404 to a cover upload — it predates the route. */
     val coverUploadSupported: Boolean = true,
+    /** The narrator catalogue, or null when the server has no `/voices` route. */
+    val voices: List<MobileVoice>? = null,
 ) {
     /** Which fields a person owns, as the server reports them. Empty on a server without the idea. */
     val overrides: Set<String> get() = fiction?.metadataOverrides?.toSet().orEmpty()
@@ -68,11 +76,33 @@ data class FictionMetadataUiState(
     /** Narration voice is a conversion setting, not metadata: changing it claims nothing. */
     val voiceChanged: Boolean get() = fiction != null && draft.voice.trim() != fiction.voice.orEmpty().trim()
 
+    /**
+     * Compared *normalised*, so re-typing `10` over a stored `+10%` is not a change.
+     * Otherwise every visit to the screen would offer to save the same rate back.
+     */
+    val rateChanged: Boolean
+        get() = fiction != null &&
+            normaliseVoiceRate(draft.rate) != normaliseVoiceRate(fiction.rate)
+
+    /** Why the typed rate cannot be sent, or null. Nothing downstream of here checks it. */
+    val rateProblem: String? get() = voiceRateProblem(draft.rate)
+
+    /** Whether a picker can be drawn: the server published a catalogue for this screen. */
+    val canPickVoice: Boolean get() = voices != null
+
+    /** What the narration change will and will not do, at the point of making it. */
+    val narrationConsequence: String?
+        get() = voiceChangeConsequence(
+            doneChapters = fiction?.doneChapters ?: 0,
+            voiceChanged = voiceChanged,
+            rateChanged = rateChanged,
+        )
+
     val hasChanges: Boolean
-        get() = changedFields.isNotEmpty() || voiceChanged || chosenCover != null ||
+        get() = changedFields.isNotEmpty() || voiceChanged || rateChanged || chosenCover != null ||
             draft.tagDraft.isNotBlank()
 
-    val canSave: Boolean get() = fiction != null && !isBusy && hasChanges
+    val canSave: Boolean get() = fiction != null && !isBusy && hasChanges && rateProblem == null
 }
 
 /**
@@ -100,6 +130,7 @@ class FictionMetadataStateHolder(
     val state: StateFlow<FictionMetadataUiState> = _state.asStateFlow()
 
     private var saveJob: Job? = null
+    private var voicesJob: Job? = null
 
     /**
      * Points the form at [fiction], or refreshes the baseline of the one already open.
@@ -108,18 +139,37 @@ class FictionMetadataStateHolder(
      * a fresher copy arrives from the library cache, and a form that reset itself under a poll
      * would lose an edit somebody was halfway through.
      */
-    fun load(fiction: FictionSummary, maxCoverBytes: Long? = null) {
+    fun load(fiction: FictionSummary, maxCoverBytes: Long? = null, voiceCatalogue: Boolean = false) {
         if (fiction.id <= 0) return
         _state.update { current ->
             if (current.fiction?.id == fiction.id) {
                 current.copy(fiction = fiction, maxCoverBytes = maxCoverBytes)
             } else {
+                // A different fiction resets the form, but the catalogue is a property of the
+                // server rather than of the book, so it is carried across rather than re-fetched.
                 FictionMetadataUiState(
                     fiction = fiction,
                     draft = draftOf(fiction),
                     maxCoverBytes = maxCoverBytes,
+                    voices = current.voices,
                 )
             }
+        }
+        if (voiceCatalogue) loadVoices()
+    }
+
+    /**
+     * Fetch the narrator catalogue, once, in the background.
+     *
+     * Silent on failure by design: the picker is an improvement on a field that still works, and an
+     * error banner for a list nobody asked for would report a problem the user does not have. A null
+     * catalogue simply leaves the voice typed.
+     */
+    private fun loadVoices() {
+        if (_state.value.voices != null || voicesJob?.isActive == true) return
+        voicesJob = scope.launch {
+            runCatching { repository.voices() }
+                .onSuccess { voices -> _state.update { it.copy(voices = voices) } }
         }
     }
 
@@ -130,6 +180,8 @@ class FictionMetadataStateHolder(
     fun setDescription(value: String) = editDraft { it.copy(description = value) }
 
     fun setVoice(value: String) = editDraft { it.copy(voice = value) }
+
+    fun setRate(value: String) = editDraft { it.copy(rate = value) }
 
     fun setTagDraft(value: String) = editDraft { it.copy(tagDraft = value) }
 
@@ -182,7 +234,9 @@ class FictionMetadataStateHolder(
         val validation = when {
             start.draft.title.isBlank() -> "Title cannot be empty"
             start.draft.voice.isBlank() -> "Voice cannot be empty"
-            else -> null
+            // Checked here and not only on the button: a disabled control is a courtesy, not a
+            // guarantee, and this is the last point before a string the server never validates.
+            else -> voiceRateProblem(start.draft.rate)
         }
         if (validation != null) {
             _state.value = start.copy(error = validation, notice = null)
@@ -373,7 +427,7 @@ class FictionMetadataStateHolder(
         /** The request for what changed, or null when nothing did. */
         internal fun patchOf(state: FictionMetadataUiState): FictionUpdateRequest? {
             val changed = state.changedFields
-            if (changed.isEmpty() && !state.voiceChanged) return null
+            if (changed.isEmpty() && !state.voiceChanged && !state.rateChanged) return null
             return FictionUpdateRequest(
                 title = state.draft.title.trim().takeIf { FictionMetadataFields.Title in changed },
                 author = state.draft.author.trim().takeIf { FictionMetadataFields.Author in changed },
@@ -381,6 +435,9 @@ class FictionMetadataStateHolder(
                     .takeIf { FictionMetadataFields.Description in changed },
                 tags = cleanFictionTags(state.draft.tags).takeIf { FictionMetadataFields.Tags in changed },
                 voice = state.draft.voice.trim().takeIf { state.voiceChanged },
+                // Normalised rather than sent as typed: the server stores this string without
+                // checking it, so "10" would be saved and then fail at the next conversion.
+                rate = normaliseVoiceRate(state.draft.rate).takeIf { state.rateChanged },
             )
         }
 
@@ -390,6 +447,7 @@ class FictionMetadataStateHolder(
             description = fiction.description.orEmpty(),
             tags = fiction.tags,
             voice = fiction.voice.orEmpty(),
+            rate = fiction.rate.orEmpty(),
         )
 
         /** Folds a tag typed but never committed into the list, so Save does not silently drop it. */

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/VoicePicker.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/VoicePicker.kt
@@ -1,0 +1,255 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.data.MobileVoice
+import dk.perspektiva.ttsroad.desktop.data.initiallyExpandedVoiceLocale
+import dk.perspektiva.ttsroad.desktop.data.voiceGroups
+
+const val VoicePickerTestTag: String = "voice-picker"
+const val VoicePickerSearchTestTag: String = "voice-picker-search"
+const val ChooseVoiceButtonTestTag: String = "choose-voice"
+
+/**
+ * The voice control: what is chosen now, and a way to change it.
+ *
+ * A row rather than a text field, because the value is no longer typed. The full wire name is on
+ * screen next to the readable one — `en-US-BrianNeural` is what is stored, and two locales' "Brian"
+ * are different narrators — so the row states the thing that will actually be saved.
+ *
+ * [voices] being null is a server without the catalogue route. The caller draws its own text field
+ * in that case rather than this; there is no half-picker.
+ */
+@Composable
+fun VoiceField(
+    voices: List<MobileVoice>,
+    selected: String,
+    enabled: Boolean,
+    onSelect: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    label: String = "VOICE",
+    /** What a blank selection means here. Add and edit answer this differently. */
+    emptyLabel: String = "Server default",
+) {
+    var picking by remember { mutableStateOf(false) }
+
+    Column(modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text(label, color = AarisColor.Dim, style = MaterialTheme.typography.labelMedium)
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = selected.trim().ifEmpty { emptyLabel },
+                color = if (selected.isBlank()) AarisColor.Dim else AarisColor.Ink,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.weight(1f),
+            )
+            AarisSecondaryAction(
+                label = if (selected.isBlank()) "Choose…" else "Change…",
+                onClick = { picking = true },
+                enabled = enabled,
+                modifier = Modifier.testTag(ChooseVoiceButtonTestTag),
+            )
+        }
+    }
+
+    if (picking) {
+        VoicePickerDialog(
+            voices = voices,
+            current = selected,
+            onPick = {
+                onSelect(it)
+                picking = false
+            },
+            onDismiss = { picking = false },
+        )
+    }
+}
+
+/**
+ * The catalogue, grouped and searchable.
+ *
+ * Several hundred narrators across a hundred-odd locales, so every group is collapsed except the
+ * one holding the current voice — "which is it now" and "what else is near it" are the same
+ * question, and answering it should not require scrolling past ninety locales of alphabet.
+ *
+ * A search opens everything it matched, because a collapsed group that contains the only hit is a
+ * search that looks like it failed.
+ */
+@Composable
+fun VoicePickerDialog(
+    voices: List<MobileVoice>,
+    current: String,
+    onPick: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var query by remember { mutableStateOf("") }
+    val groups = voiceGroups(voices = voices, current = current, query = query)
+    val initiallyOpen = remember(voices, current) {
+        initiallyExpandedVoiceLocale(voiceGroups(voices, current), current)
+    }
+    var expanded by remember(initiallyOpen) { mutableStateOf(setOfNotNull(initiallyOpen)) }
+    val searching = query.isNotBlank()
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        shape = RectangleShape,
+        title = { Text("CHOOSE A VOICE") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = query,
+                    onValueChange = { query = it },
+                    label = { Text("SEARCH") },
+                    supportingText = { Text("A name, a language, or a gender") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth().testTag(VoicePickerSearchTestTag),
+                )
+                if (groups.isEmpty()) {
+                    Text(
+                        if (searching) "No voice matches \"${query.trim()}\"." else "This server published no voices.",
+                        color = AarisColor.Dim,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                } else {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxWidth().heightIn(max = 420.dp).testTag(VoicePickerTestTag),
+                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                    ) {
+                        groups.forEach { group ->
+                            val open = searching || group.locale in expanded
+                            item(key = "group-${group.locale}") {
+                                LocaleHeader(
+                                    label = group.label,
+                                    locale = group.locale,
+                                    count = group.voices.size,
+                                    expanded = open,
+                                    // While searching, every matched group is already open and the
+                                    // chevron would be a control that does nothing.
+                                    onToggle = if (searching) null else {
+                                        {
+                                            expanded = if (group.locale in expanded) {
+                                                expanded - group.locale
+                                            } else {
+                                                expanded + group.locale
+                                            }
+                                        }
+                                    },
+                                )
+                            }
+                            if (open) {
+                                items(group.voices, key = { it.name }) { choice ->
+                                    VoiceRow(
+                                        shortName = choice.shortName,
+                                        detail = choice.detail,
+                                        chosen = choice.name == current.trim(),
+                                        onClick = { onPick(choice.name) },
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = { TextButton(onClick = onDismiss, shape = RectangleShape) { Text("CANCEL") } },
+    )
+}
+
+@Composable
+private fun LocaleHeader(
+    label: String,
+    locale: String,
+    count: Int,
+    expanded: Boolean,
+    onToggle: (() -> Unit)?,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .let { if (onToggle != null) it.clickable(onClick = onToggle).pointerHoverIcon(PointerIcon.Hand) else it }
+            .background(AarisColor.BgRaise)
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+    ) {
+        Text(
+            label.uppercase(),
+            color = AarisColor.Ink,
+            style = MaterialTheme.typography.labelMedium,
+            modifier = Modifier.weight(1f),
+        )
+        Text("$locale  ·  $count", color = AarisColor.Dim, style = MaterialTheme.typography.labelSmall)
+        if (onToggle != null) {
+            Spacer(Modifier.width(8.dp))
+            Icon(
+                if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                contentDescription = null,
+                tint = AarisColor.Dim,
+                modifier = Modifier.size(16.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun VoiceRow(shortName: String, detail: String, chosen: Boolean, onClick: () -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .pointerHoverIcon(PointerIcon.Hand)
+            .then(if (chosen) Modifier.border(1.dp, AarisColor.Accent) else Modifier)
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+    ) {
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(shortName, color = AarisColor.Ink, style = MaterialTheme.typography.bodyMedium)
+            Text(detail, color = AarisColor.Dim, style = MaterialTheme.typography.labelSmall)
+        }
+        if (chosen) {
+            Icon(
+                Icons.Default.Check,
+                contentDescription = "Currently selected",
+                tint = AarisColor.Accent,
+                modifier = Modifier.size(16.dp),
+            )
+        }
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -16,6 +16,7 @@ import dk.perspektiva.ttsroad.desktop.data.FictionUpdateRequest
 import dk.perspektiva.ttsroad.desktop.data.LibraryResponse
 import dk.perspektiva.ttsroad.desktop.data.LoginResult
 import dk.perspektiva.ttsroad.desktop.data.MobileUser
+import dk.perspektiva.ttsroad.desktop.data.MobileVoice
 import dk.perspektiva.ttsroad.desktop.data.PlaybackMarkResponse
 import dk.perspektiva.ttsroad.desktop.data.PlaybackStateRow
 import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
@@ -77,6 +78,7 @@ open class FakeRepository(
     var uploadCoverResult: Result<CoverUploadResult> =
         Result.success(CoverUploadResult.Saved(FictionSummary(id = 1, title = "Updated"))),
     var audiobookExportsResult: Result<AudiobookExportsResponse?> = Result.success(null),
+    var voicesResult: Result<List<MobileVoice>?> = Result.success(null),
     /** Null models a server whose notifications route answers 404. */
     var chapterNotificationsResult: Result<ChapterNotificationsResponse?> = Result.success(null),
 ) : TtsRoadRepository {
@@ -98,6 +100,7 @@ open class FakeRepository(
     var currentUserCalls: Int = 0
         private set
     var audiobookExportsCalls: Int = 0
+    var voicesCalls: Int = 0
         private set
     var revokeOtherDevicesCalls: Int = 0
         private set
@@ -264,6 +267,11 @@ open class FakeRepository(
     override suspend fun audiobookExports(): AudiobookExportsResponse? {
         audiobookExportsCalls++
         return audiobookExportsResult.getOrThrow()
+    }
+
+    override suspend fun voices(): List<MobileVoice>? {
+        voicesCalls++
+        return voicesResult.getOrThrow()
     }
 
     override suspend fun revokeDevice(tokenId: Int): Boolean {

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/VoiceCatalogueTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/VoiceCatalogueTest.kt
@@ -1,0 +1,220 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import java.util.Locale
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class VoiceCatalogueTest {
+
+    private val catalogue = listOf(
+        MobileVoice("en-US-BrianNeural", "en-US", "Male"),
+        MobileVoice("en-US-AvaMultilingualNeural", "en-US", "Female"),
+        MobileVoice("en-US-AvaNeural", "en-US", "Female"),
+        MobileVoice("en-GB-SoniaNeural", "en-GB", "Female"),
+        MobileVoice("da-DK-ChristelNeural", "da-DK", "Female"),
+        MobileVoice("zh-CN-liaoning-XiaobeiNeural", "zh-CN-liaoning", "Female"),
+    )
+
+    @Test
+    fun `the current voice's locale sorts first, then the machine's language`() {
+        val groups = voiceGroups(catalogue, current = "en-GB-SoniaNeural", locale = Locale.forLanguageTag("da-DK"))
+
+        assertEquals("en-GB", groups.first().locale, "the fiction's own locale opens the list")
+        assertEquals("da-DK", groups[1].locale, "then the machine's own language")
+    }
+
+    @Test
+    fun `with no current voice the machine's language leads`() {
+        val groups = voiceGroups(catalogue, locale = Locale.forLanguageTag("da-DK"))
+
+        assertEquals("da-DK", groups.first().locale)
+    }
+
+    @Test
+    fun `voices are ordered by the name a human reads, not the wire name`() {
+        val group = voiceGroups(catalogue, locale = Locale.US).first { it.locale == "en-US" }
+
+        assertContentEquals(
+            listOf("Ava", "AvaMultilingual", "Brian"),
+            group.voices.map { it.shortName },
+            "AvaNeural and AvaMultilingualNeural belong next to each other",
+        )
+    }
+
+    @Test
+    fun `a three-segment locale is stripped by its own tag`() {
+        val group = voiceGroups(catalogue, locale = Locale.US).first { it.locale == "zh-CN-liaoning" }
+
+        assertEquals(
+            "Xiaobei",
+            group.voices.single().shortName,
+            "a language-region pattern would have left 'liaoning' in the label",
+        )
+    }
+
+    @Test
+    fun `the stored name is never the display name`() {
+        val choice = voiceGroups(catalogue, locale = Locale.US)
+            .flatMap { it.voices }
+            .first { it.shortName == "Brian" }
+
+        assertEquals("en-US-BrianNeural", choice.name)
+        assertEquals("Male  ·  en-US-BrianNeural", choice.detail)
+    }
+
+    @Test
+    fun `search matches the name, the locale tag, the locale label and the gender`() {
+        assertEquals(
+            "en-GB-SoniaNeural",
+            voiceGroups(catalogue, query = "sonia", locale = Locale.US).single().voices.single().name,
+        )
+        assertEquals(
+            "en-GB",
+            voiceGroups(catalogue, query = "united kingdom", locale = Locale.US).single().locale,
+            "the label is searchable, so 'british-sounding' words find the group",
+        )
+        assertEquals("en-GB", voiceGroups(catalogue, query = "en-GB", locale = Locale.US).single().locale)
+        assertTrue(voiceGroups(catalogue, query = "male", locale = Locale.US).isNotEmpty())
+        assertTrue(voiceGroups(catalogue, query = "nothingmatchesthis", locale = Locale.US).isEmpty())
+    }
+
+    @Test
+    fun `a nameless row is dropped rather than offered as an unsaveable choice`() {
+        val groups = voiceGroups(listOf(MobileVoice("", "en-US", "Female")) + catalogue, locale = Locale.US)
+
+        assertTrue(groups.flatMap { it.voices }.none { it.name.isBlank() })
+        assertEquals(6, groups.flatMap { it.voices }.size)
+    }
+
+    @Test
+    fun `a duplicated name is kept once`() {
+        val groups = voiceGroups(catalogue + MobileVoice("en-US-BrianNeural", "en-US", "Male"), locale = Locale.US)
+
+        assertEquals(1, groups.flatMap { it.voices }.count { it.name == "en-US-BrianNeural" })
+    }
+
+    @Test
+    fun `a voice with no locale is filed under Other rather than dropped`() {
+        val groups = voiceGroups(listOf(MobileVoice("SomeLegacyVoice")), locale = Locale.US)
+
+        assertEquals(UnknownVoiceLocale, groups.single().locale)
+        assertEquals("Other", groups.single().label)
+        assertEquals("SomeLegacyVoice", groups.single().voices.single().name)
+    }
+
+    @Test
+    fun `an empty catalogue is an empty list, not a group holding nothing`() {
+        assertTrue(voiceGroups(null).isEmpty())
+        assertTrue(voiceGroups(emptyList()).isEmpty())
+    }
+
+    @Test
+    fun `the group holding the current voice is the one that opens`() {
+        val groups = voiceGroups(catalogue, current = "da-DK-ChristelNeural", locale = Locale.US)
+
+        assertEquals("da-DK", initiallyExpandedVoiceLocale(groups, "da-DK-ChristelNeural"))
+        assertEquals(groups.first().locale, initiallyExpandedVoiceLocale(groups, null))
+        assertNull(initiallyExpandedVoiceLocale(emptyList(), "en-US-BrianNeural"))
+    }
+
+    @Test
+    fun `a bare number is signed rather than refused`() {
+        assertEquals("+10%", normaliseVoiceRate("10"))
+        assertEquals("+10%", normaliseVoiceRate("10%"))
+        assertEquals("+10%", normaliseVoiceRate("+10%"))
+        assertEquals("-10%", normaliseVoiceRate("-10"))
+        assertEquals("-10%", normaliseVoiceRate(" -10% "))
+    }
+
+    @Test
+    fun `zero has one spelling`() {
+        assertEquals("+0%", normaliseVoiceRate("0"))
+        assertEquals("+0%", normaliseVoiceRate("-0%"), "minus zero and plus zero are the same rate")
+        assertEquals("+0%", normaliseVoiceRate("+0%"))
+    }
+
+    @Test
+    fun `a rate that is not a rate is refused before it can be stored`() {
+        assertNull(normaliseVoiceRate("fast"))
+        assertNull(normaliseVoiceRate("++10%"))
+        assertNull(normaliseVoiceRate("1000"), "four digits is not a rate edge-tts takes")
+        assertNull(normaliseVoiceRate("10.5"))
+        assertNull(normaliseVoiceRate("%"))
+        assertNull(normaliseVoiceRate("-"))
+    }
+
+    @Test
+    fun `an empty rate is not a problem - it means leave it alone`() {
+        assertNull(normaliseVoiceRate(""))
+        assertNull(normaliseVoiceRate(null))
+        assertNull(voiceRateProblem(""))
+        assertNull(voiceRateProblem(null))
+        assertNull(voiceRateProblem("  "))
+    }
+
+    @Test
+    fun `a malformed rate reports the shape it should have had`() {
+        val problem = voiceRateProblem("fast")
+
+        assertNotNull(problem)
+        assertTrue(problem.contains("+25%"), "the message names the form rather than only refusing")
+        assertNull(voiceRateProblem("-10%"))
+    }
+
+    @Test
+    fun `both halves of the gate are required to draw a picker`() {
+        val capable = ServerCapabilities(voiceCatalogue = true)
+
+        assertTrue(canPickVoice(capable, isAdmin = true))
+        assertTrue(
+            !canPickVoice(capable, isAdmin = false),
+            "listing is open to anyone but applying is admin-gated, so this would be a 403 on save",
+        )
+        assertTrue(!canPickVoice(ServerCapabilities.Baseline, isAdmin = true))
+    }
+
+    @Test
+    fun `the consequence names what keeps its existing audio`() {
+        assertNull(voiceChangeConsequence(doneChapters = 4, voiceChanged = false, rateChanged = false))
+
+        val many = voiceChangeConsequence(doneChapters = 4, voiceChanged = true, rateChanged = false)
+        assertNotNull(many)
+        assertTrue(many.contains("4 chapters already converted"))
+        assertTrue(many.contains("This voice is"))
+
+        val one = voiceChangeConsequence(doneChapters = 1, voiceChanged = false, rateChanged = true)
+        assertNotNull(one)
+        assertTrue(one.contains("The one chapter"))
+        assertTrue(one.contains("This rate is"))
+
+        val none = voiceChangeConsequence(doneChapters = 0, voiceChanged = true, rateChanged = true)
+        assertNotNull(none)
+        assertTrue(none.contains("Nothing has been converted yet"))
+        assertTrue(none.contains("This voice and rate are"))
+    }
+
+    @Test
+    fun `a locale with no display name falls back to its own tag`() {
+        assertEquals("Other", voiceLocaleLabel(UnknownVoiceLocale))
+        assertEquals("English (United States)", voiceLocaleLabel("en-US", Locale.US))
+    }
+
+    @Test
+    fun `a name that shortens to nothing keeps its full name`() {
+        assertEquals(
+            "en-US-",
+            shortVoiceName("en-US-", "en-US"),
+            "stripping the prefix leaves nothing, and a label is not worth losing the identity over",
+        )
+    }
+
+    @Test
+    fun `a name with no locale still loses its Neural suffix`() {
+        assertEquals("Brian", shortVoiceName("BrianNeural", null))
+        assertEquals("Brian", shortVoiceName("en-US-BrianNeural", "en-US"))
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionManagementStateHolderTest.kt
@@ -4,10 +4,12 @@ import dk.perspektiva.ttsroad.desktop.FakeRepository
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
 import dk.perspektiva.ttsroad.desktop.data.LibraryCache
 import dk.perspektiva.ttsroad.desktop.data.MobileUser
+import dk.perspektiva.ttsroad.desktop.data.MobileVoice
 import dk.perspektiva.ttsroad.desktop.data.SyncScope
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -42,6 +44,146 @@ class FictionManagementStateHolderTest {
         runCurrent()
         assertEquals(FictionManagementAccess.NotAdmin, holder.state.value.access)
         assertEquals(2, repository.currentUserCalls)
+
+        holder.clear()
+        cache.close()
+    }
+
+    @Test
+    fun `the catalogue is fetched only for an admin on a server that advertises it`() = runTest {
+        val voices = listOf(MobileVoice("en-US-BrianNeural", "en-US", "Male"))
+        val repository = FakeRepository(
+            currentUserResult = Result.success(MobileUser(1, "reader", isAdmin = false)),
+            voicesResult = Result.success(voices),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        val holder = FictionManagementStateHolder(repository, cache, dispatcher = UnconfinedTestDispatcher(testScheduler))
+
+        // Advertised, but this account cannot apply a choice — listing it would draw a picker whose
+        // save is a 403.
+        holder.ensureAccess(supported = true, voiceCatalogue = true)
+        runCurrent()
+        assertEquals(0, repository.voicesCalls)
+        assertFalse(holder.state.value.canPickVoice)
+
+        repository.currentUserResult = Result.success(MobileUser(1, "boss", isAdmin = true))
+        holder.ensureAccess(supported = true, voiceCatalogue = true, forceRefresh = true)
+        runCurrent()
+        assertEquals(1, repository.voicesCalls)
+        assertTrue(holder.state.value.canPickVoice)
+        assertEquals(voices, holder.state.value.voices)
+
+        holder.clear()
+        cache.close()
+    }
+
+    @Test
+    fun `a server that does not advertise the catalogue is never asked for it`() = runTest {
+        val repository = FakeRepository(
+            currentUserResult = Result.success(MobileUser(1, "boss", isAdmin = true)),
+            voicesResult = Result.success(listOf(MobileVoice("en-US-BrianNeural", "en-US", "Male"))),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        val holder = FictionManagementStateHolder(repository, cache, dispatcher = UnconfinedTestDispatcher(testScheduler))
+
+        holder.ensureAccess(supported = true, voiceCatalogue = false)
+        runCurrent()
+
+        assertEquals(0, repository.voicesCalls)
+        assertNull(holder.state.value.voices)
+        assertFalse(holder.state.value.canPickVoice)
+
+        holder.clear()
+        cache.close()
+    }
+
+    @Test
+    fun `a catalogue that will not load leaves the field typed rather than raising an error`() = runTest {
+        val repository = FakeRepository(
+            currentUserResult = Result.success(MobileUser(1, "boss", isAdmin = true)),
+            voicesResult = Result.failure(IllegalStateException("no route")),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        val holder = FictionManagementStateHolder(repository, cache, dispatcher = UnconfinedTestDispatcher(testScheduler))
+
+        holder.ensureAccess(supported = true, voiceCatalogue = true)
+        runCurrent()
+
+        assertEquals(1, repository.voicesCalls)
+        assertNull(holder.state.value.voices)
+        assertNull(
+            holder.state.value.error,
+            "the picker is an improvement on a field that still works; its failure is not the user's problem",
+        )
+        assertEquals(FictionManagementAccess.Admin, holder.state.value.access)
+
+        holder.clear()
+        cache.close()
+    }
+
+    @Test
+    fun `a malformed rate is reported on the add form before anything is sent`() = runTest {
+        val repository = FakeRepository(
+            currentUserResult = Result.success(MobileUser(1, "boss", isAdmin = true)),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        val holder = FictionManagementStateHolder(repository, cache, dispatcher = UnconfinedTestDispatcher(testScheduler))
+
+        holder.ensureAccess(supported = true)
+        runCurrent()
+        holder.openAdd()
+
+        assertNull(holder.state.value.rateProblem, "a blank rate means leave the default alone")
+
+        holder.updateAdd(rate = "quickly")
+        assertNotNull(holder.state.value.rateProblem)
+
+        holder.updateAdd(rate = "+10%")
+        assertNull(holder.state.value.rateProblem)
+
+        holder.clear()
+        cache.close()
+    }
+
+    @Test
+    fun `a malformed rate is refused by the holder, not only by the button`() = runTest {
+        val repository = FakeRepository(
+            currentUserResult = Result.success(MobileUser(1, "boss", isAdmin = true)),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        val holder = FictionManagementStateHolder(repository, cache, dispatcher = UnconfinedTestDispatcher(testScheduler))
+
+        holder.ensureAccess(supported = true)
+        runCurrent()
+        holder.openAdd()
+        holder.updateAdd(fictionUrl = "https://www.royalroad.com/fiction/21220", rate = "quickly")
+
+        holder.submitAdd()
+        runCurrent()
+
+        assertTrue(repository.createdFictions.isEmpty())
+        assertNotNull(holder.state.value.error)
+
+        holder.clear()
+        cache.close()
+    }
+
+    @Test
+    fun `a bare rate is signed before it is sent`() = runTest {
+        val repository = FakeRepository(
+            currentUserResult = Result.success(MobileUser(1, "boss", isAdmin = true)),
+        )
+        val cache = LibraryCache(repository, UnconfinedTestDispatcher(testScheduler))
+        val holder = FictionManagementStateHolder(repository, cache, dispatcher = UnconfinedTestDispatcher(testScheduler))
+
+        holder.ensureAccess(supported = true)
+        runCurrent()
+        holder.openAdd()
+        holder.updateAdd(fictionUrl = "https://www.royalroad.com/fiction/21220", rate = "10")
+        holder.submitAdd()
+        runCurrent()
+
+        assertEquals("+10%", repository.createdFictions.single().rate)
 
         holder.clear()
         cache.close()

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionMetadataStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionMetadataStateHolderTest.kt
@@ -5,10 +5,12 @@ import dk.perspektiva.ttsroad.desktop.data.CoverUploadResult
 import dk.perspektiva.ttsroad.desktop.data.FictionMetadataFields
 import dk.perspektiva.ttsroad.desktop.data.FictionSummary
 import dk.perspektiva.ttsroad.desktop.data.LibraryCache
+import dk.perspektiva.ttsroad.desktop.data.MobileVoice
 import java.io.File
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -341,6 +343,120 @@ class FictionMetadataStateHolderTest {
 
         assertNull(fixture.holder.state.value.fiction)
         assertEquals("", fixture.holder.state.value.draft.title)
+        fixture.close()
+    }
+
+
+    @Test
+    fun `the rate is sent normalised, so a typo cannot reach the next conversion`() = runTest {
+        val fixture = fixture()
+        val withRate = serial.copy(rate = "+0%")
+        fixture.repository.updateFictionResult = Result.success(withRate)
+        fixture.holder.load(withRate)
+
+        // The server stores this string unchecked, so "25" would save and then fail hours later.
+        fixture.holder.setRate("25")
+        fixture.holder.save()
+        runCurrent()
+
+        val sent = fixture.repository.updatedFictions.single().second
+        assertEquals("+25%", sent.rate)
+        assertNull(sent.title, "changing a rate claims no metadata field")
+        assertNull(sent.voice)
+
+        fixture.close()
+    }
+
+    @Test
+    fun `a rate that only differs in spelling is not a change`() = runTest {
+        val fixture = fixture()
+        fixture.holder.load(serial.copy(rate = "+10%"))
+
+        fixture.holder.setRate("10")
+
+        assertFalse(
+            fixture.holder.state.value.rateChanged,
+            "re-typing the same rate differently would otherwise offer to save it back forever",
+        )
+        assertFalse(fixture.holder.state.value.hasChanges)
+
+        fixture.close()
+    }
+
+    @Test
+    fun `a malformed rate blocks the save rather than being sent`() = runTest {
+        val fixture = fixture()
+        fixture.holder.load(serial.copy(rate = "+0%"))
+
+        fixture.holder.setRate("very fast")
+
+        assertNotNull(fixture.holder.state.value.rateProblem)
+        assertFalse(fixture.holder.state.value.canSave)
+
+        // The disabled button is a courtesy; the holder is what has to refuse.
+        fixture.holder.save()
+        runCurrent()
+        assertTrue(fixture.repository.updatedFictions.isEmpty())
+        assertNotNull(fixture.holder.state.value.error, "refusing silently would look like a dead button")
+
+        fixture.close()
+    }
+
+    @Test
+    fun `the consequence appears only while narration is actually changing`() = runTest {
+        val fixture = fixture()
+        fixture.holder.load(serial.copy(rate = "+0%", doneChapters = 12))
+
+        assertNull(fixture.holder.state.value.narrationConsequence)
+
+        fixture.holder.setVoice("en-GB-SoniaNeural")
+        val consequence = fixture.holder.state.value.narrationConsequence
+        assertNotNull(consequence)
+        assertTrue(consequence.contains("12 chapters already converted"))
+        assertTrue(consequence.contains("nothing is re-narrated"))
+
+        fixture.holder.setVoice(serial.voice.orEmpty())
+        assertNull(fixture.holder.state.value.narrationConsequence)
+
+        fixture.close()
+    }
+
+    @Test
+    fun `the catalogue is fetched only when the server advertises it`() = runTest {
+        val fixture = fixture()
+        fixture.repository.voicesResult = Result.success(listOf(MobileVoice("en-US-BrianNeural", "en-US", "Male")))
+
+        fixture.holder.load(serial, voiceCatalogue = false)
+        runCurrent()
+        assertEquals(0, fixture.repository.voicesCalls)
+        assertFalse(fixture.holder.state.value.canPickVoice)
+
+        fixture.holder.load(serial, voiceCatalogue = true)
+        runCurrent()
+        assertEquals(1, fixture.repository.voicesCalls)
+        assertTrue(fixture.holder.state.value.canPickVoice)
+
+        fixture.close()
+    }
+
+    @Test
+    fun `switching fiction keeps the catalogue but resets the form`() = runTest {
+        val fixture = fixture()
+        fixture.repository.voicesResult = Result.success(listOf(MobileVoice("en-US-BrianNeural", "en-US", "Male")))
+        fixture.holder.load(serial, voiceCatalogue = true)
+        runCurrent()
+
+        fixture.holder.load(serial.copy(id = 9, title = "Another"), voiceCatalogue = true)
+        runCurrent()
+
+        assertEquals("Another", fixture.holder.state.value.draft.title)
+        assertEquals(
+            1,
+            fixture.repository.voicesCalls,
+            "the catalogue belongs to the server, not to the book, so it survives the reset",
+        )
+        assertTrue(fixture.holder.state.value.canPickVoice)
+
         fixture.close()
     }
 


### PR DESCRIPTION
Closes #109. Broken out of the capability-parity tracker (#94), which marks
`voice_catalogue` **Wanted**.

Three problems of one shape: the desktop was the only client sending narration
settings it had never looked at.

## The voice was typed

The server has published the edge-tts catalogue at `GET /api/mobile/voices` all
along, and this client never asked — so choosing a voice meant knowing that
Microsoft spells it `en-US-BrianNeural`. It is a grouped picker now, ordered so
the useful locale is first: the one the fiction already uses, then the machine's
own language, then the rest. Deliberately not alphabetical, because a hundred
locales of alphabet is a control nobody reaches the bottom of.

## The rate was not validated, which is the part that was actually broken

`FictionUpdate.rate` is a bare `Optional[str]` on the server with **no
validator**. So `10` or `10%` saved cleanly, looked right on screen, and then
failed at the *next conversion* as a chapter that would not narrate — hours
later, with nothing on screen connecting the two. The web console checks this
with `VP_RATE_RE` and Android with `normaliseVoiceRate`; the desktop checked
nowhere.

Caught before the request now, and normalised rather than sent as typed.

**Both holders refuse it, not only the button.** That distinction cost a red test
on the first run of this branch and was worth the trip: `save()` and
`submitAdd()` had validation blocks that did not mention the rate, so the
disabled control was the only thing between a typo and the database — the same
bug one layer below the one being fixed.

## The rate could not be changed after adding

`FictionResponse` has always carried `rate` beside `voice`; `FictionSummary`
decoded one and not the other, so the editor had no field for it. Now decoded and
editable, and compared **normalised**, so re-typing `10` over a stored `+10%` is
not a change and the screen does not offer to save the same rate back on every
visit.

## Gates and degradation

- The picker takes **both** halves: the `voice_catalogue` capability *and*
  `is_admin`. Listing is open to any account and applying is admin-gated by the
  `PATCH`, so the capability alone would draw a control whose save is a 403.
- A server without the route keeps the typed field. It is the only way to set a
  voice at all there; retiring it would remove the feature rather than improve it.
- A catalogue that fails to load is **silent**. The picker improves on something
  that already works, so an error banner for a list nobody asked for would report
  a problem the user does not have.
- Changing a voice re-narrates nothing, and that sentence is on screen at the
  point of the change — only while something is actually changing, so it reads as
  a consequence rather than as documentation.

## Verification

`xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail
-Pttsroad.warningsAsErrors=true` — BUILD SUCCESSFUL in 6m27s. That is the CI
gate, not plain `check`.

31 new tests. The catalogue's grouping, ordering, name-shortening, search and
rate normalisation are pure functions tested directly, including
`zh-CN-liaoning-XiaobeiNeural`, whose locale is three segments and which a
language-region pattern would shorten wrongly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK3sri5jA6ne6tEJnbQaRe
