### PR TITLE
Empty a shelf that was filled without asking

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -104,6 +104,8 @@ import dk.perspektiva.ttsroad.desktop.ui.hasSession
 import dk.perspektiva.ttsroad.desktop.ui.rememberChapterDownloads
 import dk.perspektiva.ttsroad.desktop.ui.rememberChapterQueue
 import dk.perspektiva.ttsroad.desktop.ui.UpdateStateHolder
+import dk.perspektiva.ttsroad.desktop.ui.ManageShelfScreen
+import dk.perspektiva.ttsroad.desktop.ui.ManageShelfStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.rememberStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.windowSizeClassFor
 import kotlinx.coroutines.launch
@@ -161,6 +163,10 @@ fun App(
     val bookmarks = rememberStateHolder(repository, cache) {
         BookmarksStateHolder(repository, cachedChapters = { cache.chapters(it).value.value })
     }
+    // Not hoisted for a writer elsewhere, unlike the three below: nothing outside this screen edits
+    // a shelf in bulk. It lives here so the selection survives a trip into a fiction and back,
+    // which is exactly what somebody deciding what to drop will do.
+    val manageShelf = rememberStateHolder(cache) { ManageShelfStateHolder(cache) }
     // Hoisted for the same reason: "Add to queue" is pressed on a chapter list, so the queue has to
     // exist and report what happened whether or not the queue screen was ever opened.
     val serverQueue = rememberStateHolder(repository, playback) {
@@ -257,6 +263,7 @@ fun App(
             Destination.Settings, Destination.Devices -> settings.refreshCurrentSection()
             Destination.Search -> search.refresh()
             Destination.Bookmarks -> bookmarks.refresh()
+            Destination.ManageShelf -> manageShelf.refresh()
             Destination.Notifications -> chapterNotifications.refresh()
             Destination.Queue -> serverQueue.refresh()
             // A form and a player have nothing a refresh could improve; see `isRefreshable`.
@@ -661,6 +668,11 @@ fun App(
                                     onBack = { nav.back() },
                                 )
 
+                                Destination.ManageShelf -> ManageShelfScreen(
+                                    holder = manageShelf,
+                                    onBack = { nav.back() },
+                                )
+
                                 Destination.Settings, Destination.Devices -> SettingsScreen(
                                     sessionStore = sessionStore,
                                     repository = repository,
@@ -680,6 +692,7 @@ fun App(
                                     // Keeps the destination and the open pane in step, so the
                                     // Devices deep link and the in-screen pane list are the same
                                     // thing rather than two competing notions of "where am I".
+                                    onOpenShelf = { nav.open(Destination.ManageShelf) },
                                     onSectionSelected = { section ->
                                         nav.replaceTop(
                                             if (section == SettingsSection.Devices) {
@@ -756,7 +769,7 @@ fun App(
 private val Destination.isRefreshable: Boolean
     get() = when (this) {
         Destination.Library, is Destination.Fiction, Destination.Settings, Destination.Devices,
-        Destination.Bookmarks, Destination.Queue, Destination.Notifications,
+        Destination.Bookmarks, Destination.Queue, Destination.Notifications, Destination.ManageShelf,
         -> true
         // A form has nothing to refresh into: the fields hold what somebody is halfway through
         // typing, and replacing them with the server's copy is the opposite of what F5 promises.

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ShelfEditing.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ShelfEditing.kt
@@ -1,0 +1,84 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+/**
+ * Removing several fictions from a shelf at once (#110).
+ *
+ * The pure half: what a selection means, and what to say afterwards. The requests live in
+ * `ui/ManageShelfStateHolder.kt`.
+ *
+ * This exists because a shelf is routinely filled without anybody pressing Follow — the per-user
+ * library upgrade backfilled every account with every fiction so that upgrading did not blank
+ * everyone's dashboard, and adding a fiction auto-follows it for the adder, which on a single-admin
+ * install is the whole server. Emptying it one screen at a time was the only exit.
+ *
+ * There is deliberately **no bulk follow** here. The problem being solved is a shelf filled without
+ * asking; a faster way to fill it is not the answer to that.
+ */
+
+/**
+ * What actually happened, which is not always what was asked for.
+ *
+ * Ten unfollows where the seventh fails is not "the operation failed" — six of them happened, and
+ * the server is now in a state neither the request nor a rollback describes. Both lists are kept so
+ * the screen can say so and leave the selection holding only what is still there.
+ */
+data class UnfollowOutcome(
+    val removed: List<Int> = emptyList(),
+    val failed: List<Int> = emptyList(),
+) {
+    val attempted: Int get() = removed.size + failed.size
+    val isCompleteSuccess: Boolean get() = failed.isEmpty() && removed.isNotEmpty()
+    val isCompleteFailure: Boolean get() = removed.isEmpty() && failed.isNotEmpty()
+}
+
+/**
+ * The sentence for an [UnfollowOutcome].
+ *
+ * Never "done" when something failed and never "failed" when something worked. The partial case
+ * names both numbers, because the useful next action — try the rest again — depends on knowing there
+ * *is* a rest.
+ *
+ * Null when nothing was attempted: an outcome with no rows is not news.
+ */
+fun unfollowReport(outcome: UnfollowOutcome): String? = when {
+    outcome.attempted == 0 -> null
+    outcome.isCompleteFailure -> when (outcome.failed.size) {
+        1 -> "That fiction could not be unfollowed. It is still on your shelf."
+        else -> "None of the ${outcome.failed.size} could be unfollowed. They are still on your shelf."
+    }
+    outcome.failed.isEmpty() -> when (outcome.removed.size) {
+        1 -> "Unfollowed one fiction."
+        else -> "Unfollowed ${outcome.removed.size} fictions."
+    }
+    else ->
+        "Unfollowed ${outcome.removed.size} of ${outcome.attempted}. " +
+            "${outcome.failed.size} could not be removed and are still on your shelf."
+}
+
+/**
+ * The confirmation shown before anything is sent.
+ *
+ * It states what unfollowing does *not* do, because the word invites the opposite guess. Following
+ * decides whose dashboard and default library view a fiction appears on and nothing else: it is not
+ * an access boundary, nothing is deleted, progress is untouched, and the fiction stays openable and
+ * re-followable. A destructive-sounding confirmation over a reversible action teaches people to
+ * dismiss confirmations.
+ */
+fun unfollowConfirmation(count: Int): String {
+    val subject = if (count == 1) "this fiction" else "these $count fictions"
+    return "Remove $subject from your shelf. Nothing is deleted — your listening progress is kept, " +
+        "and you can find them again under all fictions and follow them back."
+}
+
+/**
+ * The selection, minus anything the shelf no longer holds.
+ *
+ * A refresh can land while rows are ticked, and a selection naming a fiction that is gone would
+ * report a count the screen cannot show. Order follows [available] rather than insertion, so the
+ * count and the ticked rows always agree.
+ */
+fun prunedSelection(selected: Set<Int>, available: List<FictionSummary>): Set<Int> {
+    if (selected.isEmpty()) return emptySet()
+    val present = available.mapTo(LinkedHashSet()) { it.id }
+    return present.filterTo(LinkedHashSet()) { it in selected }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/nav/AppNavigation.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/nav/AppNavigation.kt
@@ -80,6 +80,15 @@ sealed interface Destination {
      */
     data object Notifications : Destination
 
+    /**
+     * The followed shelf, as something to edit rather than to browse.
+     *
+     * Carries nothing: it reads the same cached library every other screen does. Reached from
+     * Settings rather than the header, because emptying a shelf is a rare, deliberate visit — the
+     * everyday way to drop one book is still the Follow control on its own screen.
+     */
+    data object ManageShelf : Destination
+
     data object Settings : Destination
 
     data object Devices : Destination
@@ -104,6 +113,7 @@ val Destination.key: String
         Destination.Bookmarks -> "Bookmarks"
         Destination.Queue -> "Queue"
         Destination.Notifications -> "Notifications"
+        Destination.ManageShelf -> "ManageShelf"
         Destination.Settings -> "Settings"
         Destination.Devices -> "Devices"
     }

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ManageShelfScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ManageShelfScreen.kt
@@ -1,0 +1,188 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+
+const val ManageShelfScreenTestTag: String = "manageShelfScreen"
+const val UnfollowSelectedTestTag: String = "unfollowSelected"
+const val ShelfRowTestTagPrefix: String = "shelfRow:"
+
+/**
+ * The followed shelf as something to edit.
+ *
+ * Subtractive by design — there is no bulk *follow* here. A shelf gets filled without anybody
+ * pressing Follow (the per-user library upgrade backfilled every account with every fiction, and
+ * adding one auto-follows it for the adder), so the operation that was missing is the one that
+ * empties it, and a faster way to fill it would not answer the same complaint.
+ *
+ * Unfollow is drawn as a plain action rather than a tinted destructive one: colour here carries
+ * severity, and nothing is destroyed. Following decides whose dashboard and default library view a
+ * fiction appears on and nothing else — progress is kept, the book stays openable, and it can be
+ * followed again. The confirmation says so, because the word invites the opposite guess.
+ */
+@Composable
+fun ManageShelfScreen(holder: ManageShelfStateHolder, onBack: () -> Unit) {
+    val ui by holder.state.collectAsState()
+
+    Box(Modifier.fillMaxSize()) {
+        Column(
+            Modifier
+                .align(Alignment.TopCenter)
+                .widthIn(max = ContentMaxWidth)
+                .fillMaxSize()
+                .padding(horizontal = PageGutter, vertical = 20.dp)
+                .testTag(ManageShelfScreenTestTag),
+        ) {
+            BackLink("Back", onBack)
+            Spacer(Modifier.height(12.dp))
+            SectionTitle("shelf", "Fictions you follow")
+            Spacer(Modifier.height(8.dp))
+            Text(
+                "Following decides what appears on your shelf and in Continue listening. " +
+                    "Unfollowing removes nothing else.",
+                color = AarisColor.Dim,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            ui.notice?.let {
+                Spacer(Modifier.height(12.dp))
+                InlineNotice(it) { holder.dismissNotice() }
+            }
+            Spacer(Modifier.height(16.dp))
+
+            if (ui.fictions.isEmpty()) {
+                EmptyState(
+                    "Nothing on your shelf",
+                    "Open a fiction under all fictions and follow it to see it here.",
+                )
+                return@Column
+            }
+
+            ShelfControls(
+                total = ui.fictions.size,
+                selected = ui.selectedCount,
+                allSelected = ui.allSelected,
+                busy = ui.isBusy,
+                canUnfollow = ui.canUnfollow,
+                onToggleAll = holder::toggleAll,
+                onUnfollow = holder::askToUnfollow,
+            )
+            Spacer(Modifier.height(12.dp))
+            LazyColumn(
+                Modifier.fillMaxWidth().weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                items(ui.fictions, key = { it.id }) { fiction ->
+                    ShelfRow(
+                        fiction = fiction,
+                        checked = fiction.id in ui.selected,
+                        enabled = !ui.isBusy,
+                        onToggle = { holder.toggle(fiction.id) },
+                    )
+                }
+            }
+        }
+    }
+
+    ui.confirming?.let { count ->
+        ConfirmDialog(
+            title = if (count == 1) "UNFOLLOW ONE FICTION" else "UNFOLLOW $count FICTIONS",
+            body = ui.confirmationBody.orEmpty(),
+            confirmLabel = "UNFOLLOW",
+            onConfirm = holder::confirmUnfollow,
+            onDismiss = holder::dismissConfirmation,
+        )
+    }
+}
+
+@Composable
+private fun ShelfControls(
+    total: Int,
+    selected: Int,
+    allSelected: Boolean,
+    busy: Boolean,
+    canUnfollow: Boolean,
+    onToggleAll: () -> Unit,
+    onUnfollow: () -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        AarisSecondaryAction(
+            label = if (allSelected) "Select none" else "Select all",
+            onClick = onToggleAll,
+            enabled = !busy,
+        )
+        Text(
+            // States the total as well as the selection: "3 selected" alone does not say of what,
+            // and the shelf is exactly the number somebody came here to reduce.
+            if (selected == 0) "$total on your shelf" else "$selected of $total selected",
+            color = AarisColor.Dim,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f),
+        )
+        AarisSecondaryAction(
+            label = if (busy) "Unfollowing…" else "Unfollow selected",
+            onClick = onUnfollow,
+            enabled = canUnfollow,
+            modifier = Modifier.testTag(UnfollowSelectedTestTag),
+        )
+    }
+}
+
+@Composable
+private fun ShelfRow(
+    fiction: FictionSummary,
+    checked: Boolean,
+    enabled: Boolean,
+    onToggle: () -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .toggleable(value = checked, enabled = enabled, role = Role.Checkbox) { onToggle() }
+            .pointerHoverIcon(PointerIcon.Hand)
+            .background(if (checked) AarisColor.BgHover else AarisColor.BgRaise)
+            .padding(horizontal = 12.dp, vertical = 10.dp)
+            .testTag("$ShelfRowTestTagPrefix${fiction.id}"),
+    ) {
+        // Null, because the whole row carries the toggle: a checkbox with its own click target
+        // inside a toggleable row is two controls reporting one state.
+        Checkbox(checked = checked, onCheckedChange = null, enabled = enabled)
+        Column(Modifier.weight(1f)) {
+            Text(fiction.title, color = AarisColor.Ink, style = MaterialTheme.typography.bodyMedium)
+            fiction.author?.takeIf { it.isNotBlank() }?.let {
+                Text(it, color = AarisColor.Dim, style = MaterialTheme.typography.labelSmall)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ManageShelfStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ManageShelfStateHolder.kt
@@ -1,0 +1,150 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.LibraryCache
+import dk.perspektiva.ttsroad.desktop.data.UnfollowOutcome
+import dk.perspektiva.ttsroad.desktop.data.prunedSelection
+import dk.perspektiva.ttsroad.desktop.data.unfollowConfirmation
+import dk.perspektiva.ttsroad.desktop.data.unfollowReport
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class ManageShelfUiState(
+    /** The followed shelf, as the cache last knew it. */
+    val fictions: List<FictionSummary> = emptyList(),
+    val selected: Set<Int> = emptySet(),
+    val isBusy: Boolean = false,
+    /** The confirmation currently on screen, or null. Holds the count it was raised for. */
+    val confirming: Int? = null,
+    val notice: String? = null,
+    val error: String? = null,
+) {
+    val selectedCount: Int get() = selected.size
+    val canUnfollow: Boolean get() = selected.isNotEmpty() && !isBusy
+    val allSelected: Boolean get() = fictions.isNotEmpty() && selected.size == fictions.size
+
+    /** The sentence under the confirmation, or null when none is up. */
+    val confirmationBody: String? get() = confirming?.let(::unfollowConfirmation)
+}
+
+/**
+ * Editing the shelf itself, rather than one fiction at a time (#110).
+ *
+ * A shelf is routinely filled without anybody pressing Follow — the per-user library upgrade
+ * backfilled every account with every fiction, and adding one auto-follows it for the adder — so the
+ * useful operation is subtractive and plural. There is deliberately no bulk *follow*: the complaint
+ * is a shelf filled without asking, and a faster way to fill it does not answer that.
+ *
+ * The unfollows are sent one at a time against the existing idempotent
+ * `DELETE /api/mobile/fictions/{id}/follow`, rather than through a new bulk route. That keeps this
+ * working against every deployment advertising `follows` today, including ones that will never be
+ * upgraded, and it is what makes a **partial** outcome the normal case to design for rather than an
+ * edge: the seventh of ten failing leaves six genuinely removed, and neither "done" nor "failed"
+ * describes that.
+ */
+class ManageShelfStateHolder(
+    private val cache: LibraryCache,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : StateHolder(dispatcher) {
+    private val _state = MutableStateFlow(ManageShelfUiState())
+    val state: StateFlow<ManageShelfUiState> = _state.asStateFlow()
+
+    private var unfollowJob: Job? = null
+
+    init {
+        scope.launch {
+            cache.library.collect { cached ->
+                val fictions = cached.value?.fictions.orEmpty()
+                _state.update {
+                    // A refresh can land while rows are ticked. Pruning here rather than at use
+                    // keeps the count and the ticked rows from ever disagreeing.
+                    it.copy(fictions = fictions, selected = prunedSelection(it.selected, fictions))
+                }
+            }
+        }
+    }
+
+    fun toggle(fictionId: Int) {
+        if (_state.value.isBusy) return
+        _state.update {
+            val selected = if (fictionId in it.selected) it.selected - fictionId else it.selected + fictionId
+            it.copy(selected = selected, notice = null, error = null)
+        }
+    }
+
+    /** Select everything, or clear it when everything already is. One control, both directions. */
+    fun toggleAll() {
+        if (_state.value.isBusy) return
+        _state.update {
+            val selected = if (it.allSelected) emptySet() else it.fictions.mapTo(LinkedHashSet()) { row -> row.id }
+            it.copy(selected = selected, notice = null, error = null)
+        }
+    }
+
+    fun clearSelection() {
+        if (_state.value.isBusy) return
+        _state.update { it.copy(selected = emptySet(), notice = null, error = null) }
+    }
+
+    fun askToUnfollow() {
+        val current = _state.value
+        if (!current.canUnfollow) return
+        _state.update { it.copy(confirming = current.selected.size, notice = null, error = null) }
+    }
+
+    fun dismissConfirmation() = _state.update { it.copy(confirming = null) }
+
+    /**
+     * Unfollow everything selected, reporting what actually happened.
+     *
+     * Rows are attempted in shelf order so a partial result is comprehensible — "the first six went"
+     * rather than a scattering. Each removal patches the cached flag as it lands, so the screen
+     * empties as it works instead of at the end; the shelf is re-read once at the finish because a
+     * membership change is a different list, not a flag flip.
+     */
+    fun confirmUnfollow() {
+        val current = _state.value
+        if (current.confirming == null || !current.canUnfollow) return
+        val targets = current.fictions.map { it.id }.filter { it in current.selected }
+        if (targets.isEmpty()) return
+
+        unfollowJob?.cancel()
+        unfollowJob = scope.launch {
+            _state.update { it.copy(isBusy = true, confirming = null, notice = null, error = null) }
+            val removed = mutableListOf<Int>()
+            val failed = mutableListOf<Int>()
+            targets.forEach { id ->
+                // A 404 is null here and is *not* success: it means no such fiction or no such
+                // endpoint, and neither removed anything.
+                val confirmed = runCatching { cache.setFollowing(id, following = false) }.getOrNull()
+                if (confirmed == false) removed += id else failed += id
+                _state.update { it.copy(selected = it.selected - removed.toSet()) }
+            }
+            val outcome = UnfollowOutcome(removed = removed, failed = failed)
+            _state.update {
+                it.copy(
+                    isBusy = false,
+                    // The failures stay ticked: they are what a retry would act on, and clearing
+                    // them would present a partial result as a finished one.
+                    selected = failed.toSet(),
+                    notice = unfollowReport(outcome),
+                    error = null,
+                )
+            }
+        }
+    }
+
+    fun refresh() = cache.refreshLibrary()
+
+    fun dismissNotice() = _state.update { it.copy(notice = null, error = null) }
+
+    override fun onCleared() {
+        unfollowJob?.cancel()
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
@@ -108,6 +108,8 @@ fun SettingsScreen(
      * in step — the app uses it to swap the top back-stack entry between Settings and Devices.
      */
     onSectionSelected: (SettingsSection) -> Unit = {},
+    /** Opens the shelf editor. A destination rather than a pane: it is a list, not a form. */
+    onOpenShelf: () -> Unit = {},
     /**
      * Listening settings. Defaulted to an in-memory store so a screen test — and a preview — never
      * writes to the real config directory just by rendering the Playback pane.
@@ -188,7 +190,8 @@ fun SettingsScreen(
                     verticalArrangement = Arrangement.spacedBy(16.dp),
                 ) {
                     when (ui.section) {
-                        SettingsSection.Account -> AccountPane(ui, session, capabilities, sessionStore, holder, selectSection, nowMs)
+                        SettingsSection.Account ->
+                            AccountPane(ui, session, capabilities, sessionStore, holder, selectSection, onOpenShelf, nowMs)
                         SettingsSection.Devices -> DevicesPane(ui, session, holder, nowMs)
                         SettingsSection.Playback -> PlaybackPane(
                             preferences,
@@ -245,6 +248,7 @@ fun SettingsScreen(
 }
 
 const val AudiobookDownloadButtonTestTag: String = "audiobookDownloadButton"
+const val ManageShelfButtonTestTag: String = "manageShelfButton"
 
 @Composable
 private fun AudiobookPane(ui: AudiobookExportsUiState, holder: SettingsStateHolder) {
@@ -463,6 +467,7 @@ private fun AccountPane(
     sessionStore: SessionStore,
     holder: SettingsStateHolder,
     onSelectSection: (SettingsSection) -> Unit,
+    onOpenShelf: () -> Unit,
     nowMs: () -> Long,
 ) {
     PaneTitle("Account", "Server, sign-in and this device")
@@ -511,6 +516,15 @@ private fun AccountPane(
             shape = RectangleShape,
             modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
         ) { Text("MANAGE DEVICE SESSIONS") }
+        // Only where the server has per-user shelves at all: without `follows`, the library is one
+        // shared list and there is no membership to edit.
+        if (capabilities.follows) {
+            OutlinedButton(
+                onClick = onOpenShelf,
+                shape = RectangleShape,
+                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).testTag(ManageShelfButtonTestTag),
+            ) { Text("MANAGE SHELF") }
+        }
         Button(
             onClick = holder::askSignOut,
             enabled = !ui.signingOut,

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -63,6 +63,13 @@ open class FakeRepository(
     var browseAllResult: Result<LibraryResponse> = Result.success(LibraryResponse()),
     /** Null means "echo what was asked". `success(null)` is the server's 404. */
     var followResult: Result<Boolean?>? = null,
+    /**
+     * Per-fiction override, consulted before [followResult].
+     *
+     * A bulk unfollow's interesting case is the *partial* one — some ids succeed and one does not —
+     * which a single shared answer cannot express.
+     */
+    var followResultFor: ((Int) -> Result<Boolean?>?)? = null,
     /** `success(null)` is the server saying it has no bookmark API — not "no bookmarks". */
     var bookmarksResult: Result<List<Bookmark>?> = Result.success(emptyList()),
     var createBookmarkResult: Result<Bookmark?> = Result.success(Bookmark(id = 1)),
@@ -210,7 +217,7 @@ open class FakeRepository(
         // An *unset* `followResult` echoes what was asked, which is what a healthy server does.
         // A set one is used as-is, null included — `success(null)` is the server's 404 and must not
         // fall through to the echo.
-        val configured = followResult ?: return following
+        val configured = followResultFor?.invoke(fictionId) ?: followResult ?: return following
         return configured.getOrThrow()
     }
 

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ShelfEditingTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ShelfEditingTest.kt
@@ -1,0 +1,84 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class ShelfEditingTest {
+
+    @Test
+    fun `a partial outcome is never reported as done or as failed`() {
+        val partial = UnfollowOutcome(removed = listOf(1, 2, 3), failed = listOf(4, 5))
+        val report = unfollowReport(partial)
+
+        assertEquals(
+            "Unfollowed 3 of 5. 2 could not be removed and are still on your shelf.",
+            report,
+            "six removals reported as a failure would send somebody to undo work that succeeded",
+        )
+        assertFalse(partial.isCompleteSuccess)
+        assertFalse(partial.isCompleteFailure)
+    }
+
+    @Test
+    fun `complete success counts what went`() {
+        assertEquals("Unfollowed one fiction.", unfollowReport(UnfollowOutcome(removed = listOf(1))))
+        assertEquals("Unfollowed 4 fictions.", unfollowReport(UnfollowOutcome(removed = listOf(1, 2, 3, 4))))
+        assertTrue(UnfollowOutcome(removed = listOf(1)).isCompleteSuccess)
+    }
+
+    @Test
+    fun `complete failure says the shelf is unchanged`() {
+        val one = unfollowReport(UnfollowOutcome(failed = listOf(1)))
+        val many = unfollowReport(UnfollowOutcome(failed = listOf(1, 2)))
+
+        assertEquals("That fiction could not be unfollowed. It is still on your shelf.", one)
+        assertEquals("None of the 2 could be unfollowed. They are still on your shelf.", many)
+        assertTrue(UnfollowOutcome(failed = listOf(1)).isCompleteFailure)
+    }
+
+    @Test
+    fun `an outcome with nothing in it is not news`() {
+        assertNull(unfollowReport(UnfollowOutcome()))
+        assertEquals(0, UnfollowOutcome().attempted)
+        assertFalse(UnfollowOutcome().isCompleteSuccess, "nothing attempted is not a success to report")
+    }
+
+    @Test
+    fun `the confirmation says what unfollowing does not do`() {
+        val one = unfollowConfirmation(1)
+        val many = unfollowConfirmation(9)
+
+        assertTrue(one.contains("this fiction"))
+        assertTrue(many.contains("these 9 fictions"))
+        // Following is not an access boundary, so a confirmation that sounded destructive would be
+        // teaching people to dismiss confirmations.
+        assertTrue(many.contains("Nothing is deleted"))
+        assertTrue(many.contains("progress is kept"))
+        assertTrue(many.contains("follow them back"))
+    }
+
+    @Test
+    fun `a selection naming a fiction the shelf no longer holds is pruned`() {
+        val shelf = listOf(FictionSummary(id = 1), FictionSummary(id = 2), FictionSummary(id = 3))
+
+        assertEquals(setOf(1, 3), prunedSelection(setOf(1, 3, 99), shelf))
+        assertEquals(emptySet(), prunedSelection(setOf(99), shelf))
+        assertEquals(emptySet(), prunedSelection(emptySet(), shelf))
+        assertEquals(emptySet(), prunedSelection(setOf(1), emptyList()))
+    }
+
+    @Test
+    fun `the pruned selection follows shelf order, not insertion order`() {
+        val shelf = listOf(FictionSummary(id = 5), FictionSummary(id = 1), FictionSummary(id = 9))
+
+        assertContentEquals(
+            listOf(5, 1, 9),
+            prunedSelection(setOf(9, 1, 5), shelf).toList(),
+            "the count and the ticked rows have to agree, which means one order",
+        )
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ManageShelfStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ManageShelfStateHolderTest.kt
@@ -1,0 +1,230 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.LibraryCache
+import dk.perspektiva.ttsroad.desktop.data.LibraryResponse
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * The shelf editor's whole job is telling the truth about a job half done.
+ *
+ * The unfollows go out one at a time against the existing per-fiction route, so a failure part-way
+ * through is the normal case rather than an edge: some rows are genuinely gone and the rest are
+ * genuinely still there, and neither "done" nor "failed" describes that.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ManageShelfStateHolderTest {
+
+    private val shelf = listOf(
+        FictionSummary(id = 1, title = "Wandering Inn", following = true),
+        FictionSummary(id = 2, title = "Mother of Learning", following = true),
+        FictionSummary(id = 3, title = "Worth the Candle", following = true),
+    )
+
+    @Test
+    fun `the shelf arrives from the cache`() = runTest {
+        val fixture = fixture()
+        fixture.cache.refreshLibrary()
+        runCurrent()
+
+        assertEquals(3, fixture.holder.state.value.fictions.size)
+        assertEquals(0, fixture.holder.state.value.selectedCount)
+        assertFalse(fixture.holder.state.value.canUnfollow)
+
+        fixture.close()
+    }
+
+    @Test
+    fun `select all toggles both ways from one control`() = runTest {
+        val fixture = fixture()
+        fixture.cache.refreshLibrary()
+        runCurrent()
+
+        fixture.holder.toggleAll()
+        assertEquals(setOf(1, 2, 3), fixture.holder.state.value.selected)
+        assertTrue(fixture.holder.state.value.allSelected)
+
+        fixture.holder.toggleAll()
+        assertEquals(emptySet(), fixture.holder.state.value.selected)
+
+        fixture.close()
+    }
+
+    @Test
+    fun `a selection is pruned when the shelf stops holding the fiction`() = runTest {
+        val fixture = fixture()
+        fixture.cache.refreshLibrary()
+        runCurrent()
+        fixture.holder.toggleAll()
+
+        fixture.repository.libraryResult = Result.success(LibraryResponse(fictions = shelf.take(1)))
+        fixture.cache.refreshLibrary()
+        runCurrent()
+
+        assertEquals(
+            setOf(1),
+            fixture.holder.state.value.selected,
+            "a count naming rows the screen cannot show is a count nobody can act on",
+        )
+
+        fixture.close()
+    }
+
+    @Test
+    fun `unfollowing everything selected reports what went`() = runTest {
+        val fixture = fixture()
+        fixture.cache.refreshLibrary()
+        runCurrent()
+        fixture.holder.toggleAll()
+        fixture.holder.askToUnfollow()
+
+        assertEquals(3, fixture.holder.state.value.confirming)
+        assertNotNull(fixture.holder.state.value.confirmationBody)
+
+        fixture.repository.libraryResult = Result.success(LibraryResponse())
+        fixture.holder.confirmUnfollow()
+        runCurrent()
+
+        assertContentEquals(
+            listOf(1 to false, 2 to false, 3 to false),
+            fixture.repository.followCalls,
+            "attempted in shelf order, so a partial result reads as a prefix",
+        )
+        assertEquals("Unfollowed 3 fictions.", fixture.holder.state.value.notice)
+        assertEquals(emptySet(), fixture.holder.state.value.selected)
+        assertFalse(fixture.holder.state.value.isBusy)
+
+        fixture.close()
+    }
+
+    @Test
+    fun `a failure part-way through keeps the failures ticked and reports both numbers`() = runTest {
+        val fixture = fixture()
+        fixture.cache.refreshLibrary()
+        runCurrent()
+        fixture.holder.toggleAll()
+
+        fixture.repository.followResultFor = { id ->
+            if (id == 2) Result.failure(IllegalStateException("boom")) else null
+        }
+        fixture.holder.askToUnfollow()
+        fixture.holder.confirmUnfollow()
+        runCurrent()
+
+        assertEquals(
+            "Unfollowed 2 of 3. 1 could not be removed and are still on your shelf.",
+            fixture.holder.state.value.notice,
+        )
+        assertEquals(
+            setOf(2),
+            fixture.holder.state.value.selected,
+            "what failed stays ticked, because that is what a retry acts on",
+        )
+        assertNull(fixture.holder.state.value.error, "a partial result is a notice, not an error")
+
+        fixture.close()
+    }
+
+    @Test
+    fun `a 404 is not counted as a removal`() = runTest {
+        val fixture = fixture()
+        fixture.cache.refreshLibrary()
+        runCurrent()
+        fixture.holder.toggle(1)
+
+        // Null is the server's 404: no such fiction, or no such endpoint. Neither removed anything.
+        fixture.repository.followResult = Result.success(null)
+        fixture.holder.askToUnfollow()
+        fixture.holder.confirmUnfollow()
+        runCurrent()
+
+        assertEquals(
+            "That fiction could not be unfollowed. It is still on your shelf.",
+            fixture.holder.state.value.notice,
+        )
+        assertEquals(setOf(1), fixture.holder.state.value.selected)
+
+        fixture.close()
+    }
+
+    @Test
+    fun `nothing is sent without a confirmation`() = runTest {
+        val fixture = fixture()
+        fixture.cache.refreshLibrary()
+        runCurrent()
+        fixture.holder.toggle(1)
+
+        fixture.holder.confirmUnfollow()
+        runCurrent()
+
+        assertTrue(
+            fixture.repository.followCalls.isEmpty(),
+            "confirmUnfollow is the answer to a question; without the question it is not an answer",
+        )
+
+        fixture.close()
+    }
+
+    @Test
+    fun `an empty selection raises no confirmation`() = runTest {
+        val fixture = fixture()
+        fixture.cache.refreshLibrary()
+        runCurrent()
+
+        fixture.holder.askToUnfollow()
+
+        assertNull(fixture.holder.state.value.confirming)
+
+        fixture.close()
+    }
+
+    @Test
+    fun `dismissing the confirmation sends nothing`() = runTest {
+        val fixture = fixture()
+        fixture.cache.refreshLibrary()
+        runCurrent()
+        fixture.holder.toggle(2)
+        fixture.holder.askToUnfollow()
+
+        fixture.holder.dismissConfirmation()
+        runCurrent()
+
+        assertNull(fixture.holder.state.value.confirming)
+        assertTrue(fixture.repository.followCalls.isEmpty())
+        assertEquals(setOf(2), fixture.holder.state.value.selected, "dismissing is not de-selecting")
+
+        fixture.close()
+    }
+
+    // --- fixture ----------------------------------------------------------------------------------
+
+    private class Fixture(
+        val repository: FakeRepository,
+        val cache: LibraryCache,
+        val holder: ManageShelfStateHolder,
+    ) {
+        fun close() {
+            holder.clear()
+            cache.close()
+        }
+    }
+
+    private fun TestScope.fixture(): Fixture {
+        val repository = FakeRepository(libraryResult = Result.success(LibraryResponse(fictions = shelf)))
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val cache = LibraryCache(repository, dispatcher)
+        return Fixture(repository, cache, ManageShelfStateHolder(cache, dispatcher))
+    }
+}


### PR DESCRIPTION
Closes #110. Prompted by a user report: *"by default I am following all fictions,
it should only be the ones I choose."*

## Why a shelf fills itself

I traced every writer of a `user_fictions` row. There are three, and two of them
need no button press:

- `backfill_user_fiction_follows()` ran **once** at the per-user-shelves upgrade
  and made every account follow every fiction. That is correct — before that
  table there was one global library everybody saw, so an empty `user_fictions`
  on an upgraded install would have read as an empty dashboard for every account,
  which is indistinguishable from data loss.
- Adding a fiction auto-follows it for the adder
  (`app/routers/fictions.py:941`, *"Everyone else starts unfollowed"*). On a
  single-admin install that is every fiction on the server.

So "following everything, having chosen none of it" is the ordinary state, and
the only exit was N screens long. **This is not a bug in the follow model** and
nothing here changes the backfill or the auto-follow; it adds the missing
subtraction.

## Subtractive only

There is deliberately no bulk *follow*. The complaint is a shelf filled without
asking; a faster way to fill it does not answer that.

## Partial failure is the design

Unfollows go out one at a time against the existing idempotent
`DELETE /api/mobile/fictions/{id}/follow` rather than a new bulk route, so this
works against every deployment advertising `follows` today — **no server change**.
That makes a partial outcome normal rather than exceptional, and it is most of
what is tested:

- Ten unfollows where the seventh fails is not "the operation failed". Six of
  them happened, and the report names both numbers.
- The failures **stay ticked**, because that is what a retry acts on. Clearing
  them would present a partial result as a finished one.
- A `404` counts as a **failure, not a removal**: it means no such fiction or no
  such endpoint, and neither removed anything.
- A refresh landing mid-selection prunes rows the shelf no longer holds, so the
  count and the ticked rows cannot disagree.

## Rank and wording

Unfollow is a plain action, not a tinted destructive one — colour here carries
severity, and nothing is destroyed. Following is explicitly *not* an access
boundary (`app/services/library.py`): progress is kept, the fiction stays
openable by URL, and it can be followed again. The confirmation says all three,
because the word invites the opposite guess and a frightening confirmation over a
reversible action teaches people to dismiss confirmations.

The entry is a row in Settings → Account, shown only where the server advertises
`follows` — without it the library is one shared list with no membership to edit.
Not in the header: emptying a shelf is a rare, deliberate visit, and the everyday
way to drop one book is still the Follow control on its own screen.

## Verification

`xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail
-Pttsroad.warningsAsErrors=true` — BUILD SUCCESSFUL in 6m6s. That is the CI gate,
not plain `check`.

15 new tests. `FakeRepository` gained `followResultFor` so a *per-id* outcome can
be modelled; a single shared answer cannot express the case this screen exists to
handle.

## Related, and not fixed here

The backfill is guarded by one marker row. If that marker is ever lost — a
restore from a backup taken mid-upgrade, an operator clearing `settings` — it
re-runs and **resurrects every follow deliberately removed**, including anything
undone with this screen. `app/database.py` names the risk in a comment. Worth a
server-side issue; it is not something a client can defend against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK3sri5jA6ne6tEJnbQaRe
