### PR TITLE
Give a failed chapter something to press

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -104,6 +104,8 @@ import dk.perspektiva.ttsroad.desktop.ui.hasSession
 import dk.perspektiva.ttsroad.desktop.ui.rememberChapterDownloads
 import dk.perspektiva.ttsroad.desktop.ui.rememberChapterQueue
 import dk.perspektiva.ttsroad.desktop.ui.UpdateStateHolder
+import dk.perspektiva.ttsroad.desktop.ui.ChapterMaintenanceStateHolder
+import dk.perspektiva.ttsroad.desktop.ui.ChapterMaintenanceUi
 import dk.perspektiva.ttsroad.desktop.ui.ManageShelfScreen
 import dk.perspektiva.ttsroad.desktop.ui.ManageShelfStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.rememberStateHolder
@@ -167,6 +169,9 @@ fun App(
     // a shelf in bulk. It lives here so the selection survives a trip into a fiction and back,
     // which is exactly what somebody deciding what to drop will do.
     val manageShelf = rememberStateHolder(cache) { ManageShelfStateHolder(cache) }
+    val chapterMaintenance = rememberStateHolder(repository, cache) {
+        ChapterMaintenanceStateHolder(repository, cache)
+    }
     // Hoisted for the same reason: "Add to queue" is pressed on a chapter list, so the queue has to
     // exist and report what happened whether or not the queue screen was ever opened.
     val serverQueue = rememberStateHolder(repository, playback) {
@@ -192,6 +197,7 @@ fun App(
         FictionManagementStateHolder(repository, cache)
     }
     val fictionManagementState by fictionManagement.state.collectAsState()
+    val chapterMaintenanceState by chapterMaintenance.state.collectAsState()
     // Hoisted for the same reason the management holder is: the editor is a form, a save is a
     // request, and neither may be lost because the user glanced at the library mid-edit.
     val fictionMetadata = rememberStateHolder(repository, cache) {
@@ -617,6 +623,23 @@ fun App(
                                         holder = serverQueue,
                                         available = capabilities.queue,
                                         fictionId = destination.fiction.id,
+                                    ),
+                                    maintenance = ChapterMaintenanceUi(
+                                        // Retry needs only the capability: the server leaves it
+                                        // open to any account on purpose.
+                                        retryAvailable = capabilities.chapterMaintenance,
+                                        // Exclude and delete change a shared object, so they take
+                                        // the same two gates the fiction controls do — and
+                                        // `fictionManagementState.canManage` is the *verified*
+                                        // is_admin, not the role cached at login.
+                                        canModerate = capabilities.chapterMaintenance &&
+                                            fictionManagementState.canManage,
+                                        busyChapterId = chapterMaintenanceState.busyChapterId,
+                                        notice = chapterMaintenanceState.notice,
+                                        error = chapterMaintenanceState.error,
+                                        onRetry = chapterMaintenance::retry,
+                                        onSetExcluded = chapterMaintenance::setExcluded,
+                                        onDelete = chapterMaintenance::delete,
                                     ),
                                     fictionManagement = fictionManagementState,
                                     onEditFiction = { nav.open(Destination.FictionMetadata(it)) },

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ChapterMaintenance.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ChapterMaintenance.kt
@@ -1,0 +1,89 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+/**
+ * Repairing one chapter (#113).
+ *
+ * The desktop has always *seen* a failed chapter — `availability()` maps the server's
+ * status/sub-status/error triple onto [ChapterAvailability.Failed] and the row draws a chip for it —
+ * and offered nothing to press. So a chapter that failed conversion was a permanent hole in a
+ * serial from this client: the scheduler does not retry on its own, and the one-request fix lived
+ * only in the web console.
+ *
+ * The three routes deliberately do **not** share a gate, and that asymmetry is the server's, not an
+ * accident to be tidied away:
+ *
+ * - **Retry** is open to any signed-in account. It repairs one chapter, harms nobody, and the
+ *   account looking at a failed row is usually the one that wants it fixed.
+ * - **Exclude** and **delete** are admin-only, because a chapter is a shared object: excluding one
+ *   changes what *every* account's podcast feed contains, and deleting destroys the audio for
+ *   everybody.
+ *
+ * The capability flag says only that the routes exist; `me.is_admin` decides which of them this
+ * account may use. Both gates, always — a drawn control is never authorization.
+ */
+
+/**
+ * What a retry actually did.
+ *
+ * The interesting member is [AlreadyRunning], the server's `409`. It is not a failure: it means the
+ * chapter is excluded or is being processed right now, so the thing the user wanted is either
+ * already happening or deliberately switched off. Reporting it as an error would invite a second
+ * press, and a second press would say the same thing.
+ */
+sealed interface ChapterRetryOutcome {
+    /** Queued for conversion. */
+    data class Queued(val chapterId: Int) : ChapterRetryOutcome
+
+    /** `409` — excluded, or already converting. */
+    data object AlreadyRunning : ChapterRetryOutcome
+
+    /** `404` — this server has no maintenance routes. */
+    data object Unsupported : ChapterRetryOutcome
+}
+
+/** The line to show for a [ChapterRetryOutcome], or null when there is nothing worth saying. */
+fun chapterRetryMessage(outcome: ChapterRetryOutcome, title: String): String? = when (outcome) {
+    is ChapterRetryOutcome.Queued -> "$title is queued for conversion again."
+    // Says which of the two it is, because the actions differ: one is waiting, the other is undoing
+    // an exclusion, and "could not retry" would point at neither.
+    ChapterRetryOutcome.AlreadyRunning ->
+        "$title is already being converted, or is excluded. Nothing to retry."
+    ChapterRetryOutcome.Unsupported -> "This server cannot retry a chapter."
+}
+
+/** The line after an exclude or un-exclude. */
+fun chapterExcludeMessage(title: String, excluded: Boolean): String = when {
+    excluded -> "$title is excluded. It is off every account's feed and player until it is put back."
+    else -> "$title is back on every account's feed and player."
+}
+
+/**
+ * What excluding or deleting costs, for the confirmation.
+ *
+ * Both sentences name *everybody*, because that is the fact a single-account mental model hides: a
+ * chapter is one shared row, not a copy per listener.
+ */
+fun chapterDeleteConfirmation(title: String): String =
+    "Delete $title and its audio from the server. Every account loses it, from the shelf and from " +
+        "the podcast feed, and the listening progress recorded against it goes with it. " +
+        "Re-converting it later means the source still has the text. This cannot be undone."
+
+fun chapterExcludeConfirmation(title: String, excluding: Boolean): String = when {
+    excluding ->
+        "Take $title off every account's podcast feed and player. The audio is kept and it can be " +
+            "put back, but while it is excluded it cannot be retried."
+    else -> "Put $title back on every account's podcast feed and player."
+}
+
+/**
+ * Whether a chapter is worth offering a retry for.
+ *
+ * Only a failed one. A converting chapter is already doing the thing retry asks for and the server
+ * answers `409`; a ready one has nothing to repair. Offering it everywhere would make the row's
+ * busiest state indistinguishable from its broken one.
+ */
+fun ChapterSummary.canRetry(): Boolean = availability() == ChapterAvailability.Failed
+
+/** Both halves of the gate for the destructive pair. */
+fun canMaintainChapters(capabilities: ServerCapabilities, isAdmin: Boolean): Boolean =
+    capabilities.chapterMaintenance && isAdmin

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
@@ -535,3 +535,29 @@ data class MobileVoice(
     val locale: String? = null,
     val gender: String? = null,
 )
+
+/**
+ * The answer every maintenance route gives (#113).
+ *
+ * One shape across all of them, and the counts are the reason it is worth modelling rather than
+ * ignoring: "requeued" and "did nothing" both come back as `status: "ok"`, and only a number
+ * separates them.
+ *
+ * Every field is nullable because each route fills a different subset. A chapter retry sets
+ * `chapterId` and nothing else; the fiction-wide routes this client does not call yet fill the
+ * counters, and they are decoded rather than dropped so adding those routes needs no model change.
+ */
+data class MaintenanceResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    val status: String = "",
+    @param:Json(name = "fiction_id") val fictionId: Int? = null,
+    @param:Json(name = "chapter_id") val chapterId: Int? = null,
+    /** Whether the chapter is now excluded, echoed by the exclude route. */
+    val excluded: Boolean? = null,
+    val deleted: Boolean? = null,
+    /** Chapters requeued by a fiction-wide retry. */
+    @param:Json(name = "reset_count") val resetCount: Int? = null,
+)
+
+/** `POST /api/mobile/chapters/{id}/exclude` — take a chapter off every feed, or put it back. */
+data class ChapterExcludeRequest(val excluded: Boolean = true)

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -214,6 +214,20 @@ interface TtsRoadRepository {
     suspend fun voices(): List<MobileVoice>? = null
 
     /**
+     * Queue one chapter for conversion again.
+     *
+     * Open to any signed-in account by the server's own design. The `409` is modelled rather than
+     * thrown because it is not a failure — see [ChapterRetryOutcome].
+     */
+    suspend fun retryChapter(chapterId: Int): ChapterRetryOutcome = ChapterRetryOutcome.Unsupported
+
+    /** Take a chapter off every account's feed, or put it back. Admin-only on the server. */
+    suspend fun setChapterExcluded(chapterId: Int, excluded: Boolean): Boolean? = null
+
+    /** Delete a chapter and its audio. Admin-only. Null means the server has no such route. */
+    suspend fun deleteChapter(chapterId: Int): Boolean? = null
+
+    /**
      * Revokes one session.
      *
      * False means the server answered 404, which is ambiguous by design: the endpoint may be
@@ -577,6 +591,26 @@ class RetrofitTtsRoadRepository(
         ifEndpointExists { it.audiobookExports() }
 
     override suspend fun voices(): List<MobileVoice>? = ifEndpointExists { it.voices() }?.voices
+
+    override suspend fun retryChapter(chapterId: Int): ChapterRetryOutcome = try {
+        val response = withAuthorizedApi { it.retryChapter(chapterId) }
+        ChapterRetryOutcome.Queued(response.chapterId ?: chapterId)
+    } catch (e: HttpException) {
+        when (e.code()) {
+            // Excluded, or already converting. The user's intent is either already happening or
+            // deliberately switched off, and neither is an error to raise.
+            409 -> ChapterRetryOutcome.AlreadyRunning
+            404 -> ChapterRetryOutcome.Unsupported
+            else -> throw e
+        }
+    }
+
+    override suspend fun setChapterExcluded(chapterId: Int, excluded: Boolean): Boolean? =
+        ifEndpointExists { it.setChapterExcluded(chapterId, ChapterExcludeRequest(excluded)) }
+            ?.let { it.excluded ?: excluded }
+
+    override suspend fun deleteChapter(chapterId: Int): Boolean? =
+        ifEndpointExists { it.deleteChapter(chapterId) }?.let { it.deleted ?: true }
 
     override suspend fun revokeDevice(tokenId: Int): Boolean =
         ifEndpointExists { it.revokeDevice(tokenId) } != null

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
@@ -88,6 +88,14 @@ data class ServerCapabilities(
      * a cache miss spends an outbound synthesis request to Microsoft.
      */
     val voiceCatalogue: Boolean = false,
+    /**
+     * Repair one chapter: retry, exclude, delete.
+     *
+     * Says only that the routes exist. The three do not share a gate — retry is open to any
+     * signed-in account, and the destructive pair is admin-only — so `me.is_admin` decides which of
+     * them this account may actually use.
+     */
+    val chapterMaintenance: Boolean = false,
     val maxChaptersPerPage: Int? = null,
     /**
      * How many items `/playback/sync` accepts in one batch.
@@ -135,6 +143,7 @@ data class ServerCapabilities(
             audiobookExport = response.capabilities.flag("audiobook_export"),
             notifications = response.capabilities.flag("notifications"),
             voiceCatalogue = response.capabilities.flag("voice_catalogue"),
+            chapterMaintenance = response.capabilities.flag("chapter_maintenance"),
             maxChaptersPerPage = response.limits.intLimit("max_chapters_per_page"),
             maxPlaybackSyncItems = response.limits.intLimit("max_playback_sync_items"),
             maxEpubBytes = response.limits.longLimit("max_epub_bytes"),

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -64,6 +64,30 @@ interface TtsRoadApi {
     @GET("api/mobile/voices")
     suspend fun voices(): VoicesResponse
 
+    // Chapter maintenance (#113). Three routes, one response shape, and deliberately *not* one
+    // gate: retry is open to any signed-in account because it repairs one chapter and harms
+    // nobody, while exclude and delete are admin-only because a chapter is a shared object — an
+    // exclusion changes what every account's podcast feed contains.
+
+    /** Queue one chapter for conversion again. A 409 means it is excluded or already processing. */
+    @POST("api/mobile/chapters/{chapter_id}/retry")
+    suspend fun retryChapter(@Path("chapter_id") chapterId: Int): MaintenanceResponse
+
+    @POST("api/mobile/chapters/{chapter_id}/exclude")
+    suspend fun setChapterExcluded(
+        @Path("chapter_id") chapterId: Int,
+        @Body request: ChapterExcludeRequest,
+    ): MaintenanceResponse
+
+    /**
+     * Delete one chapter and its audio.
+     *
+     * Answers with a body rather than the web route's `204`, deliberately: over a flaky connection
+     * an empty response is indistinguishable from a request that never arrived.
+     */
+    @DELETE("api/mobile/chapters/{chapter_id}")
+    suspend fun deleteChapter(@Path("chapter_id") chapterId: Int): MaintenanceResponse
+
     // Both revoke calls answer with a small status object (`{"status": "ok", ...}`) whose shape is
     // not worth modelling: the client re-reads the list afterwards rather than trusting an echo,
     // because a 404 on the DELETE is ambiguous between "already gone" and "no such endpoint".

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterMaintenanceDialog.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterMaintenanceDialog.kt
@@ -1,0 +1,83 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
+import dk.perspektiva.ttsroad.desktop.data.chapterExcludeConfirmation
+
+const val ChapterMaintenanceDialogTestTag: String = "chapterMaintenanceDialog"
+const val ExcludeChapterRowTestTag: String = "excludeChapterRow"
+const val DeleteChapterRowTestTag: String = "deleteChapterRow"
+
+/**
+ * The admin-only half of chapter repair, behind a disclosure (#113).
+ *
+ * Both of these are rank three by this repo's own test: **a control that needs a sentence under it
+ * to be safe to press is not a button, it is a row.** Excluding a chapter silently changes what
+ * every account's podcast feed contains, and deleting one destroys the audio and the recorded
+ * progress for everybody. Neither fits on a label, and neither belongs on the chapter row next to
+ * Play — which is why this is a dialog rather than two more icons.
+ *
+ * Colour here carries **severity, not rank**: Delete is tinted because it is irreversible, which
+ * does not promote it above Exclude in the order things are reached for.
+ */
+@Composable
+fun ChapterMaintenanceDialog(
+    chapter: ChapterSummary,
+    busy: Boolean,
+    onSetExcluded: (Boolean) -> Unit,
+    onDelete: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val title = chapter.resolvedTitle
+    val excluded = chapter.excluded
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        shape = RectangleShape,
+        containerColor = AarisColor.BgRaise,
+        modifier = Modifier.testTag(ChapterMaintenanceDialogTestTag),
+        title = { Text("MANAGE ${title.uppercase()}") },
+        text = {
+            Column(
+                Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Text(
+                    "A chapter is one shared row, not a copy for each listener. Both of these " +
+                        "change what every account sees.",
+                    color = AarisColor.Dim,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                AarisActionRow(
+                    title = if (excluded) "Put back on every feed" else "Exclude from every feed",
+                    subtitle = chapterExcludeConfirmation(title, excluding = !excluded),
+                    onClick = { onSetExcluded(!excluded) },
+                    enabled = !busy,
+                    modifier = Modifier.testTag(ExcludeChapterRowTestTag),
+                )
+                AarisActionRow(
+                    title = "Delete this chapter",
+                    subtitle = "Destroys the audio and every account's progress on it. Cannot be undone.",
+                    onClick = onDelete,
+                    enabled = !busy,
+                    // Severity, not rank: it is irreversible, which does not make it the thing
+                    // somebody came here to press.
+                    titleColor = AarisColor.Danger,
+                    modifier = Modifier.testTag(DeleteChapterRowTestTag),
+                )
+            }
+        },
+        confirmButton = { TextButton(onClick = onDismiss, shape = RectangleShape) { Text("CLOSE") } },
+    )
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterMaintenanceStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterMaintenanceStateHolder.kt
@@ -1,0 +1,105 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
+import dk.perspektiva.ttsroad.desktop.data.LibraryCache
+import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
+import dk.perspektiva.ttsroad.desktop.data.chapterExcludeMessage
+import dk.perspektiva.ttsroad.desktop.data.chapterRetryMessage
+import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class ChapterMaintenanceUiState(
+    /** The chapter a request is in flight for, so one row can be disabled rather than the list. */
+    val busyChapterId: Int? = null,
+    val notice: String? = null,
+    val error: String? = null,
+)
+
+/**
+ * Repairing one chapter (#113).
+ *
+ * Every action here re-reads the fiction's chapters afterwards rather than patching a row: a retry
+ * changes `status`, an exclusion changes `excluded` *and* what the filters count, and a delete
+ * removes the row entirely. Predicting all three locally would be three chances to disagree with the
+ * server about a shared object, and the list is already cached — the re-read is one request.
+ */
+class ChapterMaintenanceStateHolder(
+    private val repository: TtsRoadRepository,
+    private val cache: LibraryCache,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : StateHolder(dispatcher) {
+    private val _state = MutableStateFlow(ChapterMaintenanceUiState())
+    val state: StateFlow<ChapterMaintenanceUiState> = _state.asStateFlow()
+
+    private var job: Job? = null
+
+    /**
+     * Queue a chapter for conversion again.
+     *
+     * Open to any signed-in account. A `409` comes back as a notice rather than an error, because
+     * the chapter is either already converting or deliberately excluded — in both cases what the
+     * user wanted is not a thing that failed.
+     */
+    fun retry(chapter: ChapterSummary) = run(chapter) {
+        val outcome = repository.retryChapter(chapter.resolvedChapterId)
+        chapterRetryMessage(outcome, chapter.resolvedTitle)
+    }
+
+    fun setExcluded(chapter: ChapterSummary, excluded: Boolean) = run(chapter) {
+        when (val confirmed = repository.setChapterExcluded(chapter.resolvedChapterId, excluded)) {
+            null -> "This server cannot exclude a chapter."
+            else -> chapterExcludeMessage(chapter.resolvedTitle, confirmed)
+        }
+    }
+
+    fun delete(chapter: ChapterSummary) = run(chapter) {
+        when (repository.deleteChapter(chapter.resolvedChapterId)) {
+            // Null is the server's 404, which is ambiguous by design between "no such endpoint" and
+            // "already gone". Neither is worth claiming a deletion for.
+            null -> "This server cannot delete a chapter."
+            else -> "${chapter.resolvedTitle} is deleted."
+        }
+    }
+
+    fun dismissNotice() = _state.update { it.copy(notice = null, error = null) }
+
+    /**
+     * One request at a time, then re-read.
+     *
+     * The refresh runs whatever the outcome, including a failure: a retry that reported `409`
+     * because the chapter was already converting has still left the row out of date on screen.
+     */
+    private fun run(chapter: ChapterSummary, block: suspend () -> String?) {
+        if (_state.value.busyChapterId != null) return
+        // Marked busy *here*, not inside the coroutine. A launched body does not run until the
+        // dispatcher reaches it, so a guard that reads state the body sets lets a second press
+        // through in the gap — and these are writes against one shared row, where the second one
+        // would race the first rather than merely repeat it.
+        _state.update {
+            it.copy(busyChapterId = chapter.resolvedChapterId, notice = null, error = null)
+        }
+        job = scope.launch {
+            val result = runCatching { block() }
+            _state.update {
+                it.copy(
+                    busyChapterId = null,
+                    notice = result.getOrNull(),
+                    error = result.exceptionOrNull()
+                        ?.let { failure -> userFacingMessage(failure, "Could not change that chapter") },
+                )
+            }
+            cache.refreshChapters(chapter.fictionId)
+        }
+    }
+
+    override fun onCleared() {
+        job?.cancel()
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionDetailScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionDetailScreen.kt
@@ -31,6 +31,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material.icons.filled.Check
@@ -88,6 +90,8 @@ import dk.perspektiva.ttsroad.desktop.data.indexOfChapter
 import dk.perspektiva.ttsroad.desktop.data.listeningTotals
 import dk.perspektiva.ttsroad.desktop.data.markableIds
 import dk.perspektiva.ttsroad.desktop.data.playbackOrder
+import dk.perspektiva.ttsroad.desktop.data.canRetry
+import dk.perspektiva.ttsroad.desktop.data.chapterDeleteConfirmation
 import dk.perspektiva.ttsroad.desktop.data.statusLabel
 import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
 import dk.perspektiva.ttsroad.desktop.player.PlaybackController
@@ -165,6 +169,25 @@ data class ChapterDownloadsUi(
  * this screen's: the queue is hoisted above navigation, so "Added 2 chapters to the queue" is the
  * same message whether the user is looking at the chapter list or the queue when it arrives.
  */
+/**
+ * Repairing one chapter, as the row draws it (#113).
+ *
+ * Two flags rather than one, because the three routes do not share a gate. [retryAvailable] is the
+ * capability alone — retry is open to any signed-in account — while [canModerate] additionally
+ * requires `is_admin`, because excluding a chapter changes what *every* account's podcast feed
+ * contains and deleting it destroys the audio for everybody.
+ */
+data class ChapterMaintenanceUi(
+    val retryAvailable: Boolean = false,
+    val canModerate: Boolean = false,
+    val busyChapterId: Int? = null,
+    val notice: String? = null,
+    val error: String? = null,
+    val onRetry: (ChapterSummary) -> Unit = {},
+    val onSetExcluded: (ChapterSummary, Boolean) -> Unit = { _, _ -> },
+    val onDelete: (ChapterSummary) -> Unit = {},
+)
+
 data class ChapterQueueUi(
     val available: Boolean = false,
     val busy: Boolean = false,
@@ -194,6 +217,7 @@ fun FictionDetailScreen(
     onOpenReader: (ChapterSummary) -> Unit = {},
     downloads: ChapterDownloadsUi = ChapterDownloadsUi(),
     queue: ChapterQueueUi = ChapterQueueUi(),
+    maintenance: ChapterMaintenanceUi = ChapterMaintenanceUi(),
     fictionManagement: FictionManagementUiState = FictionManagementUiState(),
     onEditFiction: (FictionSummary) -> Unit = {},
     onDeleteFiction: (FictionSummary) -> Unit = {},
@@ -207,6 +231,9 @@ fun FictionDetailScreen(
     LaunchedEffect(fiction.id) { cache.ensureChapters(fiction.id) }
 
     var actionError by remember { mutableStateOf<String?>(null) }
+    // Which chapter's admin disclosure is open, and which delete is awaiting a second answer.
+    var managingChapter by remember { mutableStateOf<ChapterSummary?>(null) }
+    var deletingChapter by remember { mutableStateOf<ChapterSummary?>(null) }
     val listState = rememberLazyListState()
 
     val loaded = state.value
@@ -380,6 +407,16 @@ fun FictionDetailScreen(
                         Spacer(Modifier.height(12.dp))
                         MetaText(message, color = AarisColor.Ok)
                     }
+                    // Beside the queue's, not inside the chapter list: a delete removes the row
+                    // the notice would have hung off, and a retry changes its status.
+                    maintenance.error?.let { message ->
+                        Spacer(Modifier.height(12.dp))
+                        Text(message, color = MaterialTheme.colorScheme.error)
+                    }
+                    maintenance.notice?.let { message ->
+                        Spacer(Modifier.height(12.dp))
+                        MetaText(message, color = AarisColor.Ok)
+                    }
 
                     when {
                         loaded == null && error != null -> {
@@ -445,6 +482,8 @@ fun FictionDetailScreen(
                         readAlongTimed = chapter.hasTimings,
                         download = downloads.stateFor(chapter),
                         queue = queue,
+                        maintenance = maintenance,
+                        onManage = { managingChapter = chapter },
                         onPlay = { play(chapter) },
                         onMarkPlayed = { played -> mark(listOf(chapter.resolvedChapterId), played) },
                         onMarkPrevious = {
@@ -472,6 +511,37 @@ fun FictionDetailScreen(
             }
         }
         RefreshingStrip(state.isRefreshing && !state.isStale)
+    }
+
+    managingChapter?.let { chapter ->
+        ChapterMaintenanceDialog(
+            chapter = chapter,
+            busy = maintenance.busyChapterId == chapter.resolvedChapterId,
+            onSetExcluded = { excluded ->
+                maintenance.onSetExcluded(chapter, excluded)
+                managingChapter = null
+            },
+            // Closes the disclosure and raises the confirmation: two dialogs stacked would leave
+            // the consequence text behind the question about it.
+            onDelete = {
+                managingChapter = null
+                deletingChapter = chapter
+            },
+            onDismiss = { managingChapter = null },
+        )
+    }
+
+    deletingChapter?.let { chapter ->
+        ConfirmDialog(
+            title = "DELETE ${chapter.resolvedTitle.uppercase()}",
+            body = chapterDeleteConfirmation(chapter.resolvedTitle),
+            confirmLabel = "DELETE FOR EVERYONE",
+            onConfirm = {
+                maintenance.onDelete(chapter)
+                deletingChapter = null
+            },
+            onDismiss = { deletingChapter = null },
+        )
     }
 }
 
@@ -834,6 +904,8 @@ private fun ChapterListRow(
     readAlongTimed: Boolean,
     download: ChapterDownloadUi,
     queue: ChapterQueueUi,
+    maintenance: ChapterMaintenanceUi,
+    onManage: () -> Unit,
     onPlay: () -> Unit,
     onMarkPlayed: (Boolean) -> Unit,
     onMarkPrevious: () -> Unit,
@@ -935,7 +1007,32 @@ private fun ChapterListRow(
             )
             Spacer(Modifier.width(4.dp))
         }
-        if (readAlongAvailable) {
+        // Only on a failed chapter, and for any account: the server leaves retry ungated because it
+        // repairs one row and harms nobody. A converting chapter is already doing this and answers
+        // 409; an excluded one has to be put back first.
+        // Admin-only, and a disclosure rather than two more icons: excluding changes every
+        // account's feed and deleting destroys the audio for everybody. Neither fits on a label.
+        if (maintenance.canModerate) {
+            RowIconAction(
+                icon = Icons.Default.Tune,
+                contentDescription = "Manage ${chapter.resolvedTitle}",
+                tint = if (active) AarisColor.Ink else AarisColor.Dim,
+                enabled = maintenance.busyChapterId != chapter.resolvedChapterId,
+                onClick = { onManage() },
+            )
+            Spacer(Modifier.width(4.dp))
+        }
+        if (maintenance.retryAvailable && chapter.canRetry()) {
+            RowIconAction(
+                icon = Icons.Default.Refresh,
+                contentDescription = "Convert ${chapter.resolvedTitle} again",
+                tint = if (active) AarisColor.Warning else AarisColor.Dim,
+                enabled = maintenance.busyChapterId != chapter.resolvedChapterId,
+                onClick = { maintenance.onRetry(chapter) },
+            )
+            Spacer(Modifier.width(4.dp))
+        }
+                if (readAlongAvailable) {
             RowIconAction(
                 icon = Icons.AutoMirrored.Filled.MenuBook,
                 contentDescription = if (readAlongTimed) "Read along" else "Read chapter text",

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -16,6 +16,7 @@ import dk.perspektiva.ttsroad.desktop.data.FictionUpdateRequest
 import dk.perspektiva.ttsroad.desktop.data.LibraryResponse
 import dk.perspektiva.ttsroad.desktop.data.LoginResult
 import dk.perspektiva.ttsroad.desktop.data.MobileUser
+import dk.perspektiva.ttsroad.desktop.data.ChapterRetryOutcome
 import dk.perspektiva.ttsroad.desktop.data.MobileVoice
 import dk.perspektiva.ttsroad.desktop.data.PlaybackMarkResponse
 import dk.perspektiva.ttsroad.desktop.data.PlaybackStateRow
@@ -86,6 +87,9 @@ open class FakeRepository(
         Result.success(CoverUploadResult.Saved(FictionSummary(id = 1, title = "Updated"))),
     var audiobookExportsResult: Result<AudiobookExportsResponse?> = Result.success(null),
     var voicesResult: Result<List<MobileVoice>?> = Result.success(null),
+    var retryChapterResult: Result<ChapterRetryOutcome> = Result.success(ChapterRetryOutcome.Unsupported),
+    var setChapterExcludedResult: Result<Boolean?>? = null,
+    var deleteChapterResult: Result<Boolean?> = Result.success(null),
     /** Null models a server whose notifications route answers 404. */
     var chapterNotificationsResult: Result<ChapterNotificationsResponse?> = Result.success(null),
 ) : TtsRoadRepository {
@@ -107,8 +111,12 @@ open class FakeRepository(
     var currentUserCalls: Int = 0
         private set
     var audiobookExportsCalls: Int = 0
+        private set
     var voicesCalls: Int = 0
         private set
+    val retriedChapters: MutableList<Int> = mutableListOf()
+    val excludedChapters: MutableList<Pair<Int, Boolean>> = mutableListOf()
+    val deletedChapters: MutableList<Int> = mutableListOf()
     var revokeOtherDevicesCalls: Int = 0
         private set
     var readAlongCalls: Int = 0
@@ -279,6 +287,22 @@ open class FakeRepository(
     override suspend fun voices(): List<MobileVoice>? {
         voicesCalls++
         return voicesResult.getOrThrow()
+    }
+
+    override suspend fun retryChapter(chapterId: Int): ChapterRetryOutcome {
+        retriedChapters += chapterId
+        return retryChapterResult.getOrThrow()
+    }
+
+    override suspend fun setChapterExcluded(chapterId: Int, excluded: Boolean): Boolean? {
+        excludedChapters += chapterId to excluded
+        // Unset echoes what was asked, like `setFollowing`. A set one is used as-is, null included.
+        return (setChapterExcludedResult ?: return excluded).getOrThrow()
+    }
+
+    override suspend fun deleteChapter(chapterId: Int): Boolean? {
+        deletedChapters += chapterId
+        return deleteChapterResult.getOrThrow()
     }
 
     override suspend fun revokeDevice(tokenId: Int): Boolean {

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ChapterMaintenanceTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ChapterMaintenanceTest.kt
@@ -1,0 +1,103 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class ChapterMaintenanceTest {
+
+    @Test
+    fun `only a failed chapter is worth retrying`() {
+        assertTrue(ChapterSummary(status = "error").canRetry())
+        assertTrue(
+            ChapterSummary(errorMessage = "edge-tts timed out").canRetry(),
+            "an error message is a failure even when the status has not caught up",
+        )
+        assertFalse(
+            ChapterSummary(status = "processing").canRetry(),
+            "a converting chapter is already doing what retry asks; the server answers 409",
+        )
+        assertFalse(ChapterSummary(status = "done", audio = AudioInfo(url = "https://x/1.mp3")).canRetry())
+        assertFalse(ChapterSummary(status = "pending").canRetry())
+    }
+
+    @Test
+    fun `an excluded chapter is not offered a retry even when it also failed`() {
+        val excluded = ChapterSummary(status = "error", errorMessage = "boom", excluded = true)
+
+        assertEquals(ChapterAvailability.Excluded, excluded.availability())
+        assertFalse(
+            excluded.canRetry(),
+            "the server answers 409 for an excluded chapter; the way back is to un-exclude it",
+        )
+    }
+
+    @Test
+    fun `a 409 says which of the two things it is`() {
+        val message = chapterRetryMessage(ChapterRetryOutcome.AlreadyRunning, "Chapter 12")
+
+        // "Could not retry" would point at neither, and the two have different next actions: one is
+        // waiting, the other is undoing an exclusion.
+        assertTrue(message!!.contains("already being converted"))
+        assertTrue(message.contains("excluded"))
+        assertFalse(message.contains("failed"))
+    }
+
+    @Test
+    fun `a queued retry names the chapter`() {
+        assertEquals(
+            "Chapter 12 is queued for conversion again.",
+            chapterRetryMessage(ChapterRetryOutcome.Queued(5), "Chapter 12"),
+        )
+    }
+
+    @Test
+    fun `an unsupported server says so rather than reporting a failure`() {
+        assertEquals(
+            "This server cannot retry a chapter.",
+            chapterRetryMessage(ChapterRetryOutcome.Unsupported, "Chapter 12"),
+        )
+    }
+
+    @Test
+    fun `exclusion is described as affecting everyone, both ways`() {
+        val off = chapterExcludeMessage("Chapter 3", excluded = true)
+        val on = chapterExcludeMessage("Chapter 3", excluded = false)
+
+        assertTrue(off.contains("every account"))
+        assertTrue(on.contains("every account"))
+        assertTrue(off.contains("excluded"))
+    }
+
+    @Test
+    fun `the delete confirmation names what everybody loses`() {
+        val body = chapterDeleteConfirmation("Chapter 3")
+
+        assertTrue(body.contains("Every account"))
+        assertTrue(body.contains("podcast feed"))
+        assertTrue(body.contains("progress"))
+        assertTrue(body.contains("cannot be undone"))
+    }
+
+    @Test
+    fun `the exclude confirmation says the audio is kept and retry stops working`() {
+        val excluding = chapterExcludeConfirmation("Chapter 3", excluding = true)
+
+        assertTrue(excluding.contains("audio is kept"))
+        assertTrue(
+            excluding.contains("cannot be retried"),
+            "the server refuses a retry on an excluded chapter, so the two controls interact",
+        )
+        assertTrue(chapterExcludeConfirmation("Chapter 3", excluding = false).contains("back on"))
+    }
+
+    @Test
+    fun `the destructive pair needs the capability and the admin flag`() {
+        val capable = ServerCapabilities(chapterMaintenance = true)
+
+        assertTrue(canMaintainChapters(capable, isAdmin = true))
+        assertFalse(canMaintainChapters(capable, isAdmin = false))
+        assertFalse(canMaintainChapters(ServerCapabilities.Baseline, isAdmin = true))
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterMaintenanceStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterMaintenanceStateHolderTest.kt
@@ -1,0 +1,215 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.data.ChapterRetryOutcome
+import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
+import dk.perspektiva.ttsroad.desktop.data.LibraryCache
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChapterMaintenanceStateHolderTest {
+
+    private val chapter = ChapterSummary(
+        id = 42,
+        fictionId = 7,
+        title = "Chapter 12",
+        status = "error",
+        errorMessage = "edge-tts timed out",
+    )
+
+    @Test
+    fun `a queued retry reports success and re-reads the list`() = runTest {
+        val fixture = fixture()
+        fixture.repository.retryChapterResult = Result.success(ChapterRetryOutcome.Queued(42))
+
+        fixture.holder.retry(chapter)
+        runCurrent()
+
+        assertEquals(listOf(42), fixture.repository.retriedChapters)
+        assertEquals("Chapter 12 is queued for conversion again.", fixture.holder.state.value.notice)
+        assertNull(fixture.holder.state.value.error)
+        assertNull(fixture.holder.state.value.busyChapterId)
+
+        fixture.close()
+    }
+
+    @Test
+    fun `a 409 is a notice, not an error`() = runTest {
+        val fixture = fixture()
+        fixture.repository.retryChapterResult = Result.success(ChapterRetryOutcome.AlreadyRunning)
+
+        fixture.holder.retry(chapter)
+        runCurrent()
+
+        val notice = fixture.holder.state.value.notice
+        assertNotNull(notice)
+        assertTrue(notice.contains("already being converted"))
+        assertNull(
+            fixture.holder.state.value.error,
+            "the chapter is either converting or excluded; neither is a thing that failed",
+        )
+
+        fixture.close()
+    }
+
+    @Test
+    fun `a thrown failure becomes an error rather than a notice`() = runTest {
+        val fixture = fixture()
+        fixture.repository.retryChapterResult = Result.failure(IllegalStateException("boom"))
+
+        fixture.holder.retry(chapter)
+        runCurrent()
+
+        assertNotNull(fixture.holder.state.value.error)
+        assertNull(fixture.holder.state.value.notice)
+        assertNull(fixture.holder.state.value.busyChapterId)
+
+        fixture.close()
+    }
+
+    @Test
+    fun `excluding reports what the server confirmed, not what was asked`() = runTest {
+        val fixture = fixture()
+        // The server is the authority on what it stored, so a disagreement is reported as the
+        // server's answer rather than as the request's intent.
+        fixture.repository.setChapterExcludedResult = Result.success(false)
+
+        fixture.holder.setExcluded(chapter, excluded = true)
+        runCurrent()
+
+        assertEquals(listOf(42 to true), fixture.repository.excludedChapters)
+        assertEquals(
+            "Chapter 12 is back on every account's feed and player.",
+            fixture.holder.state.value.notice,
+        )
+
+        fixture.close()
+    }
+
+    @Test
+    fun `a 404 on exclude says the server cannot rather than claiming it worked`() = runTest {
+        val fixture = fixture()
+        fixture.repository.setChapterExcludedResult = Result.success(null)
+
+        fixture.holder.setExcluded(chapter, excluded = true)
+        runCurrent()
+
+        assertEquals("This server cannot exclude a chapter.", fixture.holder.state.value.notice)
+
+        fixture.close()
+    }
+
+    @Test
+    fun `a 404 on delete is not reported as a deletion`() = runTest {
+        val fixture = fixture()
+        fixture.repository.deleteChapterResult = Result.success(null)
+
+        fixture.holder.delete(chapter)
+        runCurrent()
+
+        assertEquals(listOf(42), fixture.repository.deletedChapters)
+        assertEquals(
+            "This server cannot delete a chapter.",
+            fixture.holder.state.value.notice,
+            "a 404 is ambiguous between no-such-endpoint and already-gone; neither is a deletion",
+        )
+
+        fixture.close()
+    }
+
+    @Test
+    fun `a successful delete says so`() = runTest {
+        val fixture = fixture()
+        fixture.repository.deleteChapterResult = Result.success(true)
+
+        fixture.holder.delete(chapter)
+        runCurrent()
+
+        assertEquals("Chapter 12 is deleted.", fixture.holder.state.value.notice)
+
+        fixture.close()
+    }
+
+    /**
+     * Deliberately on a [StandardTestDispatcher] rather than the unconfined one the rest use.
+     *
+     * Unconfined runs a launched body eagerly to its first suspension, and the fake never suspends,
+     * so the whole request finishes inside the call to `retry` and there is no in-flight window to
+     * press twice inside. A queuing dispatcher is what reproduces the real one: the body waits, and
+     * the second press arrives while the first has only been *started*.
+     *
+     * That gap is the bug this pins. Marking busy inside the coroutine — the obvious place — leaves
+     * the guard reading state nothing has written yet, and both presses go through.
+     */
+    @Test
+    fun `a second press while one is in flight is refused`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val fixture = fixture(dispatcher)
+        fixture.repository.retryChapterResult = Result.success(ChapterRetryOutcome.Queued(42))
+
+        fixture.holder.retry(chapter)
+        assertEquals(
+            42,
+            fixture.holder.state.value.busyChapterId,
+            "busy has to be visible before the body runs, or the guard has nothing to read",
+        )
+
+        fixture.holder.retry(chapter.copy(id = 43))
+        runCurrent()
+
+        assertEquals(
+            listOf(42),
+            fixture.repository.retriedChapters,
+            "a second press while one is in flight would race two writes against one shared row",
+        )
+
+        fixture.close()
+    }
+
+    @Test
+    fun `dismissing clears both the notice and the error`() = runTest {
+        val fixture = fixture()
+        fixture.repository.retryChapterResult = Result.failure(IllegalStateException("boom"))
+        fixture.holder.retry(chapter)
+        runCurrent()
+
+        fixture.holder.dismissNotice()
+
+        assertNull(fixture.holder.state.value.error)
+        assertNull(fixture.holder.state.value.notice)
+
+        fixture.close()
+    }
+
+    // --- fixture ----------------------------------------------------------------------------------
+
+    private class Fixture(
+        val repository: FakeRepository,
+        val cache: LibraryCache,
+        val holder: ChapterMaintenanceStateHolder,
+    ) {
+        fun close() {
+            holder.clear()
+            cache.close()
+        }
+    }
+
+    private fun TestScope.fixture(
+        dispatcher: TestDispatcher = UnconfinedTestDispatcher(testScheduler),
+    ): Fixture {
+        val repository = FakeRepository()
+        val cache = LibraryCache(repository, dispatcher)
+        return Fixture(repository, cache, ChapterMaintenanceStateHolder(repository, cache, dispatcher))
+    }
+}


### PR DESCRIPTION
Closes #113. Broken out of the capability-parity tracker (#94).

## The gap

The desktop already *saw* a failed chapter — `availability()` has mapped the
server's `status`/`sub_status`/`error_message` triple onto `Failed` since chapter
browsing shipped, and the row draws a chip for it. It just offered nothing to
press.

So a chapter that failed conversion was a permanent hole in a serial from this
client. The scheduler does not retry on its own, and the one-request fix existed
only in the web console.

## Three routes, deliberately not one gate

| Route | Gate | Why |
| --- | --- | --- |
| retry | capability only | The server leaves it open to any signed-in account: it repairs one chapter, harms nobody, and the account watching a failed row is usually the one that wants it fixed. |
| exclude | capability **and** verified `is_admin` | A chapter is one shared row. Excluding it changes what *every* account's podcast feed contains. |
| delete | capability **and** verified `is_admin` | Destroys the audio and every account's progress on it. |

That asymmetry is the server's and is kept rather than tidied into one flag. The
admin half uses `fictionManagementState.canManage` — the **verified** `is_admin`
from `/api/mobile/me`, not the role cached at login.

It also decided the layout. Retry is an icon on the failed row; the other two are
behind a disclosure as `AarisActionRow`s, by this repo's own test — *a control
that needs a sentence under it to be safe to press is not a button, it is a row*
— and neither consequence fits on a label.

## A 409 is a notice, not an error

It means the chapter is already converting, or is excluded. What was asked for is
either happening already or deliberately switched off, so reporting a failure
would invite a second press that says the same thing. The message names which of
the two it is, because the next action differs: one is waiting, the other is
undoing an exclusion.

## Two bugs the tests caught that reading the diff had not

**A busy guard that guarded nothing.** `busyChapterId` was set *inside* the
launched coroutine while the guard read it *outside*, so two presses in the same
frame both got through — before either body had run. On a shared chapter row that
is two writes racing, not one repeated. Now marked busy synchronously before the
launch, and the `job.cancel()` that would have cancelled a request already on the
wire is gone.

I verified this test pins the bug rather than the behaviour: reverting the fix
turns it red, restoring it turns it green. It runs on a `StandardTestDispatcher`
on purpose — the unconfined one used elsewhere runs a launched body eagerly, and
the fake never suspends, so there is no in-flight window to press twice inside.

**A `private set` I moved in #109.** Adding `voicesCalls` to `Fakes.kt` inserted
it between `audiobookExportsCalls` and its setter, silently transferring it.
Harmless while both were `var`s — which is why it passed CI — and it only
surfaced when a `val` landed at the same point. Both restored.

## Verification

`xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail
-Pttsroad.warningsAsErrors=true` — BUILD SUCCESSFUL in 4m59s. That is the CI
gate, not plain `check`.

18 new tests.

## Not in scope

`fiction_maintenance` — poll now, retry failures, reconvert, retag, apply filter.
Six more routes sharing this response shape and gating story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK3sri5jA6ne6tEJnbQaRe
