### PR TITLE
Finish a rename, and let a fiction be polled and requeued from here

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -105,6 +105,7 @@ import dk.perspektiva.ttsroad.desktop.ui.rememberChapterDownloads
 import dk.perspektiva.ttsroad.desktop.ui.rememberChapterQueue
 import dk.perspektiva.ttsroad.desktop.ui.UpdateStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.ChapterMaintenanceStateHolder
+import dk.perspektiva.ttsroad.desktop.data.fictionMaintenanceActions
 import dk.perspektiva.ttsroad.desktop.ui.ChapterMaintenanceUi
 import dk.perspektiva.ttsroad.desktop.ui.ManageShelfScreen
 import dk.perspektiva.ttsroad.desktop.ui.ManageShelfStateHolder
@@ -640,6 +641,23 @@ fun App(
                                         onRetry = chapterMaintenance::retry,
                                         onSetExcluded = chapterMaintenance::setExcluded,
                                         onDelete = chapterMaintenance::delete,
+                                        fictionActions = fictionMaintenanceActions(
+                                            capabilities,
+                                            // The verified is_admin, not the role cached at login.
+                                            isAdmin = fictionManagementState.canManage,
+                                        ),
+                                        busyAction = chapterMaintenanceState.busyAction,
+                                        confirming = chapterMaintenanceState.confirming,
+                                        onFictionAction = { action ->
+                                            chapterMaintenance.startFictionAction(
+                                                destination.fiction,
+                                                action,
+                                            )
+                                        },
+                                        onConfirmAction = {
+                                            chapterMaintenance.confirmFictionAction(destination.fiction)
+                                        },
+                                        onDismissConfirmation = chapterMaintenance::dismissConfirmation,
                                     ),
                                     fictionManagement = fictionManagementState,
                                     onEditFiction = { nav.open(Destination.FictionMetadata(it)) },

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/FictionMaintenance.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/FictionMaintenance.kt
@@ -1,0 +1,132 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+/**
+ * Acting on a whole fiction (#115).
+ *
+ * The counts are the point. `retag`, `reconvert-all` and `apply-chapter-filter` all answer
+ * `status: "ok"` whether they touched four hundred files or none, so a number is the only thing
+ * separating "done" from "there was nothing to do" — and on the expensive one, the only thing
+ * telling somebody what they just started.
+ *
+ * Two gates, as everywhere else here: the capability says the routes exist, `is_admin` says who may
+ * use them. [FictionMaintenanceAction.adminOnly] carries which is which, so the screen cannot draw a
+ * control the server will refuse.
+ */
+enum class FictionMaintenanceAction(
+    val title: String,
+    val subtitle: String,
+    /** False only for [Poll], which the server leaves open on purpose. */
+    val adminOnly: Boolean,
+    /** Whether pressing it asks a question first. Only the one that spends hours of TTS. */
+    val confirms: Boolean = false,
+) {
+    /**
+     * Not admin-gated, deliberately. The server rate-limits it, and a chapter found early benefits
+     * every reader rather than only the person who pressed it.
+     */
+    Poll(
+        title = "Check for new chapters",
+        subtitle = "Asks the source now instead of waiting for the next scheduled poll.",
+        adminOnly = false,
+    ),
+    RetryFailed(
+        title = "Retry failed chapters",
+        subtitle = "Queues every chapter of this fiction that errored. Nothing already converted is touched.",
+        adminOnly = true,
+    ),
+
+    /**
+     * The other half of the metadata editor.
+     *
+     * A title or cover changed here only reaches the database; the MP3s keep the old ID3 tags, and
+     * a podcast client reads the files. Without this, renaming a book from this client is applied
+     * in one place and not the other, with nothing on screen saying so.
+     */
+    Retag(
+        title = "Rewrite MP3 tags",
+        subtitle = "Applies the current title, author and cover to files already converted. No re-narration.",
+        adminOnly = true,
+    ),
+
+    /** One-way by design: it excludes, and never un-excludes — a hand-excluded chapter had a reason. */
+    ApplyFilter(
+        title = "Re-run the chapter filter",
+        subtitle = "Excludes existing chapters the fiction's title filter would have skipped. Never un-excludes.",
+        adminOnly = true,
+    ),
+    ReconvertAll(
+        title = "Re-narrate every chapter",
+        subtitle = "Throws away all existing audio and converts the whole serial again. Hours of TTS.",
+        adminOnly = true,
+        confirms = true,
+    ),
+}
+
+/** Which actions to draw. Poll needs only the capability; the rest need the verified admin flag. */
+fun fictionMaintenanceActions(
+    capabilities: ServerCapabilities,
+    isAdmin: Boolean,
+): List<FictionMaintenanceAction> = when {
+    !capabilities.fictionMaintenance -> emptyList()
+    isAdmin -> FictionMaintenanceAction.entries
+    else -> FictionMaintenanceAction.entries.filterNot { it.adminOnly }
+}
+
+/**
+ * What to say the question before re-narrating everything.
+ *
+ * Names the number, because "re-narrate every chapter" reads the same for a four-chapter serial and
+ * a four-hundred-chapter one, and only the second is a decision.
+ */
+fun reconvertConfirmation(doneChapters: Int): String = when (doneChapters) {
+    0 -> "Nothing is converted yet, so this only queues whatever the server has pulled."
+    1 -> "The one converted chapter is thrown away and narrated again from scratch."
+    else ->
+        "All $doneChapters converted chapters are thrown away and narrated again from scratch. " +
+            "That is $doneChapters conversions of outbound TTS, and the existing audio is gone as " +
+            "soon as this starts."
+}
+
+/**
+ * The line for a finished action.
+ *
+ * Every branch names a count, and a count of zero is reported rather than hidden: "nothing needed
+ * retagging" is a useful answer, and silence is indistinguishable from a control that did nothing.
+ */
+fun fictionMaintenanceMessage(
+    action: FictionMaintenanceAction,
+    response: MaintenanceResponse,
+): String = when (action) {
+    FictionMaintenanceAction.Poll -> when {
+        response.fullIngest -> "Re-read the whole chapter list from the source."
+        response.partialSync != null -> "Checked the source — re-read the last ${response.partialSync} chapters."
+        else -> "Checked the source for new chapters."
+    }
+
+    FictionMaintenanceAction.RetryFailed -> when (val n = response.resetCount ?: 0) {
+        0 -> "No failed chapters to retry."
+        1 -> "Queued one failed chapter again."
+        else -> "Queued $n failed chapters again."
+    }
+
+    FictionMaintenanceAction.Retag -> when (val n = response.fileCount ?: 0) {
+        0 -> "No files needed rewriting."
+        1 -> "Rewrote the tags on one file."
+        else -> "Rewrote the tags on $n files."
+    }
+
+    // `detail` distinguishes "there is no filter configured" from "the filter matched nothing", and
+    // only the first means the control had nothing to work with.
+    FictionMaintenanceAction.ApplyFilter -> response.detail?.takeIf { it.isNotBlank() }
+        ?: when (val n = response.excludedCount ?: 0) {
+            0 -> "The filter excluded nothing new."
+            1 -> "Excluded one chapter."
+            else -> "Excluded $n chapters."
+        }
+
+    FictionMaintenanceAction.ReconvertAll -> when (val n = response.resetCount ?: 0) {
+        0 -> "Nothing was queued for re-narration."
+        1 -> "Queued one chapter for re-narration."
+        else -> "Queued $n chapters for re-narration. This will take a while."
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
@@ -555,8 +555,23 @@ data class MaintenanceResponse(
     /** Whether the chapter is now excluded, echoed by the exclude route. */
     val excluded: Boolean? = null,
     val deleted: Boolean? = null,
-    /** Chapters requeued by a fiction-wide retry. */
+    /** Chapters requeued by `retry-failed` or `reconvert-all`. */
     @param:Json(name = "reset_count") val resetCount: Int? = null,
+    /** MP3s whose ID3 tags `retag` rewrote. */
+    @param:Json(name = "file_count") val fileCount: Int? = null,
+    /** Chapters the filter took out. Never un-excludes: a hand-excluded chapter had a reason. */
+    @param:Json(name = "excluded_count") val excludedCount: Int? = null,
+    /** True when `poll` re-ingested the whole chapter list rather than the recent tail. */
+    @param:Json(name = "full_ingest") val fullIngest: Boolean = false,
+    /** How many chapters a partial poll re-read, when it took that branch. */
+    @param:Json(name = "partial_sync") val partialSync: Int? = null,
+    /**
+     * Why nothing happened, when that is worth saying.
+     *
+     * `apply-chapter-filter` sets it when the fiction has no filter configured — which is not a
+     * failure, and is the difference between "excluded nothing" and "there was no rule to run".
+     */
+    val detail: String? = null,
 )
 
 /** `POST /api/mobile/chapters/{id}/exclude` — take a chapter off every feed, or put it back. */

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -228,6 +228,17 @@ interface TtsRoadRepository {
     suspend fun deleteChapter(chapterId: Int): Boolean? = null
 
     /**
+     * Run one whole-fiction maintenance action.
+     *
+     * Null means the server answered 404 — it has no such route. The response is returned rather
+     * than reduced to a boolean because the counts inside it are the answer.
+     */
+    suspend fun runFictionMaintenance(
+        fictionId: Int,
+        action: FictionMaintenanceAction,
+    ): MaintenanceResponse? = null
+
+    /**
      * Revokes one session.
      *
      * False means the server answered 404, which is ambiguous by design: the endpoint may be
@@ -611,6 +622,19 @@ class RetrofitTtsRoadRepository(
 
     override suspend fun deleteChapter(chapterId: Int): Boolean? =
         ifEndpointExists { it.deleteChapter(chapterId) }?.let { it.deleted ?: true }
+
+    override suspend fun runFictionMaintenance(
+        fictionId: Int,
+        action: FictionMaintenanceAction,
+    ): MaintenanceResponse? = ifEndpointExists { api ->
+        when (action) {
+            FictionMaintenanceAction.Poll -> api.pollFiction(fictionId)
+            FictionMaintenanceAction.RetryFailed -> api.retryFailedChapters(fictionId)
+            FictionMaintenanceAction.Retag -> api.retagFiction(fictionId)
+            FictionMaintenanceAction.ApplyFilter -> api.applyChapterFilter(fictionId)
+            FictionMaintenanceAction.ReconvertAll -> api.reconvertAllChapters(fictionId)
+        }
+    }
 
     override suspend fun revokeDevice(tokenId: Int): Boolean =
         ifEndpointExists { it.revokeDevice(tokenId) } != null

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
@@ -96,6 +96,13 @@ data class ServerCapabilities(
      * them this account may actually use.
      */
     val chapterMaintenance: Boolean = false,
+    /**
+     * Act on a whole fiction: poll it now, requeue its failures, retag, re-filter, re-narrate.
+     *
+     * Like [chapterMaintenance], the flag says only that the routes exist, and the gate is not
+     * uniform: poll is open to any account and the other four are admin-only.
+     */
+    val fictionMaintenance: Boolean = false,
     val maxChaptersPerPage: Int? = null,
     /**
      * How many items `/playback/sync` accepts in one batch.
@@ -144,6 +151,7 @@ data class ServerCapabilities(
             notifications = response.capabilities.flag("notifications"),
             voiceCatalogue = response.capabilities.flag("voice_catalogue"),
             chapterMaintenance = response.capabilities.flag("chapter_maintenance"),
+            fictionMaintenance = response.capabilities.flag("fiction_maintenance"),
             maxChaptersPerPage = response.limits.intLimit("max_chapters_per_page"),
             maxPlaybackSyncItems = response.limits.intLimit("max_playback_sync_items"),
             maxEpubBytes = response.limits.longLimit("max_epub_bytes"),

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -88,6 +88,35 @@ interface TtsRoadApi {
     @DELETE("api/mobile/chapters/{chapter_id}")
     suspend fun deleteChapter(@Path("chapter_id") chapterId: Int): MaintenanceResponse
 
+    // Fiction maintenance (#115). Same response shape and the same two-gate story as the chapter
+    // routes above: poll is open to any account (the server rate-limits it, and a fresh chapter
+    // benefits every reader), the other four are admin-only.
+
+    /** Check the source for new chapters now rather than waiting for the scheduler. */
+    @POST("api/mobile/fictions/{fiction_id}/poll")
+    suspend fun pollFiction(@Path("fiction_id") fictionId: Int): MaintenanceResponse
+
+    /** Requeue every errored chapter of one fiction. */
+    @POST("api/mobile/fictions/{fiction_id}/retry-failed")
+    suspend fun retryFailedChapters(@Path("fiction_id") fictionId: Int): MaintenanceResponse
+
+    /**
+     * Rewrite the ID3 tags on existing MP3s. No TTS is re-run.
+     *
+     * The other half of the metadata editor: a title changed here is only applied to the database
+     * until the files carrying it are rewritten, and a podcast client reads the files.
+     */
+    @POST("api/mobile/fictions/{fiction_id}/retag")
+    suspend fun retagFiction(@Path("fiction_id") fictionId: Int): MaintenanceResponse
+
+    /** Re-run the title filter over existing chapters. One-way: excludes, never un-excludes. */
+    @POST("api/mobile/fictions/{fiction_id}/apply-chapter-filter")
+    suspend fun applyChapterFilter(@Path("fiction_id") fictionId: Int): MaintenanceResponse
+
+    /** Re-narrate every chapter. Expensive — a 400-chapter serial is 400 conversions. */
+    @POST("api/mobile/fictions/{fiction_id}/reconvert-all")
+    suspend fun reconvertAllChapters(@Path("fiction_id") fictionId: Int): MaintenanceResponse
+
     // Both revoke calls answer with a small status object (`{"status": "ok", ...}`) whose shape is
     // not worth modelling: the client re-reads the list afterwards rather than trusting an echo,
     // because a 404 on the DELETE is ambiguous between "already gone" and "no such endpoint".

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterMaintenanceStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterMaintenanceStateHolder.kt
@@ -4,7 +4,10 @@ import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
 import dk.perspektiva.ttsroad.desktop.data.LibraryCache
 import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
 import dk.perspektiva.ttsroad.desktop.data.chapterExcludeMessage
+import dk.perspektiva.ttsroad.desktop.data.FictionMaintenanceAction
+import dk.perspektiva.ttsroad.desktop.data.FictionSummary
 import dk.perspektiva.ttsroad.desktop.data.chapterRetryMessage
+import dk.perspektiva.ttsroad.desktop.data.fictionMaintenanceMessage
 import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -18,9 +21,15 @@ import kotlinx.coroutines.launch
 data class ChapterMaintenanceUiState(
     /** The chapter a request is in flight for, so one row can be disabled rather than the list. */
     val busyChapterId: Int? = null,
+    /** The whole-fiction action in flight, if any. */
+    val busyAction: FictionMaintenanceAction? = null,
+    /** The expensive action waiting for an answer. Only re-narration asks. */
+    val confirming: FictionMaintenanceAction? = null,
     val notice: String? = null,
     val error: String? = null,
-)
+) {
+    val isBusy: Boolean get() = busyChapterId != null || busyAction != null
+}
 
 /**
  * Repairing one chapter (#113).
@@ -68,6 +77,57 @@ class ChapterMaintenanceStateHolder(
         }
     }
 
+    /**
+     * Start a whole-fiction action, asking first when it is the expensive one.
+     *
+     * Only re-narration confirms. The rest are cheap and reversible enough that a question before
+     * each would be the kind of prompt people learn to click through — which is what makes the one
+     * real question worth anything.
+     */
+    fun startFictionAction(fiction: FictionSummary, action: FictionMaintenanceAction) {
+        if (_state.value.isBusy) return
+        if (action.confirms) {
+            _state.update { it.copy(confirming = action, notice = null, error = null) }
+        } else {
+            runFiction(fiction, action)
+        }
+    }
+
+    fun confirmFictionAction(fiction: FictionSummary) {
+        val action = _state.value.confirming ?: return
+        _state.update { it.copy(confirming = null) }
+        runFiction(fiction, action)
+    }
+
+    fun dismissConfirmation() = _state.update { it.copy(confirming = null) }
+
+    private fun runFiction(fiction: FictionSummary, action: FictionMaintenanceAction) {
+        if (_state.value.isBusy) return
+        // Busy before the launch, for the reason the chapter guard is: a body that has not run yet
+        // has written nothing for the guard to read.
+        _state.update { it.copy(busyAction = action, notice = null, error = null) }
+        job = scope.launch {
+            val outcome = runCatching { repository.runFictionMaintenance(fiction.id, action) }
+            val failure = outcome.exceptionOrNull()
+            val response = outcome.getOrNull()
+            _state.update {
+                it.copy(
+                    busyAction = null,
+                    notice = when {
+                        failure != null -> null
+                        // Null is the server's 404: it has no such route. Not a failure to raise,
+                        // but not something to report a count for either.
+                        response == null -> "This server cannot do that."
+                        else -> fictionMaintenanceMessage(action, response)
+                    },
+                    error = failure?.let { userFacingMessage(it, "Could not run that action") },
+                )
+            }
+            // Poll and retry change chapter rows; retag and the filter change what the list shows.
+            cache.refreshChapters(fiction.id)
+        }
+    }
+
     fun dismissNotice() = _state.update { it.copy(notice = null, error = null) }
 
     /**
@@ -77,7 +137,7 @@ class ChapterMaintenanceStateHolder(
      * because the chapter was already converting has still left the row out of date on screen.
      */
     private fun run(chapter: ChapterSummary, block: suspend () -> String?) {
-        if (_state.value.busyChapterId != null) return
+        if (_state.value.isBusy) return
         // Marked busy *here*, not inside the coroutine. A launched body does not run until the
         // dispatcher reaches it, so a guard that reads state the body sets lets a second press
         // through in the gap — and these are writes against one shared row, where the second one

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionDetailScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/FictionDetailScreen.kt
@@ -91,7 +91,9 @@ import dk.perspektiva.ttsroad.desktop.data.listeningTotals
 import dk.perspektiva.ttsroad.desktop.data.markableIds
 import dk.perspektiva.ttsroad.desktop.data.playbackOrder
 import dk.perspektiva.ttsroad.desktop.data.canRetry
+import dk.perspektiva.ttsroad.desktop.data.FictionMaintenanceAction
 import dk.perspektiva.ttsroad.desktop.data.chapterDeleteConfirmation
+import dk.perspektiva.ttsroad.desktop.data.reconvertConfirmation
 import dk.perspektiva.ttsroad.desktop.data.statusLabel
 import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
 import dk.perspektiva.ttsroad.desktop.player.PlaybackController
@@ -99,6 +101,7 @@ import dk.perspektiva.ttsroad.desktop.player.playingChapterIdIn
 import kotlinx.coroutines.launch
 
 /** Test handle for "how many chapter rows did the lazy list actually compose". */
+const val PollFictionButtonTestTag: String = "pollFictionButton"
 const val ChapterRowTestTag: String = "chapterRow"
 
 /** Test handle for the chapter list's scroll container. */
@@ -183,6 +186,13 @@ data class ChapterMaintenanceUi(
     val busyChapterId: Int? = null,
     val notice: String? = null,
     val error: String? = null,
+    /** Whole-fiction actions this account may run, already filtered by capability and role. */
+    val fictionActions: List<FictionMaintenanceAction> = emptyList(),
+    val busyAction: FictionMaintenanceAction? = null,
+    val confirming: FictionMaintenanceAction? = null,
+    val onFictionAction: (FictionMaintenanceAction) -> Unit = {},
+    val onConfirmAction: () -> Unit = {},
+    val onDismissConfirmation: () -> Unit = {},
     val onRetry: (ChapterSummary) -> Unit = {},
     val onSetExcluded: (ChapterSummary, Boolean) -> Unit = { _, _ -> },
     val onDelete: (ChapterSummary) -> Unit = {},
@@ -374,6 +384,22 @@ fun FictionDetailScreen(
                         compact = compact,
                     )
 
+                    // Outside the admin block on purpose: the server leaves polling open to any
+                    // account, so gating it on `canManage` would hide it from most of them.
+                    if (FictionMaintenanceAction.Poll in maintenance.fictionActions) {
+                        Spacer(Modifier.height(16.dp))
+                        AarisSecondaryAction(
+                            label = if (maintenance.busyAction == FictionMaintenanceAction.Poll) {
+                                "Checking…"
+                            } else {
+                                FictionMaintenanceAction.Poll.title
+                            },
+                            onClick = { maintenance.onFictionAction(FictionMaintenanceAction.Poll) },
+                            enabled = maintenance.busyAction == null,
+                            modifier = Modifier.testTag(PollFictionButtonTestTag),
+                        )
+                    }
+
                     if (fictionManagement.canManage) {
                         Spacer(Modifier.height(16.dp))
                         ManageFictionBlock(
@@ -382,6 +408,7 @@ fun FictionDetailScreen(
                                 onEdit = { onEditFiction(header) },
                                 onDelete = { onDeleteFiction(header) },
                             ),
+                            maintenance = maintenance,
                         )
                     }
 
@@ -528,6 +555,16 @@ fun FictionDetailScreen(
                 deletingChapter = chapter
             },
             onDismiss = { managingChapter = null },
+        )
+    }
+
+    maintenance.confirming?.let { action ->
+        ConfirmDialog(
+            title = action.title.uppercase(),
+            body = reconvertConfirmation(fiction.doneChapters),
+            confirmLabel = "RE-NARRATE EVERYTHING",
+            onConfirm = maintenance.onConfirmAction,
+            onDismiss = maintenance.onDismissConfirmation,
         )
     }
 
@@ -824,7 +861,10 @@ const val ManageFictionTestTag: String = "manageFiction"
  * progress — which is the test for rank three. A header row of four equal buttons could say neither.
  */
 @Composable
-private fun ManageFictionBlock(actions: FictionManagementActions) {
+private fun ManageFictionBlock(
+    actions: FictionManagementActions,
+    maintenance: ChapterMaintenanceUi = ChapterMaintenanceUi(),
+) {
     var open by rememberSaveable { mutableStateOf(false) }
     Column(
         Modifier.fillMaxWidth().testTag(ManageFictionTestTag),
@@ -842,6 +882,24 @@ private fun ManageFictionBlock(actions: FictionManagementActions) {
                 enabled = !actions.busy,
                 modifier = Modifier.testTag(EditFictionButtonTestTag),
             )
+            // The admin maintenance rows sit between editing and deleting: each needs its own
+            // sentence, which is the same reason Edit and Delete are rows rather than buttons.
+            maintenance.fictionActions.filter { it.adminOnly }.forEach { action ->
+                AarisActionRow(
+                    title = if (maintenance.busyAction == action) "${action.title}…" else action.title,
+                    subtitle = action.subtitle,
+                    onClick = { maintenance.onFictionAction(action) },
+                    enabled = !actions.busy && maintenance.busyAction == null,
+                    // Severity: re-narration throws away audio that exists. That does not promote
+                    // it above the others in the order anything is reached for.
+                    titleColor = if (action == FictionMaintenanceAction.ReconvertAll) {
+                        AarisColor.Warning
+                    } else {
+                        AarisColor.Ink
+                    },
+                    modifier = Modifier.testTag("maintenance:${action.name}"),
+                )
+            }
             AarisActionRow(
                 title = "Delete fiction",
                 subtitle = "Destroys the shared chapters and every account's progress. Not undoable.",

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -17,6 +17,8 @@ import dk.perspektiva.ttsroad.desktop.data.LibraryResponse
 import dk.perspektiva.ttsroad.desktop.data.LoginResult
 import dk.perspektiva.ttsroad.desktop.data.MobileUser
 import dk.perspektiva.ttsroad.desktop.data.ChapterRetryOutcome
+import dk.perspektiva.ttsroad.desktop.data.FictionMaintenanceAction
+import dk.perspektiva.ttsroad.desktop.data.MaintenanceResponse
 import dk.perspektiva.ttsroad.desktop.data.MobileVoice
 import dk.perspektiva.ttsroad.desktop.data.PlaybackMarkResponse
 import dk.perspektiva.ttsroad.desktop.data.PlaybackStateRow
@@ -90,6 +92,7 @@ open class FakeRepository(
     var retryChapterResult: Result<ChapterRetryOutcome> = Result.success(ChapterRetryOutcome.Unsupported),
     var setChapterExcludedResult: Result<Boolean?>? = null,
     var deleteChapterResult: Result<Boolean?> = Result.success(null),
+    var fictionMaintenanceResult: Result<MaintenanceResponse?> = Result.success(null),
     /** Null models a server whose notifications route answers 404. */
     var chapterNotificationsResult: Result<ChapterNotificationsResponse?> = Result.success(null),
 ) : TtsRoadRepository {
@@ -117,6 +120,7 @@ open class FakeRepository(
     val retriedChapters: MutableList<Int> = mutableListOf()
     val excludedChapters: MutableList<Pair<Int, Boolean>> = mutableListOf()
     val deletedChapters: MutableList<Int> = mutableListOf()
+    val fictionMaintenanceCalls: MutableList<Pair<Int, FictionMaintenanceAction>> = mutableListOf()
     var revokeOtherDevicesCalls: Int = 0
         private set
     var readAlongCalls: Int = 0
@@ -303,6 +307,14 @@ open class FakeRepository(
     override suspend fun deleteChapter(chapterId: Int): Boolean? {
         deletedChapters += chapterId
         return deleteChapterResult.getOrThrow()
+    }
+
+    override suspend fun runFictionMaintenance(
+        fictionId: Int,
+        action: FictionMaintenanceAction,
+    ): MaintenanceResponse? {
+        fictionMaintenanceCalls += fictionId to action
+        return fictionMaintenanceResult.getOrThrow()
     }
 
     override suspend fun revokeDevice(tokenId: Int): Boolean {

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/FictionMaintenanceTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/FictionMaintenanceTest.kt
@@ -1,0 +1,139 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class FictionMaintenanceTest {
+
+    @Test
+    fun `poll is offered to a non-admin and the rest are not`() {
+        val capable = ServerCapabilities(fictionMaintenance = true)
+
+        assertEquals(
+            listOf(FictionMaintenanceAction.Poll),
+            fictionMaintenanceActions(capable, isAdmin = false),
+            "the server leaves polling open on purpose; the other four it does not",
+        )
+        assertEquals(
+            FictionMaintenanceAction.entries,
+            fictionMaintenanceActions(capable, isAdmin = true),
+        )
+        assertTrue(fictionMaintenanceActions(ServerCapabilities.Baseline, isAdmin = true).isEmpty())
+    }
+
+    @Test
+    fun `only re-narration asks a question`() {
+        val confirming = FictionMaintenanceAction.entries.filter { it.confirms }
+
+        assertEquals(
+            listOf(FictionMaintenanceAction.ReconvertAll),
+            confirming,
+            "a prompt before each cheap action is what teaches people to click through the real one",
+        )
+    }
+
+    @Test
+    fun `the re-narration question names the number`() {
+        val many = reconvertConfirmation(doneChapters = 412)
+
+        assertTrue(many.contains("412 converted chapters"))
+        assertTrue(many.contains("412 conversions"))
+        assertTrue(many.contains("existing audio is gone"))
+        assertTrue(reconvertConfirmation(1).contains("The one converted chapter"))
+        assertTrue(reconvertConfirmation(0).contains("Nothing is converted yet"))
+    }
+
+    @Test
+    fun `a poll reports which branch it took`() {
+        assertEquals(
+            "Re-read the whole chapter list from the source.",
+            message(FictionMaintenanceAction.Poll, MaintenanceResponse(fullIngest = true)),
+        )
+        assertEquals(
+            "Checked the source — re-read the last 25 chapters.",
+            message(FictionMaintenanceAction.Poll, MaintenanceResponse(partialSync = 25)),
+        )
+        assertEquals(
+            "Checked the source for new chapters.",
+            message(FictionMaintenanceAction.Poll, MaintenanceResponse()),
+        )
+    }
+
+    @Test
+    fun `a count of zero is reported rather than hidden`() {
+        // "status: ok" is the same answer for four hundred files and none. Silence would be
+        // indistinguishable from a control that did nothing.
+        assertEquals(
+            "No files needed rewriting.",
+            message(FictionMaintenanceAction.Retag, MaintenanceResponse(fileCount = 0)),
+        )
+        assertEquals(
+            "No failed chapters to retry.",
+            message(FictionMaintenanceAction.RetryFailed, MaintenanceResponse(resetCount = 0)),
+        )
+        assertEquals(
+            "The filter excluded nothing new.",
+            message(FictionMaintenanceAction.ApplyFilter, MaintenanceResponse(excludedCount = 0)),
+        )
+    }
+
+    @Test
+    fun `counts are singular and plural`() {
+        assertEquals(
+            "Rewrote the tags on one file.",
+            message(FictionMaintenanceAction.Retag, MaintenanceResponse(fileCount = 1)),
+        )
+        assertEquals(
+            "Rewrote the tags on 12 files.",
+            message(FictionMaintenanceAction.Retag, MaintenanceResponse(fileCount = 12)),
+        )
+        assertEquals(
+            "Queued one failed chapter again.",
+            message(FictionMaintenanceAction.RetryFailed, MaintenanceResponse(resetCount = 1)),
+        )
+    }
+
+    @Test
+    fun `no filter configured is reported as itself, not as excluding nothing`() {
+        val response = MaintenanceResponse(excludedCount = 0, detail = "No chapter filter is set.")
+
+        assertEquals(
+            "No chapter filter is set.",
+            message(FictionMaintenanceAction.ApplyFilter, response),
+            "there being no rule to run is a different answer from the rule matching nothing",
+        )
+    }
+
+    @Test
+    fun `re-narration warns that it will take a while`() {
+        val message = message(FictionMaintenanceAction.ReconvertAll, MaintenanceResponse(resetCount = 400))
+
+        assertTrue(message.contains("400 chapters"))
+        assertTrue(message.contains("take a while"))
+    }
+
+    @Test
+    fun `every action carries its own sentence`() {
+        FictionMaintenanceAction.entries.forEach { action ->
+            assertTrue(action.subtitle.isNotBlank(), "${action.name} needs a subtitle to be a row")
+            assertTrue(action.title.isNotBlank())
+        }
+    }
+
+    @Test
+    fun `retag says it does not re-narrate`() {
+        // The distinction that matters: it rewrites files, it does not spend TTS.
+        assertTrue(FictionMaintenanceAction.Retag.subtitle.contains("No re-narration"))
+        assertFalse(FictionMaintenanceAction.Retag.confirms)
+    }
+
+    @Test
+    fun `the filter row says it never un-excludes`() {
+        assertTrue(FictionMaintenanceAction.ApplyFilter.subtitle.contains("Never un-excludes"))
+    }
+
+    private fun message(action: FictionMaintenanceAction, response: MaintenanceResponse) =
+        fictionMaintenanceMessage(action, response)
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterMaintenanceStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ChapterMaintenanceStateHolderTest.kt
@@ -3,6 +3,9 @@ package dk.perspektiva.ttsroad.desktop.ui
 import dk.perspektiva.ttsroad.desktop.FakeRepository
 import dk.perspektiva.ttsroad.desktop.data.ChapterRetryOutcome
 import dk.perspektiva.ttsroad.desktop.data.ChapterSummary
+import dk.perspektiva.ttsroad.desktop.data.FictionMaintenanceAction
+import dk.perspektiva.ttsroad.desktop.data.FictionSummary
+import dk.perspektiva.ttsroad.desktop.data.MaintenanceResponse
 import dk.perspektiva.ttsroad.desktop.data.LibraryCache
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -19,6 +22,8 @@ import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ChapterMaintenanceStateHolderTest {
+
+    private val fiction = FictionSummary(id = 7, title = "Wandering Inn", doneChapters = 400)
 
     private val chapter = ChapterSummary(
         id = 42,
@@ -188,6 +193,120 @@ class ChapterMaintenanceStateHolderTest {
 
         assertNull(fixture.holder.state.value.error)
         assertNull(fixture.holder.state.value.notice)
+
+        fixture.close()
+    }
+
+
+    // --- whole-fiction actions (#115) ---------------------------------------------------------
+
+    @Test
+    fun `a cheap action runs without asking`() = runTest {
+        val fixture = fixture()
+        fixture.repository.fictionMaintenanceResult =
+            Result.success(MaintenanceResponse(fileCount = 12))
+
+        fixture.holder.startFictionAction(fiction, FictionMaintenanceAction.Retag)
+        runCurrent()
+
+        assertEquals(
+            listOf(7 to FictionMaintenanceAction.Retag),
+            fixture.repository.fictionMaintenanceCalls,
+        )
+        assertEquals("Rewrote the tags on 12 files.", fixture.holder.state.value.notice)
+        assertNull(fixture.holder.state.value.confirming)
+
+        fixture.close()
+    }
+
+    @Test
+    fun `re-narration asks first and sends nothing until confirmed`() = runTest {
+        val fixture = fixture()
+        fixture.repository.fictionMaintenanceResult =
+            Result.success(MaintenanceResponse(resetCount = 400))
+
+        fixture.holder.startFictionAction(fiction, FictionMaintenanceAction.ReconvertAll)
+        runCurrent()
+
+        assertEquals(FictionMaintenanceAction.ReconvertAll, fixture.holder.state.value.confirming)
+        assertTrue(
+            fixture.repository.fictionMaintenanceCalls.isEmpty(),
+            "hours of outbound TTS should not start on one press",
+        )
+
+        fixture.holder.confirmFictionAction(fiction)
+        runCurrent()
+
+        assertEquals(
+            listOf(7 to FictionMaintenanceAction.ReconvertAll),
+            fixture.repository.fictionMaintenanceCalls,
+        )
+        assertNull(fixture.holder.state.value.confirming)
+
+        fixture.close()
+    }
+
+    @Test
+    fun `dismissing the re-narration question sends nothing`() = runTest {
+        val fixture = fixture()
+
+        fixture.holder.startFictionAction(fiction, FictionMaintenanceAction.ReconvertAll)
+        fixture.holder.dismissConfirmation()
+        runCurrent()
+
+        assertNull(fixture.holder.state.value.confirming)
+        assertTrue(fixture.repository.fictionMaintenanceCalls.isEmpty())
+
+        fixture.close()
+    }
+
+    @Test
+    fun `a 404 says the server cannot rather than reporting a count`() = runTest {
+        val fixture = fixture()
+        fixture.repository.fictionMaintenanceResult = Result.success(null)
+
+        fixture.holder.startFictionAction(fiction, FictionMaintenanceAction.Poll)
+        runCurrent()
+
+        assertEquals("This server cannot do that.", fixture.holder.state.value.notice)
+        assertNull(fixture.holder.state.value.error)
+
+        fixture.close()
+    }
+
+    @Test
+    fun `a failure sets an error and no notice`() = runTest {
+        val fixture = fixture()
+        fixture.repository.fictionMaintenanceResult = Result.failure(IllegalStateException("boom"))
+
+        fixture.holder.startFictionAction(fiction, FictionMaintenanceAction.Poll)
+        runCurrent()
+
+        assertNotNull(fixture.holder.state.value.error)
+        assertNull(
+            fixture.holder.state.value.notice,
+            "reporting both would say it worked and failed in the same breath",
+        )
+        assertNull(fixture.holder.state.value.busyAction)
+
+        fixture.close()
+    }
+
+    @Test
+    fun `a chapter action and a fiction action cannot overlap`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val fixture = fixture(dispatcher)
+        fixture.repository.fictionMaintenanceResult = Result.success(MaintenanceResponse())
+
+        fixture.holder.startFictionAction(fiction, FictionMaintenanceAction.Poll)
+        fixture.holder.retry(chapter)
+        runCurrent()
+
+        assertTrue(
+            fixture.repository.retriedChapters.isEmpty(),
+            "both write to the same fiction; the second would race the first",
+        )
+        assertEquals(1, fixture.repository.fictionMaintenanceCalls.size)
 
         fixture.close()
     }


### PR DESCRIPTION
Closes #115. Follows #113, which did the chapter half.

## Retag is the missing half of a feature that already shipped

#109 gave this client a metadata editor, so a book can be renamed from here. But
the title only reaches the database — the MP3s keep the old ID3 tags, and **a
podcast client reads the files**. A rename was applied in one place and not the
other, with nothing on screen saying so. The server's comment on the route says
the same thing.

## The five routes

| Action | Gate | Notes |
| --- | --- | --- |
| Poll | **any account** | Check the source now. Server rate-limits it. |
| Retry failed | admin | Requeue this fiction's errored chapters. |
| Retag | admin | Rewrite ID3 tags. No TTS. |
| Re-run filter | admin | One-way — excludes, never un-excludes. |
| Re-narrate all | admin | Expensive. Confirms first. |

`POST /retry-all-failed` is library-wide and deliberately left out: it belongs in
Settings, not on one fiction's screen.

## Placement follows the gate

Poll sits with the ordinary controls, **outside** `ManageFictionBlock`. That
block is drawn only for `canManage`, so putting poll inside would have hidden an
action the server deliberately leaves open from almost everyone who wants it.

The four admin actions go in that disclosure beside Edit and Delete, each as an
`AarisActionRow` carrying its own sentence — the same rank-three test those two
already satisfy.

## Only one action asks

Re-narration, and the question names the number. "Re-narrate every chapter" reads
identically for a 4-chapter serial and a 400-chapter one, and only the second is
a decision. A prompt in front of each cheap action is what teaches people to click
through the one that matters.

## Counts, including zero

`retag`, `apply-chapter-filter` and the rest all answer `status: "ok"` whether
they touched four hundred files or none, so the count is the only real content in
the response. Zero is reported rather than hidden — "no files needed rewriting" is
a useful answer and silence looks like a broken button.

`apply-chapter-filter` reports **no filter configured** separately from *the
filter excluded nothing*, using the response's `detail`. Those are different
answers and only the first means the control had nothing to work with.

## One request at a time, across both halves

A chapter retry and a fiction poll write to the same fiction, so the busy guard
covers both rather than each guarding only itself — and it is set before the
coroutine launches, for the reason #113 established.

## Verification

`xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail
-Pttsroad.warningsAsErrors=true` — BUILD SUCCESSFUL in 5m24s, first run.

17 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK3sri5jA6ne6tEJnbQaRe
