### PR TITLE
Copy the podcast URL this project exists to serve

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -108,6 +108,7 @@ import dk.perspektiva.ttsroad.desktop.ui.ChapterMaintenanceStateHolder
 import dk.perspektiva.ttsroad.desktop.data.fictionMaintenanceActions
 import dk.perspektiva.ttsroad.desktop.ui.ChapterMaintenanceUi
 import dk.perspektiva.ttsroad.desktop.ui.ManageShelfScreen
+import dk.perspektiva.ttsroad.desktop.ui.PodcastFeedsStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.ManageShelfStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.rememberStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.windowSizeClassFor
@@ -173,6 +174,7 @@ fun App(
     val chapterMaintenance = rememberStateHolder(repository, cache) {
         ChapterMaintenanceStateHolder(repository, cache)
     }
+    val podcastFeeds = rememberStateHolder(repository) { PodcastFeedsStateHolder(repository) }
     // Hoisted for the same reason: "Add to queue" is pressed on a chapter list, so the queue has to
     // exist and report what happened whether or not the queue screen was ever opened.
     val serverQueue = rememberStateHolder(repository, playback) {
@@ -734,6 +736,7 @@ fun App(
                                     // Devices deep link and the in-screen pane list are the same
                                     // thing rather than two competing notions of "where am I".
                                     onOpenShelf = { nav.open(Destination.ManageShelf) },
+                                    feeds = podcastFeeds,
                                     onSectionSelected = { section ->
                                         nav.replaceTop(
                                             if (section == SettingsSection.Devices) {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
@@ -576,3 +576,45 @@ data class MaintenanceResponse(
 
 /** `POST /api/mobile/chapters/{id}/exclude` — take a chapter off every feed, or put it back. */
 data class ChapterExcludeRequest(val excluded: Boolean = true)
+
+/**
+ * `GET /api/mobile/feeds` — every podcast URL this account can hand to a podcast app (#117).
+ *
+ * A private podcast feed is what this project is for, and until now the only way to get a tokenised
+ * URL into a podcast app was to open the web console and copy it from there.
+ */
+data class FeedsResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    /** `followed` or `all`, echoed back — the same scoping `/library` uses. */
+    val scope: String = "followed",
+    val library: LibraryFeedUrls? = null,
+    val fictions: List<FictionFeedUrl> = emptyList(),
+)
+
+/**
+ * This account's own feeds, which are the ones its rotate lever revokes.
+ *
+ * Both URLs carry a token derived from the user and a version number, so rotating bumps the version
+ * and every previously issued URL stops working.
+ */
+data class LibraryFeedUrls(
+    @param:Json(name = "feed_token_version") val feedTokenVersion: Int = 0,
+    @param:Json(name = "feed_url") val feedUrl: String? = null,
+    @param:Json(name = "opml_url") val opmlUrl: String? = null,
+)
+
+/**
+ * One fiction's feed.
+ *
+ * Deliberately *not* user-scoped: the token comes from the fiction, so this is the same string for
+ * every account on the server and rotating it is a separate admin action on that fiction. The
+ * account's own rotate does not touch it — which is worth saying on screen, because listing these
+ * beside the account's own URLs implies otherwise.
+ */
+data class FictionFeedUrl(
+    @param:Json(name = "fiction_id") val fictionId: Int = 0,
+    val title: String = "",
+    val slug: String? = null,
+    @param:Json(name = "feed_token_version") val feedTokenVersion: Int = 0,
+    @param:Json(name = "feed_url") val feedUrl: String? = null,
+)

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PodcastFeeds.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PodcastFeeds.kt
@@ -1,0 +1,93 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
+
+/**
+ * The podcast URLs, and getting one onto the clipboard (#117).
+ *
+ * A private podcast feed is what this project is for, and this client could not show you its URL —
+ * subscribing meant opening the web console in a browser. On a desktop the whole feature is a copy
+ * button.
+ *
+ * **These strings are credentials.** The token in the URL is the entire authorization: anyone
+ * holding it can read the feed without signing in. So nothing here goes near `AppLog`, which is
+ * persistent, and no feed URL belongs in a window title, a notification or a diagnostics dump.
+ */
+
+/** One copyable row. [secret] marks the URLs that must never reach a log. */
+data class FeedLink(
+    val label: String,
+    val detail: String,
+    val url: String,
+    val secret: Boolean = true,
+)
+
+/**
+ * Writing to the system clipboard, as a seam.
+ *
+ * A `fun interface` rather than a direct AWT call so a holder can be driven from `runTest` without a
+ * display, and so the "what was copied" assertion is about the value rather than about the platform.
+ */
+fun interface ClipboardWriter {
+    fun write(text: String)
+}
+
+/** The real one. AWT rather than Compose's clipboard: this is a desktop app and it never composes. */
+val SystemClipboardWriter: ClipboardWriter = ClipboardWriter { text ->
+    Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(text), null)
+}
+
+/**
+ * The account's own two feeds, in the order they are useful.
+ *
+ * The combined feed first — it is the one most people want — then OPML, which is for importing
+ * everything at once into an app that understands it.
+ */
+fun accountFeedLinks(library: LibraryFeedUrls?): List<FeedLink> {
+    val feeds = library ?: return emptyList()
+    return listOfNotNull(
+        feeds.feedUrl?.takeIf { it.isNotBlank() }?.let {
+            FeedLink(
+                label = "Combined feed",
+                detail = "Everything on your shelf, as one podcast.",
+                url = it,
+            )
+        },
+        feeds.opmlUrl?.takeIf { it.isNotBlank() }?.let {
+            FeedLink(
+                label = "OPML",
+                detail = "Import every fiction as a separate podcast, in one go.",
+                url = it,
+            )
+        },
+    )
+}
+
+/** One row per fiction, dropping any the server sent without a URL. */
+fun fictionFeedLinks(fictions: List<FictionFeedUrl>): List<FeedLink> = fictions.mapNotNull { row ->
+    row.feedUrl?.takeIf { it.isNotBlank() }?.let {
+        FeedLink(
+            label = row.title.ifBlank { "Untitled fiction" },
+            detail = "This fiction alone.",
+            url = it,
+        )
+    }
+}
+
+/**
+ * What rotating actually costs, for the confirmation.
+ *
+ * The name hides it: "rotate" sounds like housekeeping, and what it does is break every podcast app
+ * already subscribed until each is given the new URL. It also does *not* cover the per-fiction
+ * feeds, whose tokens come from the fiction rather than the account — saying so here is the only
+ * place the distinction is visible, since the two lists sit next to each other.
+ */
+const val RotateFeedConfirmation: String =
+    "Your combined feed and OPML URLs are replaced with new ones. Every podcast app already " +
+        "subscribed stops receiving episodes until you give it the new URL. Per-fiction feeds are " +
+        "not affected — those tokens belong to the fiction, not to your account."
+
+/** The line after a successful rotate. */
+const val RotatedFeedNotice: String =
+    "New URLs issued. Re-subscribe anywhere you were using the old ones."

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -238,6 +238,12 @@ interface TtsRoadRepository {
         action: FictionMaintenanceAction,
     ): MaintenanceResponse? = null
 
+    /** Podcast URLs for this account, or null on a server without the route. */
+    suspend fun feeds(): FeedsResponse? = null
+
+    /** Revoke and reissue this account's combined feed and OPML URLs. */
+    suspend fun rotateLibraryFeed(): FeedsResponse? = null
+
     /**
      * Revokes one session.
      *
@@ -635,6 +641,11 @@ class RetrofitTtsRoadRepository(
             FictionMaintenanceAction.ReconvertAll -> api.reconvertAllChapters(fictionId)
         }
     }
+
+    override suspend fun feeds(): FeedsResponse? = ifEndpointExists { it.feeds() }
+
+    override suspend fun rotateLibraryFeed(): FeedsResponse? =
+        ifEndpointExists { it.rotateLibraryFeed() }
 
     override suspend fun revokeDevice(tokenId: Int): Boolean =
         ifEndpointExists { it.revokeDevice(tokenId) } != null

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
@@ -103,6 +103,13 @@ data class ServerCapabilities(
      * uniform: poll is open to any account and the other four are admin-only.
      */
     val fictionMaintenance: Boolean = false,
+    /**
+     * The podcast URLs this account can hand to a podcast app, and the lever that revokes them.
+     *
+     * Worth its own flag because the whole use is a copy button: a server that cannot list the URLs
+     * cannot have that control drawn at all.
+     */
+    val feedUrls: Boolean = false,
     val maxChaptersPerPage: Int? = null,
     /**
      * How many items `/playback/sync` accepts in one batch.
@@ -152,6 +159,7 @@ data class ServerCapabilities(
             voiceCatalogue = response.capabilities.flag("voice_catalogue"),
             chapterMaintenance = response.capabilities.flag("chapter_maintenance"),
             fictionMaintenance = response.capabilities.flag("fiction_maintenance"),
+            feedUrls = response.capabilities.flag("feed_urls"),
             maxChaptersPerPage = response.limits.intLimit("max_chapters_per_page"),
             maxPlaybackSyncItems = response.limits.intLimit("max_playback_sync_items"),
             maxEpubBytes = response.limits.longLimit("max_epub_bytes"),

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -117,6 +117,25 @@ interface TtsRoadApi {
     @POST("api/mobile/fictions/{fiction_id}/reconvert-all")
     suspend fun reconvertAllChapters(@Path("fiction_id") fictionId: Int): MaintenanceResponse
 
+    /**
+     * Every podcast URL this account can hand to a podcast app (#117).
+     *
+     * Scoped to the caller's shelf, matching `/library`. The strings that come back are
+     * **credentials** — the token is the whole authorization — so nothing that logs may see them.
+     */
+    @GET("api/mobile/feeds")
+    suspend fun feeds(): FeedsResponse
+
+    /**
+     * Invalidate this account's combined feed and OPML URLs.
+     *
+     * Every podcast app already subscribed to them stops working until it is given the new URL.
+     * Does *not* touch the per-fiction feeds, whose tokens come from the fiction rather than the
+     * account.
+     */
+    @POST("api/mobile/feeds/rotate")
+    suspend fun rotateLibraryFeed(): FeedsResponse
+
     // Both revoke calls answer with a small status object (`{"status": "ok", ...}`) whose shape is
     // not worth modelling: the client re-reads the list afterwards rather than trusting an echo,
     // because a 404 on the DELETE is ambiguous between "already gone" and "no such endpoint".

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PodcastFeedsStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PodcastFeedsStateHolder.kt
@@ -1,0 +1,135 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.data.ClipboardWriter
+import dk.perspektiva.ttsroad.desktop.data.FeedLink
+import dk.perspektiva.ttsroad.desktop.data.FeedsResponse
+import dk.perspektiva.ttsroad.desktop.data.RotatedFeedNotice
+import dk.perspektiva.ttsroad.desktop.data.SystemClipboardWriter
+import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
+import dk.perspektiva.ttsroad.desktop.data.accountFeedLinks
+import dk.perspektiva.ttsroad.desktop.data.fictionFeedLinks
+import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class PodcastFeedsUiState(
+    val loading: Boolean = false,
+    /** True once the server has answered 404 — it has no feed routes. */
+    val unsupported: Boolean = false,
+    val account: List<FeedLink> = emptyList(),
+    val fictions: List<FeedLink> = emptyList(),
+    val confirmingRotate: Boolean = false,
+    val notice: String? = null,
+    val error: String? = null,
+) {
+    val isEmpty: Boolean get() = account.isEmpty() && fictions.isEmpty()
+}
+
+/**
+ * The podcast URLs (#117).
+ *
+ * Nothing here logs a URL. The token in one is the whole authorization, and `AppLog` is persistent —
+ * a feed URL in a log file is a credential in a log file. Errors are reported through
+ * [userFacingMessage] on the *exception*, which never carries the request body.
+ */
+class PodcastFeedsStateHolder(
+    private val repository: TtsRoadRepository,
+    private val clipboard: ClipboardWriter = SystemClipboardWriter,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : StateHolder(dispatcher) {
+    private val _state = MutableStateFlow(PodcastFeedsUiState())
+    val state: StateFlow<PodcastFeedsUiState> = _state.asStateFlow()
+
+    private var job: Job? = null
+    private var loaded = false
+
+    /** Loads once per session. [force] is the Refresh action. */
+    fun ensureLoaded(force: Boolean = false) {
+        if (job?.isActive == true) return
+        if (loaded && !force) return
+        job = scope.launch {
+            _state.update { it.copy(loading = true, error = null) }
+            runCatching { repository.feeds() }
+                .onSuccess { response ->
+                    loaded = true
+                    _state.update { it.withResponse(response) }
+                }
+                .onFailure { failure ->
+                    _state.update {
+                        it.copy(
+                            loading = false,
+                            error = userFacingMessage(failure, "Could not load your feed URLs"),
+                        )
+                    }
+                }
+        }
+    }
+
+    /**
+     * Copy one URL.
+     *
+     * The notice names the row rather than echoing the URL: repeating a credential into a status
+     * line puts it somewhere a screenshot or a screen share picks it up, which is the one place it
+     * was not already.
+     */
+    fun copy(link: FeedLink) {
+        runCatching { clipboard.write(link.url) }
+            .onSuccess { _state.update { it.copy(notice = "Copied the ${link.label} URL.", error = null) } }
+            .onFailure {
+                _state.update { it.copy(error = "Could not reach the clipboard.", notice = null) }
+            }
+    }
+
+    fun askToRotate() {
+        if (_state.value.loading) return
+        _state.update { it.copy(confirmingRotate = true, notice = null, error = null) }
+    }
+
+    fun dismissRotate() = _state.update { it.copy(confirmingRotate = false) }
+
+    fun confirmRotate() {
+        if (!_state.value.confirmingRotate) return
+        job?.cancel()
+        _state.update { it.copy(confirmingRotate = false, loading = true, notice = null, error = null) }
+        job = scope.launch {
+            runCatching { repository.rotateLibraryFeed() }
+                .onSuccess { response ->
+                    // The rotate answers with the same shape, so the new URLs are adopted from it
+                    // rather than re-fetched — one request, and no window where the screen shows the
+                    // revoked pair as if it still worked.
+                    _state.update { it.withResponse(response).copy(notice = RotatedFeedNotice) }
+                }
+                .onFailure { failure ->
+                    _state.update {
+                        it.copy(
+                            loading = false,
+                            error = userFacingMessage(failure, "Could not issue new URLs"),
+                        )
+                    }
+                }
+        }
+    }
+
+    fun dismissNotice() = _state.update { it.copy(notice = null, error = null) }
+
+    private fun PodcastFeedsUiState.withResponse(response: FeedsResponse?): PodcastFeedsUiState =
+        when (response) {
+            null -> copy(loading = false, unsupported = true, account = emptyList(), fictions = emptyList())
+            else -> copy(
+                loading = false,
+                unsupported = false,
+                account = accountFeedLinks(response.library),
+                fictions = fictionFeedLinks(response.fictions),
+            )
+        }
+
+    override fun onCleared() {
+        job?.cancel()
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.paneTitle
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import dk.perspektiva.ttsroad.desktop.BuildInfo
 import dk.perspektiva.ttsroad.desktop.data.DeviceSession
@@ -71,6 +72,8 @@ import dk.perspektiva.ttsroad.desktop.data.ListeningStatsStore
 import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferences
 import dk.perspektiva.ttsroad.desktop.data.formatListeningSpan
 import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferencesStore
+import dk.perspektiva.ttsroad.desktop.data.FeedLink
+import dk.perspektiva.ttsroad.desktop.data.RotateFeedConfirmation
 import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
 import dk.perspektiva.ttsroad.desktop.data.AppDirectories
 import dk.perspektiva.ttsroad.desktop.update.UpdateStatus
@@ -150,13 +153,20 @@ fun SettingsScreen(
      * the About pane from claiming an update state nothing checked.
      */
     updates: UpdateStateHolder? = null,
+    /** Null where the caller has not wired it — the pane is capability-gated anyway. */
+    feeds: PodcastFeedsStateHolder? = null,
 ) {
     val ui by holder.state.collectAsState()
     val session by sessionStore.session.collectAsState()
     val capabilities by repository.currentCapabilities.collectAsState()
-    val visibleSections = remember(capabilities.audiobookExport) {
+    val visibleSections = remember(capabilities.audiobookExport, capabilities.feedUrls) {
         SettingsSection.entries.filter { section ->
-            section != SettingsSection.Audiobooks || capabilities.audiobookExport
+            when (section) {
+                SettingsSection.Audiobooks -> capabilities.audiobookExport
+                // The whole pane is copy buttons for URLs this server may not publish.
+                SettingsSection.Feeds -> capabilities.feedUrls
+                else -> true
+            }
         }
     }
 
@@ -166,6 +176,7 @@ fun SettingsScreen(
             SettingsSection.Devices -> holder.ensureDevicesLoaded()
             SettingsSection.Offline -> holder.ensureOfflineLoaded()
             SettingsSection.Audiobooks -> holder.ensureAudiobooksLoaded()
+            SettingsSection.Feeds -> feeds?.ensureLoaded()
             else -> Unit
         }
     }
@@ -204,6 +215,7 @@ fun SettingsScreen(
                         SettingsSection.Listening -> ListeningPane(listeningStats, historyOwnerKey, nowMs)
                         SettingsSection.Offline -> OfflinePane(ui.offline, holder)
                         SettingsSection.Audiobooks -> AudiobookPane(ui.audiobooks, holder)
+                        SettingsSection.Feeds -> feeds?.let { PodcastFeedsPane(it) }
                         SettingsSection.About -> AboutPane(session, capabilities, sessionStore, updates)
                     }
                 }
@@ -249,6 +261,7 @@ fun SettingsScreen(
 
 const val AudiobookDownloadButtonTestTag: String = "audiobookDownloadButton"
 const val ManageShelfButtonTestTag: String = "manageShelfButton"
+const val RotateFeedButtonTestTag: String = "rotateFeedButton"
 
 @Composable
 private fun AudiobookPane(ui: AudiobookExportsUiState, holder: SettingsStateHolder) {
@@ -1244,6 +1257,97 @@ fun describeCapabilities(capabilities: ServerCapabilities): String {
         enabled.isNotEmpty() -> enabled.joinToString(", ")
         capabilities.isDiscovered -> "None advertised"
         else -> "Not advertised by this server"
+    }
+}
+
+// --- Podcast feeds -------------------------------------------------------------------------
+
+/**
+ * The URLs a podcast app needs (#117).
+ *
+ * The entire pane is copy buttons. A URL is shown because it is the user's own screen, but it is
+ * never echoed into a notice afterwards: repeating a credential into a status line puts it somewhere
+ * a screenshot or a screen share picks it up, which is the one place it was not already.
+ */
+@Composable
+private fun PodcastFeedsPane(holder: PodcastFeedsStateHolder) {
+    val ui by holder.state.collectAsState()
+
+    PaneTitle("Podcast feeds", "URLs you can paste into a podcast app")
+    when {
+        ui.unsupported -> InfoCard("This server does not publish feed URLs over the mobile API.")
+        ui.isEmpty && ui.loading -> Box(Modifier.fillMaxWidth().height(120.dp)) { CenterProgress() }
+        ui.isEmpty && ui.error != null -> Text(ui.error.orEmpty(), color = MaterialTheme.colorScheme.error)
+        ui.isEmpty -> InfoCard("Nothing to subscribe to yet. Follow a fiction and its feed appears here.")
+        else -> {
+            InfoCard(
+                "Anyone with one of these URLs can read the feed without signing in. Treat them " +
+                    "like a password.",
+            )
+            if (ui.account.isNotEmpty()) {
+                MetaText(text = "// Your account", color = AarisColor.Accent)
+                SettingsCard {
+                    ui.account.forEachIndexed { index, link ->
+                        if (index > 0) RowDivider()
+                        FeedRow(link, holder::copy)
+                    }
+                }
+                OutlinedButton(
+                    onClick = holder::askToRotate,
+                    enabled = !ui.loading,
+                    shape = RectangleShape,
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)
+                        .testTag(RotateFeedButtonTestTag),
+                ) { Text("ISSUE NEW URLS") }
+            }
+            if (ui.fictions.isNotEmpty()) {
+                MetaText(text = "// Per fiction", color = AarisColor.Accent)
+                SettingsCard {
+                    ui.fictions.forEachIndexed { index, link ->
+                        if (index > 0) RowDivider()
+                        FeedRow(link, holder::copy)
+                    }
+                }
+            }
+            ui.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+            ui.notice?.let { MetaText(text = it, color = AarisColor.Ok) }
+        }
+    }
+
+    if (ui.confirmingRotate) {
+        ConfirmDialog(
+            title = "ISSUE NEW FEED URLS",
+            body = RotateFeedConfirmation,
+            confirmLabel = "ISSUE NEW URLS",
+            onConfirm = holder::confirmRotate,
+            onDismiss = holder::dismissRotate,
+        )
+    }
+}
+
+@Composable
+private fun FeedRow(link: FeedLink, onCopy: (FeedLink) -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(link.label, color = AarisColor.Ink, style = MaterialTheme.typography.bodyMedium)
+            Text(link.detail, color = AarisColor.Dim, style = MaterialTheme.typography.labelSmall)
+            Text(
+                link.url,
+                color = AarisColor.Muted,
+                style = MaterialTheme.typography.labelSmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        OutlinedButton(
+            onClick = { onCopy(link) },
+            shape = RectangleShape,
+            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+        ) { Text("COPY") }
     }
 }
 

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsStateHolder.kt
@@ -33,6 +33,7 @@ enum class SettingsSection(val label: String) {
     Listening("Listening"),
     Offline("Offline"),
     Audiobooks("Audiobooks"),
+    Feeds("Podcast feeds"),
     About("Updates & About"),
 }
 

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -17,6 +17,7 @@ import dk.perspektiva.ttsroad.desktop.data.LibraryResponse
 import dk.perspektiva.ttsroad.desktop.data.LoginResult
 import dk.perspektiva.ttsroad.desktop.data.MobileUser
 import dk.perspektiva.ttsroad.desktop.data.ChapterRetryOutcome
+import dk.perspektiva.ttsroad.desktop.data.FeedsResponse
 import dk.perspektiva.ttsroad.desktop.data.FictionMaintenanceAction
 import dk.perspektiva.ttsroad.desktop.data.MaintenanceResponse
 import dk.perspektiva.ttsroad.desktop.data.MobileVoice
@@ -93,6 +94,8 @@ open class FakeRepository(
     var setChapterExcludedResult: Result<Boolean?>? = null,
     var deleteChapterResult: Result<Boolean?> = Result.success(null),
     var fictionMaintenanceResult: Result<MaintenanceResponse?> = Result.success(null),
+    var feedsResult: Result<FeedsResponse?> = Result.success(null),
+    var rotateFeedResult: Result<FeedsResponse?> = Result.success(null),
     /** Null models a server whose notifications route answers 404. */
     var chapterNotificationsResult: Result<ChapterNotificationsResponse?> = Result.success(null),
 ) : TtsRoadRepository {
@@ -121,6 +124,10 @@ open class FakeRepository(
     val excludedChapters: MutableList<Pair<Int, Boolean>> = mutableListOf()
     val deletedChapters: MutableList<Int> = mutableListOf()
     val fictionMaintenanceCalls: MutableList<Pair<Int, FictionMaintenanceAction>> = mutableListOf()
+    var feedsCalls: Int = 0
+        private set
+    var rotateFeedCalls: Int = 0
+        private set
     var revokeOtherDevicesCalls: Int = 0
         private set
     var readAlongCalls: Int = 0
@@ -315,6 +322,16 @@ open class FakeRepository(
     ): MaintenanceResponse? {
         fictionMaintenanceCalls += fictionId to action
         return fictionMaintenanceResult.getOrThrow()
+    }
+
+    override suspend fun feeds(): FeedsResponse? {
+        feedsCalls++
+        return feedsResult.getOrThrow()
+    }
+
+    override suspend fun rotateLibraryFeed(): FeedsResponse? {
+        rotateFeedCalls++
+        return rotateFeedResult.getOrThrow()
     }
 
     override suspend fun revokeDevice(tokenId: Int): Boolean {

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/PodcastFeedsTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/PodcastFeedsTest.kt
@@ -1,0 +1,84 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class PodcastFeedsTest {
+
+    @Test
+    fun `the combined feed comes before OPML`() {
+        val links = accountFeedLinks(
+            LibraryFeedUrls(feedUrl = "https://x/feed?t=a", opmlUrl = "https://x/opml?t=a"),
+        )
+
+        assertContentEquals(
+            listOf("Combined feed", "OPML"),
+            links.map { it.label },
+            "the combined feed is what most people want; OPML is the bulk-import case",
+        )
+    }
+
+    @Test
+    fun `a missing url is dropped rather than shown as a blank row`() {
+        assertEquals(
+            listOf("Combined feed"),
+            accountFeedLinks(LibraryFeedUrls(feedUrl = "https://x/feed", opmlUrl = null)).map { it.label },
+        )
+        assertEquals(
+            listOf("OPML"),
+            accountFeedLinks(LibraryFeedUrls(feedUrl = "  ", opmlUrl = "https://x/opml")).map { it.label },
+        )
+        assertTrue(accountFeedLinks(null).isEmpty())
+        assertTrue(accountFeedLinks(LibraryFeedUrls()).isEmpty())
+    }
+
+    @Test
+    fun `a fiction with no url is dropped`() {
+        val links = fictionFeedLinks(
+            listOf(
+                FictionFeedUrl(fictionId = 1, title = "Wandering Inn", feedUrl = "https://x/1"),
+                FictionFeedUrl(fictionId = 2, title = "No URL", feedUrl = null),
+                FictionFeedUrl(fictionId = 3, title = "Blank", feedUrl = ""),
+            ),
+        )
+
+        assertEquals(listOf("Wandering Inn"), links.map { it.label })
+    }
+
+    @Test
+    fun `an untitled fiction still gets a label`() {
+        val links = fictionFeedLinks(listOf(FictionFeedUrl(fictionId = 1, title = "", feedUrl = "https://x/1")))
+
+        assertEquals("Untitled fiction", links.single().label)
+    }
+
+    @Test
+    fun `every link is marked secret`() {
+        val account = accountFeedLinks(LibraryFeedUrls(feedUrl = "https://x/f", opmlUrl = "https://x/o"))
+        val fictions = fictionFeedLinks(listOf(FictionFeedUrl(fictionId = 1, title = "A", feedUrl = "https://x/1")))
+
+        // The token in the URL is the whole authorization, so nothing here may reach a log.
+        assertTrue((account + fictions).all { it.secret })
+    }
+
+    @Test
+    fun `the rotate warning names the consequence and the exception`() {
+        assertTrue(RotateFeedConfirmation.contains("stops receiving episodes"))
+        assertTrue(
+            RotateFeedConfirmation.contains("Per-fiction feeds are not affected"),
+            "the two lists sit next to each other, so the account rotate looks like it covers both",
+        )
+    }
+
+    @Test
+    fun `the clipboard writer is a seam that receives the url verbatim`() {
+        val written = mutableListOf<String>()
+        val writer = ClipboardWriter { written += it }
+
+        writer.write("https://x/feed?token=secret")
+
+        assertEquals(listOf("https://x/feed?token=secret"), written)
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/PodcastFeedsStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/PodcastFeedsStateHolderTest.kt
@@ -1,0 +1,209 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.data.ClipboardWriter
+import dk.perspektiva.ttsroad.desktop.data.FeedsResponse
+import dk.perspektiva.ttsroad.desktop.data.FictionFeedUrl
+import dk.perspektiva.ttsroad.desktop.data.LibraryFeedUrls
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PodcastFeedsStateHolderTest {
+
+    private val response = FeedsResponse(
+        library = LibraryFeedUrls(
+            feedTokenVersion = 2,
+            feedUrl = "https://ttsroad/feed/7?t=abc",
+            opmlUrl = "https://ttsroad/opml/7?t=abc",
+        ),
+        fictions = listOf(
+            FictionFeedUrl(fictionId = 1, title = "Wandering Inn", feedUrl = "https://ttsroad/f/1?t=xyz"),
+        ),
+    )
+
+    @Test
+    fun `loads once and not again`() = runTest {
+        val repository = FakeRepository(feedsResult = Result.success(response))
+        val holder = holder(repository)
+
+        holder.ensureLoaded()
+        runCurrent()
+        holder.ensureLoaded()
+        runCurrent()
+
+        assertEquals(1, repository.feedsCalls)
+        assertEquals(2, holder.state.value.account.size)
+        assertEquals(1, holder.state.value.fictions.size)
+
+        holder.clear()
+    }
+
+    @Test
+    fun `refresh asks again`() = runTest {
+        val repository = FakeRepository(feedsResult = Result.success(response))
+        val holder = holder(repository)
+
+        holder.ensureLoaded()
+        runCurrent()
+        holder.ensureLoaded(force = true)
+        runCurrent()
+
+        assertEquals(2, repository.feedsCalls)
+
+        holder.clear()
+    }
+
+    @Test
+    fun `a 404 is unsupported, not an error`() = runTest {
+        val repository = FakeRepository(feedsResult = Result.success(null))
+        val holder = holder(repository)
+
+        holder.ensureLoaded()
+        runCurrent()
+
+        assertTrue(holder.state.value.unsupported)
+        assertNull(holder.state.value.error)
+
+        holder.clear()
+    }
+
+    @Test
+    fun `copying puts the url on the clipboard and does not echo it back`() = runTest {
+        val repository = FakeRepository(feedsResult = Result.success(response))
+        val written = mutableListOf<String>()
+        val holder = holder(repository, ClipboardWriter { written += it })
+        holder.ensureLoaded()
+        runCurrent()
+
+        val link = holder.state.value.account.first()
+        holder.copy(link)
+
+        assertContentEquals(listOf("https://ttsroad/feed/7?t=abc"), written)
+        val notice = holder.state.value.notice
+        assertNotNull(notice)
+        assertEquals("Copied the Combined feed URL.", notice)
+        assertFalse(
+            notice.contains("t=abc"),
+            "repeating a credential into a status line puts it where a screenshot catches it",
+        )
+
+        holder.clear()
+    }
+
+    @Test
+    fun `a clipboard that refuses is reported without losing the list`() = runTest {
+        val repository = FakeRepository(feedsResult = Result.success(response))
+        val holder = holder(repository, ClipboardWriter { error("no clipboard") })
+        holder.ensureLoaded()
+        runCurrent()
+
+        holder.copy(holder.state.value.account.first())
+
+        assertEquals("Could not reach the clipboard.", holder.state.value.error)
+        assertEquals(2, holder.state.value.account.size)
+
+        holder.clear()
+    }
+
+    @Test
+    fun `rotate asks first and sends nothing until confirmed`() = runTest {
+        val repository = FakeRepository(feedsResult = Result.success(response))
+        val holder = holder(repository)
+        holder.ensureLoaded()
+        runCurrent()
+
+        holder.askToRotate()
+        assertTrue(holder.state.value.confirmingRotate)
+        assertEquals(0, repository.rotateFeedCalls)
+
+        holder.dismissRotate()
+        runCurrent()
+        assertFalse(holder.state.value.confirmingRotate)
+        assertEquals(
+            0,
+            repository.rotateFeedCalls,
+            "dismissing must not revoke URLs every subscribed podcast app is using",
+        )
+
+        holder.clear()
+    }
+
+    @Test
+    fun `confirming adopts the new urls from the same response`() = runTest {
+        val rotated = response.copy(
+            library = LibraryFeedUrls(
+                feedTokenVersion = 3,
+                feedUrl = "https://ttsroad/feed/7?t=new",
+                opmlUrl = "https://ttsroad/opml/7?t=new",
+            ),
+        )
+        val repository = FakeRepository(
+            feedsResult = Result.success(response),
+            rotateFeedResult = Result.success(rotated),
+        )
+        val holder = holder(repository)
+        holder.ensureLoaded()
+        runCurrent()
+
+        holder.askToRotate()
+        holder.confirmRotate()
+        runCurrent()
+
+        assertEquals(1, repository.rotateFeedCalls)
+        assertEquals(
+            1,
+            repository.feedsCalls,
+            "the rotate answers with the same shape, so re-fetching would be a second request " +
+                "and a window showing revoked URLs as if they worked",
+        )
+        assertEquals("https://ttsroad/feed/7?t=new", holder.state.value.account.first().url)
+        assertNotNull(holder.state.value.notice)
+
+        holder.clear()
+    }
+
+    @Test
+    fun `confirming without asking does nothing`() = runTest {
+        val repository = FakeRepository(feedsResult = Result.success(response))
+        val holder = holder(repository)
+        holder.ensureLoaded()
+        runCurrent()
+
+        holder.confirmRotate()
+        runCurrent()
+
+        assertEquals(0, repository.rotateFeedCalls)
+
+        holder.clear()
+    }
+
+    @Test
+    fun `a failed load reports an error`() = runTest {
+        val repository = FakeRepository(feedsResult = Result.failure(IllegalStateException("boom")))
+        val holder = holder(repository)
+
+        holder.ensureLoaded()
+        runCurrent()
+
+        assertNotNull(holder.state.value.error)
+        assertFalse(holder.state.value.unsupported)
+        assertFalse(holder.state.value.loading)
+
+        holder.clear()
+    }
+
+    private fun kotlinx.coroutines.test.TestScope.holder(
+        repository: FakeRepository,
+        clipboard: ClipboardWriter = ClipboardWriter { },
+    ) = PodcastFeedsStateHolder(repository, clipboard, UnconfinedTestDispatcher(testScheduler))
+}


### PR DESCRIPTION
Closes #117. From #94, which marks `feed_urls` **Wanted** because a desktop can
copy a URL to the clipboard and that is the whole use.

## The gap

A private podcast feed is what this project is *for*, and this client could not
show you its URL. Subscribing meant opening the web console in a browser. The
server has listed them since #166; nothing here had asked.

## What it is

A Settings pane, capability-gated. The account's combined feed and OPML, then one
row per fiction on the shelf, each with **Copy**.

## These URLs are credentials, and the code treats them that way

The token in a feed URL is the entire authorization — anyone holding the string
reads the feed without signing in.

- **Nothing logs one.** `AppLog` is persistent; a feed URL in a log file is a
  credential in a log file.
- **The "copied" notice names the row, not the URL.** Echoing a credential into a
  status line puts it somewhere a screenshot or a screen share picks it up, which
  is the one place it was not already. Tested.
- The pane says so in a sentence, because a URL on screen does not look like a
  password.

## Rotate, and what it does not cover

Behind a confirmation for two reasons. The name sounds like housekeeping, and
what it does is stop **every podcast app already subscribed** from receiving
episodes until each is given the new URL.

And it covers only the account's own two feeds. A per-fiction token is derived
from the *fiction*, so it is the same string for every account on the server and
rotating it is a separate admin action. The two lists sit next to each other, so
without saying so the one lever looks like it covers both.

The rotate response has the same shape as the list, so the new URLs are adopted
from it rather than re-fetched — one request, and no window where the screen
shows a revoked pair as though it still worked. Tested by asserting the list
endpoint is *not* called a second time.

## Testability

The clipboard goes through a `ClipboardWriter` seam rather than calling AWT
directly, so the holder runs under `runTest` with no display and the assertion is
about the value copied rather than about the platform. AWT rather than Compose's
clipboard because the pinned Compose version deprecates `LocalClipboardManager`,
and this repo builds with warnings as errors.

## Verification

`xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail
-Pttsroad.warningsAsErrors=true` — BUILD SUCCESSFUL in 6m7s.

16 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK3sri5jA6ne6tEJnbQaRe
