### PR TITLE
Keep a copy of where you are in everything

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -108,6 +108,7 @@ import dk.perspektiva.ttsroad.desktop.ui.ChapterMaintenanceStateHolder
 import dk.perspektiva.ttsroad.desktop.data.fictionMaintenanceActions
 import dk.perspektiva.ttsroad.desktop.ui.ChapterMaintenanceUi
 import dk.perspektiva.ttsroad.desktop.ui.ManageShelfScreen
+import dk.perspektiva.ttsroad.desktop.ui.ListeningBackupStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.PodcastFeedsStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.ManageShelfStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.rememberStateHolder
@@ -175,6 +176,7 @@ fun App(
         ChapterMaintenanceStateHolder(repository, cache)
     }
     val podcastFeeds = rememberStateHolder(repository) { PodcastFeedsStateHolder(repository) }
+    val listeningBackup = rememberStateHolder(repository) { ListeningBackupStateHolder(repository) }
     // Hoisted for the same reason: "Add to queue" is pressed on a chapter list, so the queue has to
     // exist and report what happened whether or not the queue screen was ever opened.
     val serverQueue = rememberStateHolder(repository, playback) {
@@ -737,6 +739,7 @@ fun App(
                                     // thing rather than two competing notions of "where am I".
                                     onOpenShelf = { nav.open(Destination.ManageShelf) },
                                     feeds = podcastFeeds,
+                                    backup = listeningBackup,
                                     onSectionSelected = { section ->
                                         nav.replaceTop(
                                             if (section == SettingsSection.Devices) {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ListeningStateBackup.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ListeningStateBackup.kt
@@ -1,0 +1,74 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import java.time.LocalDate
+
+/**
+ * Keeping a copy of where you are in everything (#119).
+ *
+ * The state lived only on the server: no way to keep a copy, and no way to move it to a rebuilt
+ * instance. This is the client with a real filesystem, so the document goes to a folder the user
+ * picks rather than into an app-managed directory.
+ *
+ * The one thing worth stating loudly is that **import merges and cannot lose progress**. The server
+ * only moves a position forward and adds bookmarks rather than reconciling them, so restoring a
+ * six-month-old backup over a live account cannot undo six months of listening. Without saying so,
+ * "import" reads as "overwrite" and nobody presses it.
+ */
+
+/** A sensible filename for a fresh export. Dated, because the point is keeping more than one. */
+fun listeningBackupFileName(today: LocalDate): String = "ttsroad-listening-$today.json"
+
+/** The sentence shown beside Import, before anything is picked. */
+const val ImportMergeExplanation: String =
+    "Importing merges: a position only moves forward and marks are added, never removed. " +
+        "Restoring an old backup cannot undo listening you have done since."
+
+/**
+ * What the merge did, as lines.
+ *
+ * Only non-zero counts are listed — a report of eight zeroes is a wall nobody reads — but an
+ * entirely empty result still says something, because "nothing happened" is itself the answer and
+ * silence looks like a failure.
+ *
+ * [ListeningStateReport.playbackSkippedOlder] is the line that earns this function: a restore where
+ * every position was already further ahead looks broken, and this is the only thing that explains it.
+ */
+fun listeningImportLines(report: ListeningStateReport): List<String> {
+    val lines = buildList {
+        if (report.playbackRestored > 0) add(count(report.playbackRestored, "position", "restored"))
+        if (report.playbackSkippedOlder > 0) {
+            add(
+                count(report.playbackSkippedOlder, "position", "left alone") +
+                    " — this account was already further ahead",
+            )
+        }
+        if (report.bookmarksRestored > 0) add(count(report.bookmarksRestored, "bookmark", "restored"))
+        if (report.bookmarksAlreadyPresent > 0) {
+            add(count(report.bookmarksAlreadyPresent, "bookmark", "already here"))
+        }
+        if (report.bookmarksSkippedFull > 0) {
+            add(count(report.bookmarksSkippedFull, "bookmark", "dropped") + " — this account is at its limit")
+        }
+        if (report.chaptersMissing > 0) {
+            add(count(report.chaptersMissing, "chapter", "not found on this server"))
+        }
+        if (report.fictionsMissing.isNotEmpty()) {
+            // Named rather than counted: on a different server this is the normal case, and knowing
+            // *which* books did not come across is what tells you whether it mattered.
+            add("Not on this server: ${report.fictionsMissing.joinToString(", ")}")
+        }
+    }
+    return lines.ifEmpty {
+        listOf(
+            if (report.fictionsMatched > 0) {
+                "Nothing to change — this account was already up to date with that backup."
+            } else {
+                "Nothing in that backup matched anything on this server."
+            },
+        )
+    }
+}
+
+/** "4 positions restored", "one position restored". */
+private fun count(n: Int, noun: String, verb: String): String =
+    if (n == 1) "One $noun $verb" else "$n ${noun}s $verb"

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
@@ -618,3 +618,41 @@ data class FictionFeedUrl(
     @param:Json(name = "feed_token_version") val feedTokenVersion: Int = 0,
     @param:Json(name = "feed_url") val feedUrl: String? = null,
 )
+
+/**
+ * `GET /api/mobile/account/listening-state` — where this account is in everything (#119).
+ *
+ * The document is deliberately opaque here: it is the server's own shape, written to a file and
+ * posted back unchanged. Modelling its interior would mean a client that had to be updated whenever
+ * the server added a field, for no gain — nothing here reads it.
+ */
+data class ListeningStateExport(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    val document: Map<String, Any?>? = null,
+)
+
+/** `POST /api/mobile/account/listening-state` — what the merge did. */
+data class ListeningStateImport(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    val status: String = "",
+    val report: ListeningStateReport? = null,
+)
+
+/**
+ * The merge, counted.
+ *
+ * Every field matters to somebody, and reducing this to "imported" throws away the only answer to
+ * *did it actually do anything*. [playbackSkippedOlder] especially: it is what explains a restore
+ * that looks like it did nothing, because the server only ever moves a position forward.
+ */
+data class ListeningStateReport(
+    @param:Json(name = "fictions_matched") val fictionsMatched: Int = 0,
+    /** Titles the document named that this server does not have. Expected across servers. */
+    @param:Json(name = "fictions_missing") val fictionsMissing: List<String> = emptyList(),
+    @param:Json(name = "chapters_missing") val chaptersMissing: Int = 0,
+    @param:Json(name = "playback_restored") val playbackRestored: Int = 0,
+    @param:Json(name = "playback_skipped_older") val playbackSkippedOlder: Int = 0,
+    @param:Json(name = "bookmarks_restored") val bookmarksRestored: Int = 0,
+    @param:Json(name = "bookmarks_already_present") val bookmarksAlreadyPresent: Int = 0,
+    @param:Json(name = "bookmarks_skipped_full") val bookmarksSkippedFull: Int = 0,
+)

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -244,6 +244,12 @@ interface TtsRoadRepository {
     /** Revoke and reissue this account's combined feed and OPML URLs. */
     suspend fun rotateLibraryFeed(): FeedsResponse? = null
 
+    /** The listening-state document, or null on a server without the route. */
+    suspend fun exportListeningState(): Map<String, Any?>? = null
+
+    /** Merge a document back in, returning what the merge did. */
+    suspend fun importListeningState(document: Map<String, Any?>): ListeningStateReport? = null
+
     /**
      * Revokes one session.
      *
@@ -646,6 +652,12 @@ class RetrofitTtsRoadRepository(
 
     override suspend fun rotateLibraryFeed(): FeedsResponse? =
         ifEndpointExists { it.rotateLibraryFeed() }
+
+    override suspend fun exportListeningState(): Map<String, Any?>? =
+        ifEndpointExists { it.exportListeningState() }?.document
+
+    override suspend fun importListeningState(document: Map<String, Any?>): ListeningStateReport? =
+        ifEndpointExists { it.importListeningState(document) }?.report
 
     override suspend fun revokeDevice(tokenId: Int): Boolean =
         ifEndpointExists { it.revokeDevice(tokenId) } != null

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
@@ -110,6 +110,8 @@ data class ServerCapabilities(
      * cannot have that control drawn at all.
      */
     val feedUrls: Boolean = false,
+    /** Export and re-import where this account is in everything. */
+    val listeningStateBackup: Boolean = false,
     val maxChaptersPerPage: Int? = null,
     /**
      * How many items `/playback/sync` accepts in one batch.
@@ -160,6 +162,7 @@ data class ServerCapabilities(
             chapterMaintenance = response.capabilities.flag("chapter_maintenance"),
             fictionMaintenance = response.capabilities.flag("fiction_maintenance"),
             feedUrls = response.capabilities.flag("feed_urls"),
+            listeningStateBackup = response.capabilities.flag("listening_state_backup"),
             maxChaptersPerPage = response.limits.intLimit("max_chapters_per_page"),
             maxPlaybackSyncItems = response.limits.intLimit("max_playback_sync_items"),
             maxEpubBytes = response.limits.longLimit("max_epub_bytes"),

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -136,6 +136,22 @@ interface TtsRoadApi {
     @POST("api/mobile/feeds/rotate")
     suspend fun rotateLibraryFeed(): FeedsResponse
 
+    /** This account's positions and chosen marks, as a portable document (#119). */
+    @GET("api/mobile/listening-state")
+    suspend fun exportListeningState(): ListeningStateExport
+
+    /**
+     * Merge a previously exported document back in.
+     *
+     * Never destructive: a position only moves forward and bookmarks are added rather than
+     * reconciled. The document is posted bare — the server accepts it either way, and sending what
+     * was read from the file unchanged is one fewer shape to get wrong.
+     */
+    @POST("api/mobile/listening-state")
+    suspend fun importListeningState(
+        @Body document: Map<String, @JvmSuppressWildcards Any?>,
+    ): ListeningStateImport
+
     // Both revoke calls answer with a small status object (`{"status": "ok", ...}`) whose shape is
     // not worth modelling: the client re-reads the list afterwards rather than trusting an echo,
     // because a 404 on the DELETE is ambiguous between "already gone" and "no such endpoint".

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ListeningBackupPickers.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ListeningBackupPickers.kt
@@ -1,0 +1,48 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import java.awt.FileDialog
+import java.awt.Frame
+import java.awt.GraphicsEnvironment
+import java.io.File
+
+/**
+ * Choosing where a listening-state backup goes, and which one to read (#119).
+ *
+ * The same shape as the pickers beside it and for the same reason: a real `FileDialog` needs a
+ * display, so the holder takes the seam and a test supplies a plain file.
+ */
+fun interface ListeningBackupSavePicker {
+    /** Null means the user cancelled. */
+    fun choose(suggestedFileName: String): File?
+}
+
+fun interface ListeningBackupOpenPicker {
+    /** Null means the user cancelled. */
+    fun choose(): File?
+}
+
+object DesktopListeningBackupSavePicker : ListeningBackupSavePicker {
+    override fun choose(suggestedFileName: String): File? {
+        if (GraphicsEnvironment.isHeadless()) return null
+        val dialog = FileDialog(null as Frame?, "Save listening backup", FileDialog.SAVE)
+        dialog.file = suggestedFileName
+        dialog.isVisible = true
+        val directory = dialog.directory ?: return null
+        val filename = dialog.file ?: return null
+        return File(directory, filename)
+    }
+}
+
+object DesktopListeningBackupOpenPicker : ListeningBackupOpenPicker {
+    override fun choose(): File? {
+        if (GraphicsEnvironment.isHeadless()) return null
+        val dialog = FileDialog(null as Frame?, "Open listening backup", FileDialog.LOAD)
+        // A hint several Linux window managers ignore, which is why the holder still checks what
+        // came back rather than trusting the filter.
+        dialog.setFilenameFilter { _, name -> name.endsWith(".json", ignoreCase = true) }
+        dialog.isVisible = true
+        val directory = dialog.directory ?: return null
+        val filename = dialog.file ?: return null
+        return File(directory, filename)
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ListeningBackupStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/ListeningBackupStateHolder.kt
@@ -1,0 +1,132 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
+import dk.perspektiva.ttsroad.desktop.data.listeningBackupFileName
+import dk.perspektiva.ttsroad.desktop.data.listeningImportLines
+import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
+import java.io.File
+import java.time.LocalDate
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class ListeningBackupUiState(
+    val busy: Boolean = false,
+    /** Where the last export went, so "it worked" names a path rather than being a word. */
+    val savedTo: String? = null,
+    /** What the last import did, already formatted. */
+    val importLines: List<String> = emptyList(),
+    val error: String? = null,
+)
+
+/**
+ * Export and re-import where this account is in everything (#119).
+ *
+ * The document is passed through untouched — read from the server, written to the file, read back,
+ * posted. Nothing here inspects its interior, so a server that adds a field needs no change here.
+ */
+class ListeningBackupStateHolder(
+    private val repository: TtsRoadRepository,
+    private val savePicker: ListeningBackupSavePicker = DesktopListeningBackupSavePicker,
+    private val openPicker: ListeningBackupOpenPicker = DesktopListeningBackupOpenPicker,
+    private val today: () -> LocalDate = LocalDate::now,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : StateHolder(dispatcher) {
+    private val _state = MutableStateFlow(ListeningBackupUiState())
+    val state: StateFlow<ListeningBackupUiState> = _state.asStateFlow()
+
+    private val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    private val documentAdapter = moshi.adapter<Map<String, Any?>>(
+        Types.newParameterizedType(Map::class.java, String::class.java, Any::class.java),
+    )
+
+    private var job: Job? = null
+
+    /**
+     * Fetch the document, then ask where to put it.
+     *
+     * In that order deliberately: a save dialog raised before the request would leave a file behind
+     * on a server that answers 404, and an empty file called `ttsroad-listening-….json` is worse
+     * than no file.
+     */
+    fun export() {
+        if (_state.value.busy) return
+        _state.update { it.copy(busy = true, savedTo = null, importLines = emptyList(), error = null) }
+        job = scope.launch {
+            val outcome = runCatching { repository.exportListeningState() }
+            val document = outcome.getOrNull()
+            val failure = outcome.exceptionOrNull()
+            when {
+                failure != null -> fail(userFacingMessage(failure, "Could not read your listening state"))
+                document == null -> fail("This server cannot export listening state.")
+                else -> {
+                    val target = savePicker.choose(listeningBackupFileName(today()))
+                    if (target == null) {
+                        // Cancelling is not a failure and should leave no trace.
+                        _state.update { it.copy(busy = false) }
+                        return@launch
+                    }
+                    runCatching { target.writeText(documentAdapter.toJson(document)) }
+                        .onSuccess {
+                            _state.update { s -> s.copy(busy = false, savedTo = target.absolutePath) }
+                        }
+                        .onFailure { fail(userFacingMessage(it, "Could not write that file")) }
+                }
+            }
+        }
+    }
+
+    fun import() {
+        if (_state.value.busy) return
+        val source = openPicker.choose() ?: return
+        _state.update { it.copy(busy = true, savedTo = null, importLines = emptyList(), error = null) }
+        job = scope.launch {
+            val document = readDocument(source)
+            if (document == null) {
+                fail("That file is not a listening backup.")
+                return@launch
+            }
+            runCatching { repository.importListeningState(document) }
+                .onSuccess { report ->
+                    when (report) {
+                        null -> fail("This server cannot import listening state.")
+                        else -> _state.update {
+                            it.copy(busy = false, importLines = listeningImportLines(report))
+                        }
+                    }
+                }
+                .onFailure { fail(userFacingMessage(it, "That backup was refused")) }
+        }
+    }
+
+    fun dismiss() = _state.update { it.copy(savedTo = null, importLines = emptyList(), error = null) }
+
+    /**
+     * Read the file, unwrapping `{"document": …}` if that is what was saved.
+     *
+     * Both shapes are accepted because both exist in the wild: the server's export is wrapped, and
+     * anything hand-edited or produced by the web route may not be. Returns null for anything that
+     * is not an object at all, which is the check the filename filter cannot do.
+     */
+    private fun readDocument(source: File): Map<String, Any?>? = runCatching {
+        val parsed = documentAdapter.fromJson(source.readText()) ?: return null
+        @Suppress("UNCHECKED_CAST")
+        (parsed["document"] as? Map<String, Any?>) ?: parsed
+    }.getOrNull()
+
+    private fun fail(message: String) {
+        _state.update { it.copy(busy = false, error = message) }
+    }
+
+    override fun onCleared() {
+        job?.cancel()
+    }
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/SettingsScreen.kt
@@ -73,6 +73,7 @@ import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferences
 import dk.perspektiva.ttsroad.desktop.data.formatListeningSpan
 import dk.perspektiva.ttsroad.desktop.data.PlaybackPreferencesStore
 import dk.perspektiva.ttsroad.desktop.data.FeedLink
+import dk.perspektiva.ttsroad.desktop.data.ImportMergeExplanation
 import dk.perspektiva.ttsroad.desktop.data.RotateFeedConfirmation
 import dk.perspektiva.ttsroad.desktop.data.ServerCapabilities
 import dk.perspektiva.ttsroad.desktop.data.AppDirectories
@@ -155,6 +156,7 @@ fun SettingsScreen(
     updates: UpdateStateHolder? = null,
     /** Null where the caller has not wired it — the pane is capability-gated anyway. */
     feeds: PodcastFeedsStateHolder? = null,
+    backup: ListeningBackupStateHolder? = null,
 ) {
     val ui by holder.state.collectAsState()
     val session by sessionStore.session.collectAsState()
@@ -202,7 +204,10 @@ fun SettingsScreen(
                 ) {
                     when (ui.section) {
                         SettingsSection.Account ->
-                            AccountPane(ui, session, capabilities, sessionStore, holder, selectSection, onOpenShelf, nowMs)
+                            AccountPane(
+                                ui, session, capabilities, sessionStore, holder,
+                                selectSection, onOpenShelf, backup, nowMs,
+                            )
                         SettingsSection.Devices -> DevicesPane(ui, session, holder, nowMs)
                         SettingsSection.Playback -> PlaybackPane(
                             preferences,
@@ -262,6 +267,8 @@ fun SettingsScreen(
 const val AudiobookDownloadButtonTestTag: String = "audiobookDownloadButton"
 const val ManageShelfButtonTestTag: String = "manageShelfButton"
 const val RotateFeedButtonTestTag: String = "rotateFeedButton"
+const val ExportBackupButtonTestTag: String = "exportBackupButton"
+const val ImportBackupButtonTestTag: String = "importBackupButton"
 
 @Composable
 private fun AudiobookPane(ui: AudiobookExportsUiState, holder: SettingsStateHolder) {
@@ -481,6 +488,7 @@ private fun AccountPane(
     holder: SettingsStateHolder,
     onSelectSection: (SettingsSection) -> Unit,
     onOpenShelf: () -> Unit,
+    backup: ListeningBackupStateHolder?,
     nowMs: () -> Long,
 ) {
     PaneTitle("Account", "Server, sign-in and this device")
@@ -521,6 +529,10 @@ private fun AccountPane(
                 formatExpiresIn(session.expiresAt, nowMs()),
             ).joinToString(" · ").ifBlank { "Unknown" },
         )
+    }
+
+    backup?.takeIf { capabilities.listeningStateBackup }?.let { holder2 ->
+        ListeningBackupBlock(holder2)
     }
 
     Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -1258,6 +1270,44 @@ fun describeCapabilities(capabilities: ServerCapabilities): String {
         capabilities.isDiscovered -> "None advertised"
         else -> "Not advertised by this server"
     }
+}
+
+// --- Listening backup ----------------------------------------------------------------------
+
+/**
+ * Keeping a copy of where you are in everything (#119).
+ *
+ * The merge sentence is above the buttons rather than in a confirmation, because it is the thing
+ * that makes Import safe to press at all — a confirmation would only be read by someone who had
+ * already decided, and the people this reassures are the ones who never press it.
+ */
+@Composable
+private fun ListeningBackupBlock(holder: ListeningBackupStateHolder) {
+    val ui by holder.state.collectAsState()
+
+    MetaText(text = "// Listening backup", color = AarisColor.Accent)
+    Text(
+        ImportMergeExplanation,
+        style = MaterialTheme.typography.bodyMedium,
+        color = AarisColor.Muted,
+    )
+    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        OutlinedButton(
+            onClick = holder::export,
+            enabled = !ui.busy,
+            shape = RectangleShape,
+            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).testTag(ExportBackupButtonTestTag),
+        ) { Text(if (ui.busy) "WORKING…" else "SAVE A BACKUP") }
+        OutlinedButton(
+            onClick = holder::import,
+            enabled = !ui.busy,
+            shape = RectangleShape,
+            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).testTag(ImportBackupButtonTestTag),
+        ) { Text("RESTORE FROM A BACKUP") }
+    }
+    ui.savedTo?.let { MetaText(text = "Saved to $it", color = AarisColor.Ok) }
+    ui.importLines.forEach { MetaText(text = it, color = AarisColor.Ok) }
+    ui.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
 }
 
 // --- Podcast feeds -------------------------------------------------------------------------

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -18,6 +18,7 @@ import dk.perspektiva.ttsroad.desktop.data.LoginResult
 import dk.perspektiva.ttsroad.desktop.data.MobileUser
 import dk.perspektiva.ttsroad.desktop.data.ChapterRetryOutcome
 import dk.perspektiva.ttsroad.desktop.data.FeedsResponse
+import dk.perspektiva.ttsroad.desktop.data.ListeningStateReport
 import dk.perspektiva.ttsroad.desktop.data.FictionMaintenanceAction
 import dk.perspektiva.ttsroad.desktop.data.MaintenanceResponse
 import dk.perspektiva.ttsroad.desktop.data.MobileVoice
@@ -96,6 +97,8 @@ open class FakeRepository(
     var fictionMaintenanceResult: Result<MaintenanceResponse?> = Result.success(null),
     var feedsResult: Result<FeedsResponse?> = Result.success(null),
     var rotateFeedResult: Result<FeedsResponse?> = Result.success(null),
+    var exportListeningStateResult: Result<Map<String, Any?>?> = Result.success(null),
+    var importListeningStateResult: Result<ListeningStateReport?> = Result.success(null),
     /** Null models a server whose notifications route answers 404. */
     var chapterNotificationsResult: Result<ChapterNotificationsResponse?> = Result.success(null),
 ) : TtsRoadRepository {
@@ -128,6 +131,7 @@ open class FakeRepository(
         private set
     var rotateFeedCalls: Int = 0
         private set
+    val importedDocuments: MutableList<Map<String, Any?>> = mutableListOf()
     var revokeOtherDevicesCalls: Int = 0
         private set
     var readAlongCalls: Int = 0
@@ -332,6 +336,14 @@ open class FakeRepository(
     override suspend fun rotateLibraryFeed(): FeedsResponse? {
         rotateFeedCalls++
         return rotateFeedResult.getOrThrow()
+    }
+
+    override suspend fun exportListeningState(): Map<String, Any?>? =
+        exportListeningStateResult.getOrThrow()
+
+    override suspend fun importListeningState(document: Map<String, Any?>): ListeningStateReport? {
+        importedDocuments += document
+        return importListeningStateResult.getOrThrow()
     }
 
     override suspend fun revokeDevice(tokenId: Int): Boolean {

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ListeningStateBackupTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/ListeningStateBackupTest.kt
@@ -1,0 +1,106 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import java.time.LocalDate
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class ListeningStateBackupTest {
+
+    @Test
+    fun `the filename is dated, because the point is keeping more than one`() {
+        assertEquals(
+            "ttsroad-listening-2026-09-04.json",
+            listeningBackupFileName(LocalDate.of(2026, 9, 4)),
+        )
+    }
+
+    @Test
+    fun `the merge explanation says progress cannot be lost`() {
+        // Without this, "import" reads as "overwrite" and the people it reassures never press it.
+        assertTrue(ImportMergeExplanation.contains("only moves forward"))
+        assertTrue(ImportMergeExplanation.contains("cannot undo"))
+    }
+
+    @Test
+    fun `skipped-as-older is explained, not just counted`() {
+        val lines = listeningImportLines(
+            ListeningStateReport(fictionsMatched = 3, playbackSkippedOlder = 7),
+        )
+
+        val line = lines.single()
+        assertTrue(line.contains("7 positions left alone"))
+        assertTrue(
+            line.contains("already further ahead"),
+            "a restore where every position was ahead looks broken; this is the only explanation",
+        )
+    }
+
+    @Test
+    fun `only non-zero counts are listed`() {
+        val lines = listeningImportLines(
+            ListeningStateReport(
+                fictionsMatched = 2,
+                playbackRestored = 4,
+                bookmarksRestored = 1,
+            ),
+        )
+
+        assertEquals(2, lines.size, "a report of eight zeroes is a wall nobody reads")
+        assertTrue(lines.any { it == "4 positions restored" })
+        assertTrue(lines.any { it == "One bookmark restored" })
+    }
+
+    @Test
+    fun `missing fictions are named rather than counted`() {
+        val lines = listeningImportLines(
+            ListeningStateReport(fictionsMatched = 1, fictionsMissing = listOf("Worth the Candle", "Katalepsis")),
+        )
+
+        assertEquals(
+            "Not on this server: Worth the Candle, Katalepsis",
+            lines.single(),
+            "on a different server this is normal, and which books did not come across is the point",
+        )
+    }
+
+    @Test
+    fun `a no-op import still says something`() {
+        val matched = listeningImportLines(ListeningStateReport(fictionsMatched = 4))
+
+        assertEquals(
+            "Nothing to change — this account was already up to date with that backup.",
+            matched.single(),
+            "silence after pressing a button looks like a failure",
+        )
+    }
+
+    @Test
+    fun `a document matching nothing says so distinctly`() {
+        val nothing = listeningImportLines(ListeningStateReport())
+
+        assertEquals("Nothing in that backup matched anything on this server.", nothing.single())
+    }
+
+    @Test
+    fun `a bookmark limit is reported with its reason`() {
+        val lines = listeningImportLines(
+            ListeningStateReport(fictionsMatched = 1, bookmarksSkippedFull = 3),
+        )
+
+        assertTrue(lines.single().contains("3 bookmarks dropped"))
+        assertTrue(lines.single().contains("at its limit"))
+    }
+
+    @Test
+    fun `singular and plural both read`() {
+        assertTrue(
+            listeningImportLines(ListeningStateReport(playbackRestored = 1)).single() ==
+                "One position restored",
+        )
+        assertTrue(
+            listeningImportLines(ListeningStateReport(chaptersMissing = 2)).single() ==
+                "2 chapters not found on this server",
+        )
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ListeningBackupStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/ListeningBackupStateHolderTest.kt
@@ -1,0 +1,206 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.data.ListeningStateReport
+import java.io.File
+import java.time.LocalDate
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ListeningBackupStateHolderTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private val document: Map<String, Any?> = mapOf(
+        "version" to 1.0,
+        "fictions" to listOf(mapOf("slug" to "wandering-inn")),
+    )
+
+    @Test
+    fun `export writes the document to the chosen file`() = runTest {
+        val target = File(tempDir, "backup.json")
+        val repository = FakeRepository(exportListeningStateResult = Result.success(document))
+        val holder = holder(repository, save = { target })
+
+        holder.export()
+        runCurrent()
+
+        assertTrue(target.isFile)
+        assertTrue(target.readText().contains("wandering-inn"))
+        assertEquals(target.absolutePath, holder.state.value.savedTo)
+        assertNull(holder.state.value.error)
+
+        holder.clear()
+    }
+
+    @Test
+    fun `the suggested filename is dated`() = runTest {
+        var suggested: String? = null
+        val repository = FakeRepository(exportListeningStateResult = Result.success(document))
+        val holder = holder(
+            repository,
+            save = { name -> suggested = name; File(tempDir, "out.json") },
+            today = { LocalDate.of(2026, 9, 4) },
+        )
+
+        holder.export()
+        runCurrent()
+
+        assertEquals("ttsroad-listening-2026-09-04.json", suggested)
+
+        holder.clear()
+    }
+
+    @Test
+    fun `the document is fetched before the save dialog opens`() = runTest {
+        var dialogOpened = false
+        val repository = FakeRepository(exportListeningStateResult = Result.success(null))
+        val holder = holder(repository, save = { dialogOpened = true; null })
+
+        holder.export()
+        runCurrent()
+
+        assertFalse(
+            dialogOpened,
+            "asking where to save first would leave an empty file behind when the server 404s",
+        )
+        assertEquals("This server cannot export listening state.", holder.state.value.error)
+
+        holder.clear()
+    }
+
+    @Test
+    fun `cancelling the save dialog leaves no trace`() = runTest {
+        val repository = FakeRepository(exportListeningStateResult = Result.success(document))
+        val holder = holder(repository, save = { null })
+
+        holder.export()
+        runCurrent()
+
+        assertNull(holder.state.value.savedTo)
+        assertNull(holder.state.value.error, "cancelling is not a failure")
+        assertFalse(holder.state.value.busy)
+
+        holder.clear()
+    }
+
+    @Test
+    fun `import posts the document and reports the merge`() = runTest {
+        val source = File(tempDir, "in.json")
+        source.writeText("""{"version":1,"fictions":[]}""")
+        val repository = FakeRepository(
+            importListeningStateResult = Result.success(
+                ListeningStateReport(fictionsMatched = 2, playbackRestored = 4),
+            ),
+        )
+        val holder = holder(repository, open = { source })
+
+        holder.import()
+        runCurrent()
+
+        assertEquals(1, repository.importedDocuments.size)
+        assertTrue(holder.state.value.importLines.any { it == "4 positions restored" })
+        assertNull(holder.state.value.error)
+
+        holder.clear()
+    }
+
+    @Test
+    fun `a wrapped document is unwrapped before posting`() = runTest {
+        val source = File(tempDir, "wrapped.json")
+        source.writeText("""{"document":{"version":1,"fictions":[]}}""")
+        val repository = FakeRepository(
+            importListeningStateResult = Result.success(ListeningStateReport(fictionsMatched = 1)),
+        )
+        val holder = holder(repository, open = { source })
+
+        holder.import()
+        runCurrent()
+
+        val sent = repository.importedDocuments.single()
+        assertTrue(
+            sent.containsKey("version"),
+            "the export wraps the document; posting the wrapper back would be a different shape",
+        )
+        assertFalse(sent.containsKey("document"))
+
+        holder.clear()
+    }
+
+    @Test
+    fun `a file that is not JSON is refused before a request`() = runTest {
+        val source = File(tempDir, "notes.txt")
+        source.writeText("this is not a backup")
+        val repository = FakeRepository()
+        val holder = holder(repository, open = { source })
+
+        holder.import()
+        runCurrent()
+
+        assertEquals("That file is not a listening backup.", holder.state.value.error)
+        assertTrue(
+            repository.importedDocuments.isEmpty(),
+            "the filename filter is a hint several window managers ignore",
+        )
+
+        holder.clear()
+    }
+
+    @Test
+    fun `cancelling the open dialog does nothing at all`() = runTest {
+        val repository = FakeRepository()
+        val holder = holder(repository, open = { null })
+
+        holder.import()
+        runCurrent()
+
+        assertFalse(holder.state.value.busy)
+        assertNull(holder.state.value.error)
+        assertTrue(repository.importedDocuments.isEmpty())
+
+        holder.clear()
+    }
+
+    @Test
+    fun `a rejected document surfaces the server's reason`() = runTest {
+        val source = File(tempDir, "bad.json")
+        source.writeText("""{"version":99}""")
+        val repository = FakeRepository(
+            importListeningStateResult = Result.failure(IllegalStateException("Unsupported version")),
+        )
+        val holder = holder(repository, open = { source })
+
+        holder.import()
+        runCurrent()
+
+        assertNotNull(holder.state.value.error)
+        assertTrue(holder.state.value.importLines.isEmpty())
+
+        holder.clear()
+    }
+
+    private fun TestScope.holder(
+        repository: FakeRepository,
+        save: (String) -> File? = { null },
+        open: () -> File? = { null },
+        today: () -> LocalDate = { LocalDate.of(2026, 9, 4) },
+    ) = ListeningBackupStateHolder(
+        repository,
+        savePicker = { name -> save(name) },
+        openPicker = { open() },
+        today = today,
+        dispatcher = UnconfinedTestDispatcher(testScheduler),
+    )
+}


### PR DESCRIPTION
Closes #119. From #94, which marks `listening_state_backup` **Wanted** because
this is the client with a real filesystem.

## The gap

Positions and chosen marks lived only on the server. No way to keep a copy, and
no way to move them to a rebuilt instance or a second one. The routes have been
there since #166 and nothing here had asked.

## Import merges — and the screen says so before the button

A position only moves forward and marks are added rather than reconciled, so
restoring a six-month-old backup over a live account **cannot undo six months of
listening**.

That sentence sits above the buttons rather than in a confirmation, deliberately.
A confirmation is only read by somebody who has already decided to press the
thing; the people this reassures are the ones who otherwise never would.

## The report is most of the feature

Reducing eight counters to "imported" throws away the only answer to whether
anything actually happened. `playback_skipped_older` is the one that earns it:
restore an old backup, find every position already further ahead, and a screen
that said nothing would look broken.

- Missing fictions are **named, not counted** — across two servers that is the
  normal case, and *which* books did not come across is the whole question.
- Only non-zero counts are listed. An empty result still says something, because
  silence after pressing a button reads as failure.

## Two ordering details

**The document is fetched before the save dialog opens.** The other order leaves
an empty `ttsroad-listening-….json` behind whenever the server answers 404, and a
file that looks like a backup and is not is worse than no file. Tested.

**The `.json` filter on the open dialog is a hint several Linux window managers
ignore**, so the holder parses what actually came back. A text file is refused
before any request goes out. Tested.

The document itself is passed through untouched — read from the server, written
to the file, read back, posted. Nothing here looks inside it, so a server that
adds a field needs no change on this side. Both the bare and `{"document": …}`
shapes are accepted on read, because both exist.

## Verification

`xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail
-Pttsroad.warningsAsErrors=true` — BUILD SUCCESSFUL, exit 0.

The first run of this printed `e: Daemon compilation failed` before recovering —
the Kotlin compile daemon dropped and Gradle fell back. `:compileKotlin`,
`:compileTestKotlin`, `:test` and `:check` all ran with zero failures, and a
second clean run reproduced the pass with no daemon error. Noting it because a
stack trace in a green log is worth explaining rather than leaving for the next
person to find.

18 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK3sri5jA6ne6tEJnbQaRe
