### PR TITLE
Report a mispronounced word without leaving the app

### DIFF
--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/App.kt
@@ -110,6 +110,8 @@ import dk.perspektiva.ttsroad.desktop.ui.ChapterMaintenanceUi
 import dk.perspektiva.ttsroad.desktop.ui.ManageShelfScreen
 import dk.perspektiva.ttsroad.desktop.ui.ListeningBackupStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.PodcastFeedsStateHolder
+import dk.perspektiva.ttsroad.desktop.ui.PronunciationReportDialog
+import dk.perspektiva.ttsroad.desktop.ui.PronunciationReportsStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.ManageShelfStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.rememberStateHolder
 import dk.perspektiva.ttsroad.desktop.ui.windowSizeClassFor
@@ -177,6 +179,7 @@ fun App(
     }
     val podcastFeeds = rememberStateHolder(repository) { PodcastFeedsStateHolder(repository) }
     val listeningBackup = rememberStateHolder(repository) { ListeningBackupStateHolder(repository) }
+    val pronunciation = rememberStateHolder(repository) { PronunciationReportsStateHolder(repository) }
     // Hoisted for the same reason: "Add to queue" is pressed on a chapter list, so the queue has to
     // exist and report what happened whether or not the queue screen was ever opened.
     val serverQueue = rememberStateHolder(repository, playback) {
@@ -694,6 +697,10 @@ fun App(
                                     readAlongAvailable = capabilities.readAlong,
                                     bookmarksAvailable = capabilities.bookmarks,
                                     onAddBookmark = { addBookmark() },
+                                    pronunciationAvailable = capabilities.pronunciationReports,
+                                    onReportPronunciation = { chapterId, title, positionMs ->
+                                        pronunciation.open(chapterId, title, positionMs)
+                                    },
                                     onOpenReader = { chapterId, title ->
                                         nav.open(Destination.Reader(chapterId, title))
                                     },
@@ -804,6 +811,9 @@ fun App(
     // screen, and the list is useful there too.
     if (showShortcuts) ShortcutsDialog(onDismiss = { showShortcuts = false })
     if (session.isLoggedIn) FictionManagementDialogs(fictionManagement)
+    // Hoisted above navigation like the management dialogs: the form is opened from the player and
+    // has to survive the user walking back to the library while it is up.
+    if (session.isLoggedIn) PronunciationReportDialog(pronunciation)
 
     // The Devices destination is a deep link into the settings screen: entering it selects the
     // pane, so a future "manage sessions" link from anywhere lands on the right place.

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Models.kt
@@ -656,3 +656,50 @@ data class ListeningStateReport(
     @param:Json(name = "bookmarks_already_present") val bookmarksAlreadyPresent: Int = 0,
     @param:Json(name = "bookmarks_skipped_full") val bookmarksSkippedFull: Int = 0,
 )
+
+/** `GET /api/mobile/pronunciation-reports` — this account's reports (#121). */
+data class PronunciationReportsResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    val reports: List<PronunciationReport> = emptyList(),
+)
+
+/** The envelope a create returns: the report the server actually stored. */
+data class PronunciationReportResponse(
+    @param:Json(name = "api_version") val apiVersion: Int = 1,
+    val report: PronunciationReport? = null,
+)
+
+/**
+ * One "that word is pronounced wrong".
+ *
+ * Fiction and chapter titles are joined in by the server rather than left to the client, because
+ * every consumer needs them and a report whose book cannot be named is not actionable.
+ */
+data class PronunciationReport(
+    val id: Int = 0,
+    @param:Json(name = "fiction_id") val fictionId: Int = 0,
+    @param:Json(name = "fiction_title") val fictionTitle: String? = null,
+    @param:Json(name = "chapter_id") val chapterId: Int = 0,
+    @param:Json(name = "chapter_number") val chapterNumber: Int? = null,
+    @param:Json(name = "chapter_title") val chapterTitle: String? = null,
+    @param:Json(name = "position_seconds") val positionSeconds: Double = 0.0,
+    val word: String? = null,
+    val note: String? = null,
+    @param:Json(name = "reported_by") val reportedBy: String? = null,
+    val resolved: Boolean = false,
+    @param:Json(name = "created_at") val createdAt: String? = null,
+)
+
+/**
+ * The body of a new report.
+ *
+ * `fiction_id` is deliberately **not** sent. The server derives it from the chapter rather than
+ * trusting a client, so sending one is at best redundant and at worst a mismatched pair that files
+ * a report the fiction's own panel never shows.
+ */
+data class PronunciationReportRequest(
+    @param:Json(name = "chapter_id") val chapterId: Int,
+    @param:Json(name = "position_seconds") val positionSeconds: Double? = null,
+    val word: String? = null,
+    val note: String? = null,
+)

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PronunciationReports.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/PronunciationReports.kt
@@ -1,0 +1,89 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+/**
+ * "That word is pronounced wrong", filed where it was heard (#121).
+ *
+ * TTS gets names wrong constantly and in ways only a listener notices. The server has had a store
+ * for these and a panel that acts on them; this client had no way to file one, so the only route was
+ * to remember the word, leave the app and open a browser. That remembering step is where the report
+ * was lost.
+ *
+ * Which is the whole argument for filing from the player: the chapter and the position are already
+ * known to the millisecond, so a report is one field — the word — and everything else is filled in.
+ */
+
+/** The server's own ceilings, checked here so a too-long note is not a 400 after the fact. */
+const val MaxReportedWordChars: Int = 200
+const val MaxReportNoteChars: Int = 2000
+
+/**
+ * Why this report cannot be sent, or null when it can.
+ *
+ * A note with no word is a valid report — "the narrator garbles the surname in the third paragraph"
+ * says something. A report with neither is noise, and the server would store an empty row.
+ */
+fun pronunciationReportProblem(word: String, note: String): String? = when {
+    word.isBlank() && note.isBlank() -> "Type the word that sounded wrong, or a note about it."
+    word.trim().length > MaxReportedWordChars -> "That word is too long — $MaxReportedWordChars characters at most."
+    note.trim().length > MaxReportNoteChars -> "That note is too long — $MaxReportNoteChars characters at most."
+    else -> null
+}
+
+/**
+ * The body to send, or null when [pronunciationReportProblem] would refuse it.
+ *
+ * Blank fields are sent as absent rather than as empty strings, and `fiction_id` is never sent: the
+ * server derives it from the chapter rather than trusting a client, so including one is at best
+ * redundant and at worst a mismatched pair.
+ */
+fun pronunciationReportRequest(
+    chapterId: Int,
+    positionMs: Long,
+    word: String,
+    note: String,
+): PronunciationReportRequest? {
+    if (pronunciationReportProblem(word, note) != null) return null
+    return PronunciationReportRequest(
+        chapterId = chapterId,
+        // Seconds, because that is the server's unit. Taken from the player rather than typed —
+        // it is already known exactly and nobody can type a timestamp accurately.
+        positionSeconds = (positionMs.coerceAtLeast(0L) / 1000.0),
+        word = word.trim().takeIf { it.isNotEmpty() },
+        note = note.trim().takeIf { it.isNotEmpty() },
+    )
+}
+
+/** "Chapter 12 · 41:07", or as much of it as the report carries. */
+fun pronunciationReportLocation(report: PronunciationReport): String {
+    val chapter = report.chapterTitle?.takeIf { it.isNotBlank() }
+        ?: report.chapterNumber?.let { "Chapter $it" }
+    val position = formatReportPosition(report.positionSeconds)
+    return listOfNotNull(chapter, position).joinToString("  ·  ").ifEmpty { "Unknown position" }
+}
+
+/** `m:ss`, or `h:mm:ss` past an hour. Null at zero — an unset position is not "the very start". */
+fun formatReportPosition(seconds: Double): String? {
+    if (seconds <= 0.0) return null
+    val total = seconds.toLong()
+    val hours = total / 3600
+    val minutes = (total % 3600) / 60
+    val secs = total % 60
+    return if (hours > 0) {
+        "%d:%02d:%02d".format(hours, minutes, secs)
+    } else {
+        "%d:%02d".format(minutes, secs)
+    }
+}
+
+/**
+ * What filing a report did.
+ *
+ * [AtCapacity] is the server's `409` and is not a failure to retry: the account has too many open
+ * reports and the fix is to resolve or delete some. Its message is the server's own, because the
+ * number in it is the only actionable part and it can differ per deployment.
+ */
+sealed interface ReportOutcome {
+    data class Filed(val report: PronunciationReport) : ReportOutcome
+    data class AtCapacity(val message: String) : ReportOutcome
+    data object Unsupported : ReportOutcome
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/Repository.kt
@@ -1,6 +1,7 @@
 package dk.perspektiva.ttsroad.desktop.data
 
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -249,6 +250,21 @@ interface TtsRoadRepository {
 
     /** Merge a document back in, returning what the merge did. */
     suspend fun importListeningState(document: Map<String, Any?>): ListeningStateReport? = null
+
+    /** This account's pronunciation reports, or null on a server without the routes. */
+    suspend fun pronunciationReports(): List<PronunciationReport>? = null
+
+    /**
+     * File a report.
+     *
+     * A `409` is the account's open-report cap and comes back as [ReportOutcome.AtCapacity] with
+     * the server's own sentence, because the number in it is the only actionable part.
+     */
+    suspend fun createPronunciationReport(request: PronunciationReportRequest): ReportOutcome =
+        ReportOutcome.Unsupported
+
+    /** Delete one of your own. False means the server answered 404. */
+    suspend fun deletePronunciationReport(reportId: Int): Boolean = false
 
     /**
      * Revokes one session.
@@ -659,6 +675,25 @@ class RetrofitTtsRoadRepository(
     override suspend fun importListeningState(document: Map<String, Any?>): ListeningStateReport? =
         ifEndpointExists { it.importListeningState(document) }?.report
 
+    override suspend fun pronunciationReports(): List<PronunciationReport>? =
+        ifEndpointExists { it.pronunciationReports() }?.reports
+
+    override suspend fun createPronunciationReport(request: PronunciationReportRequest): ReportOutcome =
+        try {
+            val stored = withAuthorizedApi { it.createPronunciationReport(request) }.report
+            stored?.let(ReportOutcome::Filed) ?: ReportOutcome.Unsupported
+        } catch (e: HttpException) {
+            when (e.code()) {
+                // The server's message names the cap, which is the only part worth showing.
+                409 -> ReportOutcome.AtCapacity(serverDetail(e) ?: "You have too many open reports.")
+                404 -> ReportOutcome.Unsupported
+                else -> throw e
+            }
+        }
+
+    override suspend fun deletePronunciationReport(reportId: Int): Boolean =
+        ifEndpointExists { it.deletePronunciationReport(reportId) } != null
+
     override suspend fun revokeDevice(tokenId: Int): Boolean =
         ifEndpointExists { it.revokeDevice(tokenId) } != null
 
@@ -883,6 +918,24 @@ class RetrofitTtsRoadRepository(
      * it. Everything else keeps its normal meaning — in particular a 401 still ends the session,
      * because "this server is old" and "this token is dead" must not be confused.
      */
+    /**
+     * The server's own `detail` from an error body, or null.
+     *
+     * Only worth reading where the sentence carries something the client cannot know — the
+     * pronunciation cap names its own number, which may differ per deployment. Deliberately total:
+     * an unparseable body on an error path must not turn one failure into two.
+     */
+    private fun serverDetail(error: HttpException): String? = runCatching {
+        val body = error.response()?.errorBody()?.string().orEmpty()
+        if (body.isBlank()) return@runCatching null
+        val parsed = moshi
+            .adapter<Map<String, Any?>>(
+                Types.newParameterizedType(Map::class.java, String::class.java, Any::class.java),
+            )
+            .fromJson(body)
+        (parsed?.get("detail") as? String)?.trim()?.takeIf { it.isNotEmpty() }
+    }.getOrNull()
+
     private suspend fun <T> ifEndpointExists(block: suspend (TtsRoadApi) -> T): T? = try {
         withAuthorizedApi(block)
     } catch (e: HttpException) {

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/ServerCapabilities.kt
@@ -112,6 +112,13 @@ data class ServerCapabilities(
     val feedUrls: Boolean = false,
     /** Export and re-import where this account is in everything. */
     val listeningStateBackup: Boolean = false,
+    /**
+     * "That word is pronounced wrong", captured where it is heard.
+     *
+     * The server gates this on the write route as well as the read one, because a client that can
+     * list but not create has nothing to list.
+     */
+    val pronunciationReports: Boolean = false,
     val maxChaptersPerPage: Int? = null,
     /**
      * How many items `/playback/sync` accepts in one batch.
@@ -163,6 +170,7 @@ data class ServerCapabilities(
             fictionMaintenance = response.capabilities.flag("fiction_maintenance"),
             feedUrls = response.capabilities.flag("feed_urls"),
             listeningStateBackup = response.capabilities.flag("listening_state_backup"),
+            pronunciationReports = response.capabilities.flag("pronunciation_reports"),
             maxChaptersPerPage = response.limits.intLimit("max_chapters_per_page"),
             maxPlaybackSyncItems = response.limits.intLimit("max_playback_sync_items"),
             maxEpubBytes = response.limits.longLimit("max_epub_bytes"),

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/data/TtsRoadApi.kt
@@ -152,6 +152,20 @@ interface TtsRoadApi {
         @Body document: Map<String, @JvmSuppressWildcards Any?>,
     ): ListeningStateImport
 
+    /** This account's pronunciation reports (#121). */
+    @GET("api/mobile/pronunciation-reports")
+    suspend fun pronunciationReports(): PronunciationReportsResponse
+
+    /** File one. A 409 means this account is at its open-report cap, and the body says so. */
+    @POST("api/mobile/pronunciation-reports")
+    suspend fun createPronunciationReport(
+        @Body request: PronunciationReportRequest,
+    ): PronunciationReportResponse
+
+    /** Delete one of your own. */
+    @DELETE("api/mobile/pronunciation-reports/{report_id}")
+    suspend fun deletePronunciationReport(@Path("report_id") reportId: Int)
+
     // Both revoke calls answer with a small status object (`{"status": "ok", ...}`) whose shape is
     // not worth modelling: the client re-reads the list afterwards rather than trusting an echo,
     // because a 404 on the DELETE is ambiguous between "already gone" and "no such endpoint".

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreen.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PlayerScreen.kt
@@ -95,6 +95,8 @@ fun PlayerScreen(
     /** Capability-gated like read-along: no control at all where the server has no bookmark API. */
     bookmarksAvailable: Boolean = false,
     onAddBookmark: () -> Unit = {},
+    pronunciationAvailable: Boolean = false,
+    onReportPronunciation: (Int, String, Long) -> Unit = { _, _, _ -> },
     onOpenReader: (chapterId: Int, title: String) -> Unit = { _, _ -> },
     onBack: () -> Unit,
 ) {
@@ -120,6 +122,8 @@ fun PlayerScreen(
                     readAlongAvailable = readAlongAvailable,
                     bookmarksAvailable = bookmarksAvailable,
                     onAddBookmark = onAddBookmark,
+                    pronunciationAvailable = pronunciationAvailable,
+                    onReportPronunciation = onReportPronunciation,
                     onOpenReader = onOpenReader,
                     modifier = Modifier.fillMaxWidth(),
                 )
@@ -139,6 +143,8 @@ fun PlayerScreen(
                         readAlongAvailable = readAlongAvailable,
                         bookmarksAvailable = bookmarksAvailable,
                         onAddBookmark = onAddBookmark,
+                        pronunciationAvailable = pronunciationAvailable,
+                        onReportPronunciation = onReportPronunciation,
                         onOpenReader = onOpenReader,
                         modifier = Modifier.align(Alignment.TopCenter).widthIn(max = NarrowMaxWidth)
                             .fillMaxWidth().fillMaxHeight(),
@@ -162,6 +168,8 @@ private fun PlayerMain(
     compact: Boolean,
     readAlongAvailable: Boolean,
     bookmarksAvailable: Boolean,
+    pronunciationAvailable: Boolean,
+    onReportPronunciation: (Int, String, Long) -> Unit,
     onAddBookmark: () -> Unit,
     onOpenReader: (chapterId: Int, title: String) -> Unit,
     modifier: Modifier,
@@ -198,7 +206,7 @@ private fun PlayerMain(
             MetaText(it)
         }
         val chapterId = s.queue.getOrNull(s.currentIndex)?.chapterId ?: 0
-        if ((readAlongAvailable || bookmarksAvailable) && chapterId > 0) {
+        if ((readAlongAvailable || bookmarksAvailable || pronunciationAvailable) && chapterId > 0) {
             Spacer(Modifier.height(12.dp))
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
                 if (readAlongAvailable) {
@@ -215,6 +223,17 @@ private fun PlayerMain(
                 // Enabled on loaded media rather than on "is playing": marking the spot you just
                 // paused at is the most ordinary reason to reach for this at all.
                 if (bookmarksAvailable) BookmarkAction(enabled = s.hasMedia, onClick = onAddBookmark)
+                // The whole point is capturing it where it is heard: the chapter and the position
+                // are already known, so the report is one field rather than a hunt for the timestamp.
+                if (pronunciationAvailable) {
+                    OutlinedButton(
+                        onClick = { onReportPronunciation(chapterId, s.title, s.positionMs) },
+                        enabled = s.hasMedia,
+                        shape = androidx.compose.ui.graphics.RectangleShape,
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)
+                            .testTag(ReportPronunciationTestTag),
+                    ) { Text("SOUNDS WRONG") }
+                }
             }
         }
         Spacer(Modifier.height(20.dp))
@@ -342,6 +361,7 @@ private val SpeedPresets = listOf(0.75f, 1f, 1.25f, 1.5f, 1.75f, 2f, 3f)
 const val SpeedChipTestTag = "player-speed-chip"
 const val SpeedDefaultChipTestTag = "player-speed-default"
 const val RetryButtonTestTag = "player-retry"
+const val ReportPronunciationTestTag = "player-report-pronunciation"
 
 /**
  * The rate row, which sets the rate for *this serial* while one is loaded.

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PronunciationReportDialog.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PronunciationReportDialog.kt
@@ -1,0 +1,87 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import dk.perspektiva.ttsroad.desktop.data.formatReportPosition
+
+const val PronunciationDialogTestTag: String = "pronunciationDialog"
+const val PronunciationWordFieldTestTag: String = "pronunciationWord"
+const val PronunciationSendTestTag: String = "pronunciationSend"
+
+/**
+ * "That word sounded wrong", filed from the player (#121).
+ *
+ * The chapter and the position are already on the draft, frozen at the moment the form opened —
+ * they are shown rather than editable, because they are facts the player knows exactly and a typed
+ * timestamp would only ever be worse.
+ */
+@Composable
+fun PronunciationReportDialog(holder: PronunciationReportsStateHolder) {
+    val ui by holder.state.collectAsState()
+    val draft = ui.draft ?: return
+
+    AlertDialog(
+        onDismissRequest = holder::dismiss,
+        shape = RectangleShape,
+        containerColor = AarisColor.BgRaise,
+        modifier = Modifier.testTag(PronunciationDialogTestTag),
+        title = { Text("REPORT A PRONUNCIATION") },
+        text = {
+            Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    listOfNotNull(draft.chapterTitle.takeIf { it.isNotBlank() }, formatReportPosition(draft.positionMs / 1000.0))
+                        .joinToString("  ·  "),
+                    color = AarisColor.Dim,
+                    style = MaterialTheme.typography.labelMedium,
+                )
+                OutlinedTextField(
+                    value = draft.word,
+                    onValueChange = holder::setWord,
+                    label = { Text("THE WORD") },
+                    supportingText = { Text("As it is written — the server's tools match on the text.") },
+                    singleLine = true,
+                    enabled = !ui.busy,
+                    modifier = Modifier.fillMaxWidth().testTag(PronunciationWordFieldTestTag),
+                )
+                OutlinedTextField(
+                    value = draft.note,
+                    onValueChange = holder::setNote,
+                    label = { Text("NOTE (OPTIONAL)") },
+                    supportingText = { Text("How it should sound, if you can say.") },
+                    minLines = 2,
+                    enabled = !ui.busy,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                draft.problem?.takeIf { draft.word.isNotEmpty() || draft.note.isNotEmpty() }?.let {
+                    Text(it, color = MaterialTheme.colorScheme.error)
+                }
+                ui.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = holder::send,
+                enabled = draft.canSend && !ui.busy,
+                shape = RectangleShape,
+                modifier = Modifier.testTag(PronunciationSendTestTag),
+            ) { Text(if (ui.busy) "SENDING…" else "REPORT") }
+        },
+        dismissButton = {
+            TextButton(onClick = holder::dismiss, shape = RectangleShape) { Text("CANCEL") }
+        },
+    )
+}

--- a/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PronunciationReportsStateHolder.kt
+++ b/src/main/kotlin/dk/perspektiva/ttsroad/desktop/ui/PronunciationReportsStateHolder.kt
@@ -1,0 +1,167 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.data.PronunciationReport
+import dk.perspektiva.ttsroad.desktop.data.ReportOutcome
+import dk.perspektiva.ttsroad.desktop.data.TtsRoadRepository
+import dk.perspektiva.ttsroad.desktop.data.pronunciationReportProblem
+import dk.perspektiva.ttsroad.desktop.data.pronunciationReportRequest
+import dk.perspektiva.ttsroad.desktop.data.userFacingMessage
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/** The form, while it is open. Null [chapterId] means nothing is loaded to report against. */
+data class PronunciationDraft(
+    val chapterId: Int,
+    val chapterTitle: String,
+    val positionMs: Long,
+    val word: String = "",
+    val note: String = "",
+) {
+    val problem: String? get() = pronunciationReportProblem(word, note)
+    val canSend: Boolean get() = problem == null
+}
+
+data class PronunciationUiState(
+    val draft: PronunciationDraft? = null,
+    val reports: List<PronunciationReport> = emptyList(),
+    val busy: Boolean = false,
+    val notice: String? = null,
+    val error: String? = null,
+)
+
+/**
+ * Filing "that word is pronounced wrong" from where it was heard (#121).
+ *
+ * The draft carries the chapter and the position taken from the player at the moment the form
+ * opened, not at the moment it is sent. Those differ by however long somebody spends typing, and the
+ * useful timestamp is the one where the word actually was.
+ */
+class PronunciationReportsStateHolder(
+    private val repository: TtsRoadRepository,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : StateHolder(dispatcher) {
+    private val _state = MutableStateFlow(PronunciationUiState())
+    val state: StateFlow<PronunciationUiState> = _state.asStateFlow()
+
+    private var job: Job? = null
+    private var loaded = false
+
+    /** Opens the form against a frozen chapter and position. */
+    fun open(chapterId: Int, chapterTitle: String, positionMs: Long) {
+        if (chapterId <= 0) return
+        _state.update {
+            it.copy(
+                draft = PronunciationDraft(chapterId, chapterTitle, positionMs),
+                notice = null,
+                error = null,
+            )
+        }
+    }
+
+    fun setWord(value: String) = editDraft { it.copy(word = value) }
+
+    fun setNote(value: String) = editDraft { it.copy(note = value) }
+
+    fun dismiss() = _state.update { it.copy(draft = null, error = null) }
+
+    fun send() {
+        val draft = _state.value.draft ?: return
+        if (_state.value.busy) return
+        val request = pronunciationReportRequest(
+            chapterId = draft.chapterId,
+            positionMs = draft.positionMs,
+            word = draft.word,
+            note = draft.note,
+        ) ?: return
+        _state.update { it.copy(busy = true, error = null, notice = null) }
+        job = scope.launch {
+            runCatching { repository.createPronunciationReport(request) }
+                .onSuccess { outcome ->
+                    when (outcome) {
+                        is ReportOutcome.Filed -> _state.update {
+                            it.copy(
+                                busy = false,
+                                draft = null,
+                                // Prepended rather than re-fetched: the server returns the stored
+                                // row, so a second request would only confirm what it just said.
+                                reports = listOf(outcome.report) + it.reports,
+                                notice = "Reported. It shows up in the server's text tools.",
+                            )
+                        }
+                        // Not a failure to retry — the fix is to clear some, and the server's
+                        // sentence names how many.
+                        is ReportOutcome.AtCapacity ->
+                            _state.update { it.copy(busy = false, error = outcome.message) }
+                        ReportOutcome.Unsupported -> _state.update {
+                            it.copy(busy = false, error = "This server does not take pronunciation reports.")
+                        }
+                    }
+                }
+                .onFailure { failure ->
+                    _state.update {
+                        it.copy(busy = false, error = userFacingMessage(failure, "Could not file that report"))
+                    }
+                }
+        }
+    }
+
+    fun ensureLoaded(force: Boolean = false) {
+        if (job?.isActive == true) return
+        if (loaded && !force) return
+        job = scope.launch {
+            runCatching { repository.pronunciationReports() }
+                .onSuccess { reports ->
+                    loaded = true
+                    _state.update { it.copy(reports = reports.orEmpty()) }
+                }
+                .onFailure { failure ->
+                    _state.update {
+                        it.copy(error = userFacingMessage(failure, "Could not load your reports"))
+                    }
+                }
+        }
+    }
+
+    fun delete(report: PronunciationReport) {
+        if (_state.value.busy) return
+        _state.update { it.copy(busy = true, error = null, notice = null) }
+        job = scope.launch {
+            runCatching { repository.deletePronunciationReport(report.id) }
+                .onSuccess { removed ->
+                    _state.update {
+                        if (removed) {
+                            it.copy(busy = false, reports = it.reports.filterNot { r -> r.id == report.id })
+                        } else {
+                            // A 404 is ambiguous between "no such endpoint" and "already gone", so
+                            // the row stays rather than being removed on a guess.
+                            it.copy(busy = false, error = "That report could not be deleted.")
+                        }
+                    }
+                }
+                .onFailure { failure ->
+                    _state.update {
+                        it.copy(busy = false, error = userFacingMessage(failure, "Could not delete that report"))
+                    }
+                }
+        }
+    }
+
+    fun dismissNotice() = _state.update { it.copy(notice = null, error = null) }
+
+    private fun editDraft(block: (PronunciationDraft) -> PronunciationDraft) {
+        _state.update { current ->
+            val draft = current.draft ?: return@update current
+            current.copy(draft = block(draft), error = null)
+        }
+    }
+
+    override fun onCleared() {
+        job?.cancel()
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/Fakes.kt
@@ -19,6 +19,9 @@ import dk.perspektiva.ttsroad.desktop.data.MobileUser
 import dk.perspektiva.ttsroad.desktop.data.ChapterRetryOutcome
 import dk.perspektiva.ttsroad.desktop.data.FeedsResponse
 import dk.perspektiva.ttsroad.desktop.data.ListeningStateReport
+import dk.perspektiva.ttsroad.desktop.data.PronunciationReport
+import dk.perspektiva.ttsroad.desktop.data.PronunciationReportRequest
+import dk.perspektiva.ttsroad.desktop.data.ReportOutcome
 import dk.perspektiva.ttsroad.desktop.data.FictionMaintenanceAction
 import dk.perspektiva.ttsroad.desktop.data.MaintenanceResponse
 import dk.perspektiva.ttsroad.desktop.data.MobileVoice
@@ -99,6 +102,9 @@ open class FakeRepository(
     var rotateFeedResult: Result<FeedsResponse?> = Result.success(null),
     var exportListeningStateResult: Result<Map<String, Any?>?> = Result.success(null),
     var importListeningStateResult: Result<ListeningStateReport?> = Result.success(null),
+    var pronunciationReportsResult: Result<List<PronunciationReport>?> = Result.success(null),
+    var createPronunciationReportResult: Result<ReportOutcome> = Result.success(ReportOutcome.Unsupported),
+    var deletePronunciationReportResult: Result<Boolean> = Result.success(false),
     /** Null models a server whose notifications route answers 404. */
     var chapterNotificationsResult: Result<ChapterNotificationsResponse?> = Result.success(null),
 ) : TtsRoadRepository {
@@ -132,6 +138,8 @@ open class FakeRepository(
     var rotateFeedCalls: Int = 0
         private set
     val importedDocuments: MutableList<Map<String, Any?>> = mutableListOf()
+    val filedReports: MutableList<PronunciationReportRequest> = mutableListOf()
+    val deletedReports: MutableList<Int> = mutableListOf()
     var revokeOtherDevicesCalls: Int = 0
         private set
     var readAlongCalls: Int = 0
@@ -344,6 +352,19 @@ open class FakeRepository(
     override suspend fun importListeningState(document: Map<String, Any?>): ListeningStateReport? {
         importedDocuments += document
         return importListeningStateResult.getOrThrow()
+    }
+
+    override suspend fun pronunciationReports(): List<PronunciationReport>? =
+        pronunciationReportsResult.getOrThrow()
+
+    override suspend fun createPronunciationReport(request: PronunciationReportRequest): ReportOutcome {
+        filedReports += request
+        return createPronunciationReportResult.getOrThrow()
+    }
+
+    override suspend fun deletePronunciationReport(reportId: Int): Boolean {
+        deletedReports += reportId
+        return deletePronunciationReportResult.getOrThrow()
     }
 
     override suspend fun revokeDevice(tokenId: Int): Boolean {

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/PronunciationReportsTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/data/PronunciationReportsTest.kt
@@ -1,0 +1,99 @@
+package dk.perspektiva.ttsroad.desktop.data
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class PronunciationReportsTest {
+
+    @Test
+    fun `a note with no word is still a valid report`() {
+        assertNull(
+            pronunciationReportProblem(word = "", note = "The narrator garbles the surname."),
+            "'the third paragraph sounds wrong' says something even without a single word",
+        )
+        assertNull(pronunciationReportProblem(word = "Erin", note = ""))
+    }
+
+    @Test
+    fun `neither is refused`() {
+        val problem = pronunciationReportProblem(word = "  ", note = "")
+
+        assertNotNull(problem)
+        assertTrue(problem.contains("word that sounded wrong"))
+    }
+
+    @Test
+    fun `the server's ceilings are checked before sending`() {
+        val longWord = "a".repeat(MaxReportedWordChars + 1)
+        val longNote = "a".repeat(MaxReportNoteChars + 1)
+
+        assertTrue(pronunciationReportProblem(longWord, "")!!.contains("200"))
+        assertTrue(pronunciationReportProblem("Erin", longNote)!!.contains("2000"))
+        assertNull(pronunciationReportProblem("a".repeat(MaxReportedWordChars), ""))
+    }
+
+    @Test
+    fun `the chapter is what identifies the report`() {
+        // The server derives the fiction from the chapter rather than trusting a client, which is
+        // why the request type has no fiction field for a caller to get wrong.
+        val request = pronunciationReportRequest(chapterId = 42, positionMs = 61_000, word = "Erin", note = "")
+
+        assertNotNull(request)
+        assertEquals(42, request.chapterId)
+        assertEquals("Erin", request.word)
+    }
+
+    @Test
+    fun `position is converted to seconds`() {
+        val request = pronunciationReportRequest(chapterId = 1, positionMs = 61_500, word = "x", note = "")
+
+        assertEquals(61.5, request!!.positionSeconds)
+    }
+
+    @Test
+    fun `a negative position is floored rather than sent`() {
+        val request = pronunciationReportRequest(chapterId = 1, positionMs = -5_000, word = "x", note = "")
+
+        assertEquals(0.0, request!!.positionSeconds)
+    }
+
+    @Test
+    fun `blank fields are sent as absent, not as empty strings`() {
+        val request = pronunciationReportRequest(chapterId = 1, positionMs = 0, word = "  Erin  ", note = "   ")
+
+        assertEquals("Erin", request!!.word)
+        assertNull(request.note, "an empty string would store a blank note rather than none")
+    }
+
+    @Test
+    fun `an invalid draft produces no request at all`() {
+        assertNull(pronunciationReportRequest(chapterId = 1, positionMs = 0, word = "", note = ""))
+    }
+
+    @Test
+    fun `a position of zero is not shown as the very start`() {
+        assertNull(formatReportPosition(0.0), "an unset position is not a timestamp")
+        assertNull(formatReportPosition(-1.0))
+        assertEquals("1:01", formatReportPosition(61.0))
+        assertEquals("41:07", formatReportPosition(2467.0))
+        assertEquals("1:00:00", formatReportPosition(3600.0))
+        assertEquals("2:03:04", formatReportPosition(7384.0))
+    }
+
+    @Test
+    fun `the location prefers the chapter title over its number`() {
+        val titled = PronunciationReport(chapterTitle = "The Inn", chapterNumber = 12, positionSeconds = 61.0)
+        val numbered = PronunciationReport(chapterNumber = 12, positionSeconds = 61.0)
+
+        assertEquals("The Inn  ·  1:01", pronunciationReportLocation(titled))
+        assertEquals("Chapter 12  ·  1:01", pronunciationReportLocation(numbered))
+    }
+
+    @Test
+    fun `a report with nothing to place still reads`() {
+        assertEquals("Unknown position", pronunciationReportLocation(PronunciationReport()))
+    }
+}

--- a/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/PronunciationReportsStateHolderTest.kt
+++ b/src/test/kotlin/dk/perspektiva/ttsroad/desktop/ui/PronunciationReportsStateHolderTest.kt
@@ -1,0 +1,190 @@
+package dk.perspektiva.ttsroad.desktop.ui
+
+import dk.perspektiva.ttsroad.desktop.FakeRepository
+import dk.perspektiva.ttsroad.desktop.data.PronunciationReport
+import dk.perspektiva.ttsroad.desktop.data.ReportOutcome
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PronunciationReportsStateHolderTest {
+
+    private val stored = PronunciationReport(id = 9, chapterId = 42, word = "Erin")
+
+    @Test
+    fun `the position is frozen when the form opens, not when it is sent`() = runTest {
+        val repository = FakeRepository(
+            createPronunciationReportResult = Result.success(ReportOutcome.Filed(stored)),
+        )
+        val holder = holder(repository)
+
+        holder.open(chapterId = 42, chapterTitle = "Chapter 12", positionMs = 61_000)
+        // Typing takes time; the useful timestamp is where the word actually was.
+        holder.setWord("Erin")
+        holder.setNote("Should rhyme with 'Karen'.")
+        holder.send()
+        runCurrent()
+
+        val sent = repository.filedReports.single()
+        assertEquals(61.0, sent.positionSeconds)
+        assertEquals(42, sent.chapterId)
+        assertEquals("Erin", sent.word)
+
+        holder.clear()
+    }
+
+    @Test
+    fun `a filed report closes the form and joins the list without a second request`() = runTest {
+        val repository = FakeRepository(
+            createPronunciationReportResult = Result.success(ReportOutcome.Filed(stored)),
+        )
+        val holder = holder(repository)
+        holder.open(42, "Chapter 12", 0)
+        holder.setWord("Erin")
+
+        holder.send()
+        runCurrent()
+
+        assertNull(holder.state.value.draft)
+        assertEquals(listOf(9), holder.state.value.reports.map { it.id })
+        assertNotNull(holder.state.value.notice)
+        assertFalse(holder.state.value.busy)
+
+        holder.clear()
+    }
+
+    @Test
+    fun `a full queue shows the server's own sentence`() = runTest {
+        val message = "You already have 500 open pronunciation reports. Resolve or delete some before adding more."
+        val repository = FakeRepository(
+            createPronunciationReportResult = Result.success(ReportOutcome.AtCapacity(message)),
+        )
+        val holder = holder(repository)
+        holder.open(42, "Chapter 12", 0)
+        holder.setWord("Erin")
+
+        holder.send()
+        runCurrent()
+
+        assertEquals(
+            message,
+            holder.state.value.error,
+            "the number in it is the actionable part and can differ per deployment",
+        )
+        assertNotNull(holder.state.value.draft, "the typing is kept so it can be retried after clearing some")
+
+        holder.clear()
+    }
+
+    @Test
+    fun `an empty draft sends nothing`() = runTest {
+        val repository = FakeRepository()
+        val holder = holder(repository)
+        holder.open(42, "Chapter 12", 0)
+
+        holder.send()
+        runCurrent()
+
+        assertTrue(repository.filedReports.isEmpty())
+        assertFalse(holder.state.value.draft!!.canSend)
+
+        holder.clear()
+    }
+
+    @Test
+    fun `a chapter that is not loaded cannot open the form`() = runTest {
+        val holder = holder(FakeRepository())
+
+        holder.open(chapterId = 0, chapterTitle = "", positionMs = 0)
+
+        assertNull(holder.state.value.draft)
+
+        holder.clear()
+    }
+
+    @Test
+    fun `deleting removes the row only when the server confirmed it`() = runTest {
+        val repository = FakeRepository(
+            pronunciationReportsResult = Result.success(listOf(stored)),
+            deletePronunciationReportResult = Result.success(true),
+        )
+        val holder = holder(repository)
+        holder.ensureLoaded()
+        runCurrent()
+
+        holder.delete(stored)
+        runCurrent()
+
+        assertEquals(listOf(9), repository.deletedReports)
+        assertTrue(holder.state.value.reports.isEmpty())
+
+        holder.clear()
+    }
+
+    @Test
+    fun `a 404 on delete keeps the row rather than guessing`() = runTest {
+        val repository = FakeRepository(
+            pronunciationReportsResult = Result.success(listOf(stored)),
+            deletePronunciationReportResult = Result.success(false),
+        )
+        val holder = holder(repository)
+        holder.ensureLoaded()
+        runCurrent()
+
+        holder.delete(stored)
+        runCurrent()
+
+        assertEquals(
+            1,
+            holder.state.value.reports.size,
+            "a 404 is ambiguous between no-such-endpoint and already-gone",
+        )
+        assertNotNull(holder.state.value.error)
+
+        holder.clear()
+    }
+
+    @Test
+    fun `an unsupported server says so rather than failing silently`() = runTest {
+        val repository = FakeRepository(
+            createPronunciationReportResult = Result.success(ReportOutcome.Unsupported),
+        )
+        val holder = holder(repository)
+        holder.open(42, "Chapter 12", 0)
+        holder.setWord("Erin")
+
+        holder.send()
+        runCurrent()
+
+        assertEquals("This server does not take pronunciation reports.", holder.state.value.error)
+
+        holder.clear()
+    }
+
+    @Test
+    fun `the list loads once`() = runTest {
+        val repository = FakeRepository(pronunciationReportsResult = Result.success(listOf(stored)))
+        val holder = holder(repository)
+
+        holder.ensureLoaded()
+        runCurrent()
+        holder.ensureLoaded()
+        runCurrent()
+
+        assertEquals(1, holder.state.value.reports.size)
+
+        holder.clear()
+    }
+
+    private fun TestScope.holder(repository: FakeRepository) =
+        PronunciationReportsStateHolder(repository, UnconfinedTestDispatcher(testScheduler))
+}


### PR DESCRIPTION
Closes #121. From #94, which marks `pronunciation_reports` **Wanted** because the
desktop has the reader open next to the audio.

## The gap

TTS gets names wrong constantly, in ways only a listener notices. The server has
had a store for these reports and a text-tools panel that acts on them. This
client had no way to file one, so the only route was to remember the word, leave
the app and open a browser.

**That remembering step is where the report was lost.**

## Filed from the player, which is the whole point

The chapter and the position are already known to the millisecond, so a report is
one field — the word — and everything else is filled in.

Both are **frozen when the form opens**, not when it is sent. Those differ by
however long somebody spends typing, and the useful timestamp is where the word
actually was. Tested.

## Decisions

- **A note with no word is valid.** "The narrator garbles the surname in the third
  paragraph" says something. Neither is refused, because that stores an empty row.
- **`fiction_id` is never sent.** The server derives it from the chapter rather
  than trusting a client, so the request type has no field for a caller to get
  wrong. A mismatched pair would file a report the fiction's own panel never
  shows.
- **A 409 is a full queue, not a failure.** The account has a cap on open reports
  and the fix is to clear some — so the typing is kept and the server's own
  sentence is shown, because the number in it is the actionable part and it can
  differ per deployment.
- **A 404 on delete leaves the row alone.** It is ambiguous between "no such
  endpoint" and "already gone"; removing the row on that guess would show a
  deletion that may not have happened.
- The word and note are length-checked against the server's own ceilings (200 /
  2000) before sending, so a long note is not a 400 after the fact.

## One new helper

`serverDetail(HttpException)` reads a `detail` from an error body. Only used where
the server's sentence carries something the client cannot know — here, the cap's
own number. Written to be total: an unparseable body on an error path must not
turn one failure into two.

## Verification

`xvfb-run -a ./gradlew --no-daemon clean check --warning-mode fail
-Pttsroad.warningsAsErrors=true` — BUILD SUCCESSFUL in 6m24s, first run.

20 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK3sri5jA6ne6tEJnbQaRe
